### PR TITLE
Fix to use TargetTransform Getter in update to get camera in first run

### DIFF
--- a/XRTK-Core/Assets/XRTK.SDK/Features/UX/Scripts/Utilities/Billboard.cs
+++ b/XRTK-Core/Assets/XRTK.SDK/Features/UX/Scripts/Utilities/Billboard.cs
@@ -44,7 +44,7 @@ namespace XRTK.SDK.UX.Utilities
         private void Update()
         {
             // Get a Vector that points from the target to the main camera.
-            Vector3 directionToTarget = targetTransform.position - transform.position;
+            Vector3 directionToTarget = TargetTransform.position - transform.position;
 
             bool useCameraAsUpVector = true;
 


### PR DESCRIPTION
**Overview**

Billboard script did not automatically use the Camera due to private field usage instead of getter.

