### PR TITLE
Fix NRE when custom controller implementation does not have a visualizer

### DIFF
--- a/XRTK-Core/Assets/XRTK/Utilities/Solvers/ControllerFinder.cs
+++ b/XRTK-Core/Assets/XRTK/Utilities/Solvers/ControllerFinder.cs
@@ -100,7 +100,7 @@ namespace XRTK.SDK.Utilities.Solvers
         /// <param name="newController">The new controller to be tracked.</param>
         protected virtual void AddControllerTransform(IMixedRealityController newController)
         {
-            if (newController.ControllerHandedness == handedness && newController.Visualizer.GameObjectProxy.transform != null && !newController.Visualizer.GameObjectProxy.transform.Equals(ControllerTransform))
+            if (newController.ControllerHandedness == handedness && newController.Visualizer != null && newController.Visualizer.GameObjectProxy.transform != null && !newController.Visualizer.GameObjectProxy.transform.Equals(ControllerTransform))
             {
                 ControllerTransform = newController.Visualizer.GameObjectProxy.transform;
 


### PR DESCRIPTION
**Overview**

When implementing a custom controller without a visualizer (Keyboard controller) a NRE occurred in check when accessing GameObjectProxy

**Breaking Changes:**

- nothing
