### PR TITLE
Sets the start scene on load

### DIFF
--- a/XRTK-Core/Assets/XRTK/Inspectors/Utilities/AutoSceneSwitcher.cs
+++ b/XRTK-Core/Assets/XRTK/Inspectors/Utilities/AutoSceneSwitcher.cs
@@ -19,6 +19,13 @@ namespace XRTK.Inspectors.Utilities
         static AutoSceneSwitcher()
         {
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+
+            if (MixedRealityPreferences.StartSceneAsset == null &&
+                EditorBuildSettings.scenes.Length > 0 &&
+                !EditorBuildSettings.scenes[0].path.Contains("SampleScene"))
+            {
+                MixedRealityPreferences.StartSceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(EditorBuildSettings.scenes[0].path);
+            }
         }
 
         private static void OnPlayModeStateChanged(PlayModeStateChange playModeState)


### PR DESCRIPTION
When pulling a project, team members didn't get the base/start scene set as their `MixedRealityPreference.StartSceneAsset`. This ensures everyone that pulls the repository starts with the same scene.