### PR TITLE
Fixed an issue where link validation was failing

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/package.json
+++ b/XRTK-Core/Packages/com.xrtk.core/package.json
@@ -2,7 +2,7 @@
   "name": "com.xrtk.core",
   "displayName": "XRTK.Core",
   "description": "The core framework of the Mixed Reality Toolkit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "unity": "2019.1",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Just because a folder exists doesn't mean that the link is valid. So we pass back the validity results and use that in our next step in the linker sync loop.