### PR TITLE
Component extensions use == null instead unity's Object.bool

### DIFF
--- a/XRTK-Core/Assets/XRTK/Extensions/ComponentExtensions.cs
+++ b/XRTK-Core/Assets/XRTK/Extensions/ComponentExtensions.cs
@@ -49,7 +49,7 @@ namespace XRTK.Extensions
         public static T EnsureComponent<T>(this GameObject gameObject) where T : Component
         {
             T foundComponent = gameObject.GetComponent<T>();
-            return foundComponent == null ? gameObject.AddComponent<T>() : foundComponent;
+            return foundComponent ? foundComponent : gameObject.AddComponent<T>();
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace XRTK.Extensions
         public static Component EnsureComponent(this GameObject gameObject, Type component)
         {
             var foundComponent = gameObject.GetComponent(component);
-            return foundComponent == null ? gameObject.AddComponent(component) : foundComponent;
+            return foundComponent ? foundComponent : gameObject.AddComponent(component);
         }
     }
 }


### PR DESCRIPTION
**Overview**

Same in: https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/3691

**Changes:**

- Fixes: #...

**Breaking Changes:**

- Breaks...
