### PR TITLE
Development

### DIFF
--- a/XRTK-Core/Assets/XRTK/Utilities/CanvasUtility.cs
+++ b/XRTK-Core/Assets/XRTK/Utilities/CanvasUtility.cs
@@ -14,7 +14,6 @@ namespace XRTK.Utilities
     public class CanvasUtility : MonoBehaviour
     {
         [SerializeField]
-        [HideInInspector]
         private Canvas canvas;
 
         /// <summary>


### PR DESCRIPTION
**Overview**

Small fix / improvement to `CanvasUtility` to allow setting the Canvas in the inspector.
Previously the field was hidden from the inspector but Awake would check whether it is null
before getting it. Since we cannot set it in editor, it will always be null at this point.

To support both cases, the field should be visible in inspector.

**Changes:**

- Fixes: Canvas reference cannot be set in inspector for CanvasUtility

**Breaking Changes:**

None
