### PR TITLE
Services that utilize uwp capabilities, now properly set them

### DIFF
--- a/XRTK-Core/Assets/XRTK.WindowsMixedReality/Controllers/WindowsSpeechDataProvider.cs
+++ b/XRTK-Core/Assets/XRTK.WindowsMixedReality/Controllers/WindowsSpeechDataProvider.cs
@@ -37,6 +37,13 @@ namespace XRTK.WindowsMixedReality.Controllers
                 throw new Exception("Null speech commands in the speech commands profile!");
             }
 
+#if UNITY_WSA && UNITY_EDITOR
+            if (!UnityEditor.PlayerSettings.WSA.GetCapability(UnityEditor.PlayerSettings.WSACapability.Microphone))
+            {
+                UnityEditor.PlayerSettings.WSA.SetCapability(UnityEditor.PlayerSettings.WSACapability.Microphone, true);
+            }
+#endif
+
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
             var newKeywords = new string[Commands.Length];
 

--- a/XRTK-Core/Assets/XRTK.WindowsMixedReality/SpatialObservers/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/XRTK-Core/Assets/XRTK.WindowsMixedReality/SpatialObservers/WindowsMixedRealitySpatialMeshObserver.cs
@@ -32,6 +32,13 @@ namespace XRTK.WindowsMixedReality.SpatialObservers
             }
 
 #if UNITY_WSA
+#if UNITY_EDITOR 
+            if (!UnityEditor.PlayerSettings.WSA.GetCapability(UnityEditor.PlayerSettings.WSACapability.SpatialPerception))
+            {
+                UnityEditor.PlayerSettings.WSA.SetCapability(UnityEditor.PlayerSettings.WSACapability.SpatialPerception, true);
+            }
+#endif // UNITY_EDITOR
+
             observer = new SurfaceObserver();
 
             // Apply the initial observer volume settings.


### PR DESCRIPTION
Ensures that services that use a uwp component are setting them when they're constructor is called in the editor, which then updates the player settings.

When the Mixed Reality Toolkit instance is created all services get their constructors called, even at edit time.