### PR TITLE
Dev package fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ XRTK-Core/Assets/XRTK.WindowsMixedReality
 XRTK-Core/Assets/XRTK.WindowsMixedReality.meta
 XRTK-Core/Assets/XRTK.SDK
 XRTK-Core/Assets/XRTK.SDK.meta
+XRTK-Core/Assets/XRTK.UpmGitExtension
+XRTK-Core/Assets/XRTK.UpmGitExtension.meta

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "Submodules/SDK"]
 	path = Submodules/SDK
 	url = https://github.com/XRTK/SDK.git
+[submodule "Submodules/UpmGitExtension"]
+	path = Submodules/UpmGitExtension
+	url = https://github.com/XRTK/UpmGitExtension.git

--- a/XRTK-Core/Assets/SymbolicLinkSettings.asset
+++ b/XRTK-Core/Assets/SymbolicLinkSettings.asset
@@ -18,4 +18,6 @@ MonoBehaviour:
     isActive: 1
   - sourceRelativePath: /Submodules/SDK/XRTK.SDK/Assets/XRTK.SDK
     targetRelativePath: /XRTK-Core/Assets/XRTK.SDK
+  - sourceRelativePath: /Submodules/UpmGitExtension/XRTK.UpmGitExtension/Assets/XRTK.UpmGitExtension
+    targetRelativePath: /XRTK-Core/Assets/XRTK.UpmGitExtension
     isActive: 1

--- a/XRTK-Core/Assets/SymbolicLinkSettings.asset
+++ b/XRTK-Core/Assets/SymbolicLinkSettings.asset
@@ -18,6 +18,7 @@ MonoBehaviour:
     isActive: 1
   - sourceRelativePath: /Submodules/SDK/XRTK.SDK/Assets/XRTK.SDK
     targetRelativePath: /XRTK-Core/Assets/XRTK.SDK
+    isActive: 1
   - sourceRelativePath: /Submodules/UpmGitExtension/XRTK.UpmGitExtension/Assets/XRTK.UpmGitExtension
     targetRelativePath: /XRTK-Core/Assets/XRTK.UpmGitExtension
     isActive: 1

--- a/XRTK-Core/Assets/XRTK/Inspectors/Utilities/GitUtilities.cs
+++ b/XRTK-Core/Assets/XRTK/Inspectors/Utilities/GitUtilities.cs
@@ -5,6 +5,7 @@ using System.Text;
 using UnityEditor;
 using UnityEngine;
 using XRTK.Extensions;
+using XRTK.Inspectors.Utilities.SymbolicLinks;
 using Debug = UnityEngine.Debug;
 
 namespace XRTK.Inspectors.Utilities
@@ -23,7 +24,7 @@ namespace XRTK.Inspectors.Utilities
             {
                 if (!string.IsNullOrEmpty(projectRootDir)) { return projectRootDir; }
 
-                if (new Process().Run($@"/C cd {Application.dataPath} && git rev-parse --show-toplevel", out string rootDir))
+                if (new Process().Run($@"/C cd {Application.dataPath} && git rev-parse --show-toplevel", out var rootDir))
                 {
                     return projectRootDir = rootDir.ToBackSlashes().Replace("\n", string.Empty);
                 }
@@ -38,7 +39,7 @@ namespace XRTK.Inspectors.Utilities
         public static void ForceUpdateSubmodules()
         {
             UpdateSubmodules();
-            // SymbolicLinkUtilities.RunSync(true);
+            SymbolicLinker.RunSync(true);
         }
 
         /// <summary>

--- a/XRTK-Core/Assets/XRTK/Inspectors/Utilities/Packages/MixedRealityPackageInfo.cs
+++ b/XRTK-Core/Assets/XRTK/Inspectors/Utilities/Packages/MixedRealityPackageInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEditor.PackageManager;
 using UnityEngine;
 
 namespace XRTK.Inspectors.Utilities.Packages
@@ -9,6 +10,11 @@ namespace XRTK.Inspectors.Utilities.Packages
     [Serializable]
     public struct MixedRealityPackageInfo
     {
+        /// <summary>
+        /// The Unity <see cref="PackageInfo"/>
+        /// </summary>
+        public PackageInfo PackageInfo { get; internal set; }
+
         [SerializeField]
         [Tooltip("The package name\n\"com.company.product\"")]
         private string name;

--- a/XRTK-Core/Assets/XRTK/Inspectors/Utilities/Packages/MixedRealityPackageUtilities.cs
+++ b/XRTK-Core/Assets/XRTK/Inspectors/Utilities/Packages/MixedRealityPackageUtilities.cs
@@ -39,7 +39,7 @@ namespace XRTK.Inspectors.Utilities.Packages
         /// <summary>
         /// Is the package utility running a check?
         /// </summary>
-        public static bool IsRunningCheck { get; private set; } = false;
+        public static bool IsRunningCheck { get; private set; }
 
         /// <summary>
         /// Debug the package utility.
@@ -185,9 +185,15 @@ namespace XRTK.Inspectors.Utilities.Packages
             var addRequest = Client.Add($"{packageInfo.Name}@{packageInfo.Uri}");
             await new WaitUntil(() => addRequest.Status != StatusCode.InProgress);
 
-            if (addRequest.Status == StatusCode.Success && DebugEnabled)
+            if (addRequest.Status == StatusCode.Success)
             {
-                Debug.Log($"successfully added {packageInfo.Name}");
+                if (DebugEnabled)
+                {
+                    Debug.Log($"successfully added {packageInfo.Name}@{addRequest.Result.packageId}");
+                }
+
+                // HACK to remove submodules
+                //File.Delete("Library\\PackageCache\\com.xrtk.core@f4a4a0ed7a42e52aa5ad3a3f5dc6b8780752f017");
             }
             else
             {
@@ -200,9 +206,12 @@ namespace XRTK.Inspectors.Utilities.Packages
             var removeRequest = Client.Remove($"{packageInfo.Name}");
             await new WaitUntil(() => removeRequest.Status != StatusCode.InProgress);
 
-            if (removeRequest.Status == StatusCode.Success && DebugEnabled)
+            if (removeRequest.Status == StatusCode.Success)
             {
-                Debug.Log($"successfully removed {packageInfo.Name}");
+                if (DebugEnabled)
+                {
+                    Debug.Log($"successfully removed {packageInfo.Name}");
+                }
             }
             else if (removeRequest.Error?.errorCode != ErrorCode.NotFound)
             {

--- a/XRTK-Core/Assets/XRTK/Inspectors/Utilities/SymbolicLinks/SymbolicLinker.cs
+++ b/XRTK-Core/Assets/XRTK/Inspectors/Utilities/SymbolicLinks/SymbolicLinker.cs
@@ -28,7 +28,7 @@ namespace XRTK.Inspectors.Utilities.SymbolicLinks
             EditorApplication.delayCall += () => RunSync();
         }
 
-        private const string LinkIconText = "<=link=>";
+        private const string LINK_ICON_TEXT = "<=link=>";
         private const string REGEX_BRACKETS = @"\{(.*?)\}";
         private const FileAttributes FOLDER_SYMLINK_ATTRIBUTES = FileAttributes.ReparsePoint;
 
@@ -274,7 +274,7 @@ namespace XRTK.Inspectors.Utilities.SymbolicLinks
 
                 if ((attributes & FOLDER_SYMLINK_ATTRIBUTES) != FOLDER_SYMLINK_ATTRIBUTES) { return; }
 
-                GUI.Label(rect, LinkIconText, SymlinkMarkerStyle);
+                GUI.Label(rect, LINK_ICON_TEXT, SymlinkMarkerStyle);
 
                 if (Settings.SymbolicLinks.Any(link => link.TargetRelativePath.Contains(path))) { return; }
 

--- a/XRTK-Core/Packages/manifest.json
+++ b/XRTK-Core/Packages/manifest.json
@@ -6,7 +6,6 @@
     "com.unity.xr.oculus.standalone": "1.29.1",
     "com.unity.xr.openvr.standalone": "1.0.3",
     "com.unity.xr.windowsmr.metro": "1.0.8",
-    "com.xrtk.upm-git-extension": "https://github.com/XRTK/UpmGitExtension.git#0.9.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",
@@ -37,11 +36,5 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  },
-  "lock": {
-    "com.xrtk.upm-git-extension": {
-      "hash": "9cdc5a92ad0d1f3606026765a29d458555e54251",
-      "revision": "0.9.1"
-    }
   }
 }


### PR DESCRIPTION
There was an issue with the core package pulling in the subodules into the package of other projects.

Linked to a unity bug, but added a temp hackaround to solve the problem in the short term.

Also fixed a new small bugs:
- batch mode debugging was overwriting the local setting, now properly xor the flag
- ensured we were syncing after updating submodules
- minor formatting changes.