### PR TITLE
Updated PreferenceItem to SettingsProvider

### DIFF
--- a/XRTK-Core/Assets/XRTK/Inspectors/MixedRealityPreferences.cs
+++ b/XRTK-Core/Assets/XRTK/Inspectors/MixedRealityPreferences.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using XRTK.Utilities.Editor;
@@ -10,6 +11,8 @@ namespace XRTK.Inspectors
 {
     public static class MixedRealityPreferences
     {
+        private static readonly string[] XRTK_Keywords = new[] { "XRTK", "Mixed", "Reality" };
+
         #region Lock Profile Preferences
 
         private static readonly GUIContent LockContent = new GUIContent("Lock SDK profiles", "Locks the SDK profiles from being edited.\n\nThis setting only applies to the currently running project.");
@@ -121,65 +124,77 @@ namespace XRTK.Inspectors
 
         #endregion  Start Scene Preference
 
-        [PreferenceItem("Mixed Reality Toolkit")]
-        private static void Preferences()
+        [SettingsProvider]
+        private static SettingsProvider Preferences()
         {
-            var prevLabelWidth = EditorGUIUtility.labelWidth;
-            EditorGUIUtility.labelWidth = 200f;
-
-            EditorGUI.BeginChangeCheck();
-            lockProfiles = EditorGUILayout.Toggle(LockContent, LockProfiles);
-
-            // Save the preference
-            if (EditorGUI.EndChangeCheck())
+            var provider = new SettingsProvider("Project/XRTK", SettingsScope.Project)
             {
-                LockProfiles = lockProfiles;
-            }
+                label = "XRTK",
 
-            if (!LockProfiles)
-            {
-                EditorGUILayout.HelpBox("This is only to be used to update the default SDK profiles. If any edits are made, and not checked into the XRTK's Github, the changes may be lost next time you update your local copy.", MessageType.Warning);
-            }
+                guiHandler = (searchContext) =>
+                {
+                    var prevLabelWidth = EditorGUIUtility.labelWidth;
+                    EditorGUIUtility.labelWidth = 200f;
 
-            EditorGUI.BeginChangeCheck();
-            ignoreSettingsPrompt = EditorGUILayout.Toggle(IgnoreContent, IgnoreSettingsPrompt);
+                    EditorGUI.BeginChangeCheck();
+                    lockProfiles = EditorGUILayout.Toggle(LockContent, LockProfiles);
 
-            // Save the preference
-            if (EditorGUI.EndChangeCheck())
-            {
-                IgnoreSettingsPrompt = ignoreSettingsPrompt;
-            }
+                    // Save the preference
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        LockProfiles = lockProfiles;
+                    }
 
-            EditorGUI.BeginChangeCheck();
-            showCanvasUtilityPrompt = EditorGUILayout.Toggle(CanvasUtilityContent, ShowCanvasUtilityPrompt);
+                    if (!LockProfiles)
+                    {
+                        EditorGUILayout.HelpBox("This is only to be used to update the default SDK profiles. If any edits are made, and not checked into the XRTK's Github, the changes may be lost next time you update your local copy.", MessageType.Warning);
+                    }
 
-            if (EditorGUI.EndChangeCheck())
-            {
-                ShowCanvasUtilityPrompt = showCanvasUtilityPrompt;
-            }
+                    EditorGUI.BeginChangeCheck();
+                    ignoreSettingsPrompt = EditorGUILayout.Toggle(IgnoreContent, IgnoreSettingsPrompt);
 
-            if (!ShowCanvasUtilityPrompt)
-            {
-                EditorGUILayout.HelpBox("Be aware that if a Canvas needs to receive input events it is required to have the CanvasUtility attached or the Focus Provider's UIRaycast Camera assigned to the canvas' camera reference.", MessageType.Warning);
-            }
+                    // Save the preference
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        IgnoreSettingsPrompt = ignoreSettingsPrompt;
+                    }
 
-            EditorGUI.BeginChangeCheck();
-            var startScene = (SceneAsset)EditorGUILayout.ObjectField(StartSceneContent, StartSceneAsset, typeof(SceneAsset), true);
+                    EditorGUI.BeginChangeCheck();
+                    showCanvasUtilityPrompt = EditorGUILayout.Toggle(CanvasUtilityContent, ShowCanvasUtilityPrompt);
 
-            if (EditorGUI.EndChangeCheck())
-            {
-                StartSceneAsset = startScene;
-            }
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        ShowCanvasUtilityPrompt = showCanvasUtilityPrompt;
+                    }
 
-            EditorGUI.BeginChangeCheck();
-            var scriptLock = EditorGUILayout.Toggle("Is Script Reloading locked?", EditorAssemblyReloadManager.LockReloadAssemblies);
+                    if (!ShowCanvasUtilityPrompt)
+                    {
+                        EditorGUILayout.HelpBox("Be aware that if a Canvas needs to receive input events it is required to have the CanvasUtility attached or the Focus Provider's UIRaycast Camera assigned to the canvas' camera reference.", MessageType.Warning);
+                    }
 
-            if (EditorGUI.EndChangeCheck())
-            {
-                EditorAssemblyReloadManager.LockReloadAssemblies = scriptLock;
-            }
+                    EditorGUI.BeginChangeCheck();
+                    var startScene = (SceneAsset)EditorGUILayout.ObjectField(StartSceneContent, StartSceneAsset, typeof(SceneAsset), true);
 
-            EditorGUIUtility.labelWidth = prevLabelWidth;
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        StartSceneAsset = startScene;
+                    }
+
+                    EditorGUI.BeginChangeCheck();
+                    var scriptLock = EditorGUILayout.Toggle("Is Script Reloading locked?", EditorAssemblyReloadManager.LockReloadAssemblies);
+
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        EditorAssemblyReloadManager.LockReloadAssemblies = scriptLock;
+                    }
+
+                    EditorGUIUtility.labelWidth = prevLabelWidth;
+                },
+
+                keywords = new HashSet<string>(XRTK_Keywords)
+            };
+
+            return provider;
         }
 
         private static SceneAsset GetSceneObject(string sceneName)


### PR DESCRIPTION
**Overview**

Unity recommends to update to the new SettingsProvider:
`Assets\XRTK\Inspectors\MixedRealityPreferences.cs(124,10): warning CS0618: 'PreferenceItem' is obsolete: '[PreferenceItem] is deprecated. Use [SettingsProvider] instead.'`

No functional changes.