### PR TITLE
added DidReloadScripts attribute to RunSync to cover more edge cases

### DIFF
--- a/XRTK-Core/Assets/XRTK/Inspectors/Utilities/SymbolicLinks/SymbolicLinker.cs
+++ b/XRTK-Core/Assets/XRTK/Inspectors/Utilities/SymbolicLinks/SymbolicLinker.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEditor;
+using UnityEditor.Callbacks;
 using UnityEngine;
 using XRTK.Extensions;
 using XRTK.Inspectors.Utilities.Packages;
@@ -77,6 +78,12 @@ namespace XRTK.Inspectors.Utilities.SymbolicLinks
         }
 
         private static SymbolicLinkSettings settings;
+
+        [DidReloadScripts]
+        public static void RunSync()
+        {
+            RunSync(false);
+        }
 
         /// <summary>
         /// Synchronizes the project with any symbolic links defined in the settings.


### PR DESCRIPTION
Sometimes symbolic links aren't created properly when switching branches and the editor doesn't trigger a domain reload