### PR TITLE
No longer require the service locator to configure profiles

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityProfile.cs
@@ -11,5 +11,17 @@ namespace XRTK.Definitions
         private bool isCustomProfile = true;
 
         internal bool IsCustomProfile => isCustomProfile;
+
+        [SerializeField]
+        private BaseMixedRealityProfile parentProfile = null;
+
+        /// <summary>
+        /// The profile's parent.
+        /// </summary>
+        public BaseMixedRealityProfile ParentProfile
+        {
+            get => parentProfile;
+            internal set => parentProfile = value;
+        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Devices/ControllerMappingLibrary.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Devices/ControllerMappingLibrary.cs
@@ -238,12 +238,13 @@ namespace XRTK.Definitions.Devices
         /// <summary>
         /// Gets a texture for the <see cref="SupportedControllerType"/> based on a list of the active <see cref="MixedRealityControllerMappingProfiles"/>.
         /// </summary>
+        /// <param name="mappingProfile"></param>
         /// <param name="controllerType"></param>
         /// <param name="handedness"></param>
         /// <returns>The texture for the controller type, if none found then a generic texture is returned.</returns>
-        public static Texture2D GetControllerTexture(SupportedControllerType controllerType, Handedness handedness)
+        public static Texture2D GetControllerTexture(BaseMixedRealityControllerMappingProfile mappingProfile, SupportedControllerType controllerType, Handedness handedness)
         {
-            return GetControllerTextureCached(controllerType, handedness);
+            return GetControllerTextureCached(mappingProfile, controllerType, handedness);
         }
 
         /// <summary>
@@ -252,44 +253,35 @@ namespace XRTK.Definitions.Devices
         /// <param name="controllerType"></param>
         /// <param name="handedness"></param>
         /// <returns>The scaled texture for the controller type, if none found then a generic texture is returned.</returns>
-        public static Texture2D GetControllerTextureScaled(SupportedControllerType controllerType, Handedness handedness)
+        public static Texture2D GetControllerTextureScaled(BaseMixedRealityControllerMappingProfile mappingProfile, SupportedControllerType controllerType, Handedness handedness)
         {
-            return GetControllerTextureCached(controllerType, handedness, true);
+            return GetControllerTextureCached(mappingProfile, controllerType, handedness, true);
         }
 
-        private static Texture2D GetControllerTextureCached(SupportedControllerType controllerType, Handedness handedness, bool scaled = false)
+        private static Texture2D GetControllerTextureCached(BaseMixedRealityControllerMappingProfile mappingProfile, SupportedControllerType controllerType, Handedness handedness, bool scaled = false)
         {
             var key = new Tuple<SupportedControllerType, Handedness, bool>(controllerType, handedness, scaled);
 
-            if (CachedTextures.TryGetValue(key, out Texture2D texture))
+            if (CachedTextures.TryGetValue(key, out var texture))
             {
                 return texture;
             }
 
-            texture = GetControllerTextureInternal(controllerType, handedness, scaled);
+            texture = GetControllerTextureInternal(mappingProfile, controllerType, handedness, scaled);
             CachedTextures.Add(key, texture);
             return texture;
         }
 
-        private static Texture2D GetControllerTextureInternal(SupportedControllerType controllerType, Handedness handedness, bool scaled)
+        private static Texture2D GetControllerTextureInternal(BaseMixedRealityControllerMappingProfile mappingProfile, SupportedControllerType controllerType, Handedness handedness, bool scaled)
         {
-            var profiles = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.ControllerMappingProfiles;
-
-            if (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
-                profiles != null)
+            if (mappingProfile != null &&
+                mappingProfile.ControllerType == controllerType)
             {
-                foreach (var profile in profiles.ControllerMappingProfiles)
-                {
-                    if (profile != null &&
-                        profile.ControllerType == controllerType)
-                    {
-                        var texture = GetControllerTextureInternal(profile.TexturePath, handedness, scaled);
+                var texture = GetControllerTextureInternal(mappingProfile.TexturePath, handedness, scaled);
 
-                        if (texture != null)
-                        {
-                            return texture;
-                        }
-                    }
+                if (texture != null)
+                {
+                    return texture;
                 }
             }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/ControllerPopupWindow.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/ControllerPopupWindow.cs
@@ -11,7 +11,9 @@ using XRTK.Definitions.Devices;
 using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.Utilities;
 using XRTK.Inspectors.Data;
+using XRTK.Inspectors.Profiles;
 using XRTK.Inspectors.Utilities;
+using XRTK.Providers.Controllers;
 using XRTK.Services;
 using XRTK.Utilities.Editor;
 
@@ -92,17 +94,22 @@ namespace XRTK.Inspectors
         private Texture2D currentControllerTexture;
         private ControllerInputActionOption currentControllerOption;
 
+        private MixedRealityInputSystemProfile inputSystemProfile;
+        private static BaseMixedRealityControllerMappingProfile mappingProfile;
+
         private bool IsCustomController => currentControllerType == SupportedControllerType.GenericOpenVR ||
                                            currentControllerType == SupportedControllerType.GenericUnity;
         private static string EditorWindowOptionsPath => $"{MixedRealityEditorSettings.MixedRealityToolkit_RelativeFolderPath}/Inspectors/Data/EditorWindowOptions.json";
 
         private void OnFocus()
         {
-            currentControllerTexture = ControllerMappingLibrary.GetControllerTexture(currentControllerType, currentHandedness);
+            currentControllerTexture = ControllerMappingLibrary.GetControllerTexture(mappingProfile, currentControllerType, currentHandedness);
+            inputSystemProfile = mappingProfile.ParentProfile.ParentProfile as MixedRealityInputSystemProfile;
 
             #region Interaction Constraint Setup
 
-            actionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+
+            actionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Select(action => (int)action.Id)
                 .Prepend(0).ToArray();
 
@@ -110,81 +117,81 @@ namespace XRTK.Inspectors
                 .Select(axis => new GUIContent(axis.Name))
                 .Prepend(new GUIContent("None")).ToArray();
 
-            actionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            actionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.None)
                 .Select(action => (int)action.Id)
                 .Prepend(0).ToArray();
 
-            actionLabels = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            actionLabels = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.None)
                 .Select(inputAction => new GUIContent(inputAction.Description))
                 .Prepend(new GUIContent("None")).ToArray();
 
-            rawActionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            rawActionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.Raw)
                 .Select(action => (int)action.Id)
                 .Prepend(0).ToArray();
 
-            rawActionLabels = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            rawActionLabels = inputSystemProfile.InputActionsProfile.InputActions
                  .Where(inputAction => inputAction.AxisConstraint == AxisType.Raw)
                  .Select(inputAction => new GUIContent(inputAction.Description))
                  .Prepend(new GUIContent("None")).ToArray();
 
-            digitalActionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            digitalActionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.Digital)
                 .Select(action => (int)action.Id)
                 .Prepend(0).ToArray();
 
-            digitalActionLabels = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            digitalActionLabels = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.Digital)
                 .Select(inputAction => new GUIContent(inputAction.Description))
                 .Prepend(new GUIContent("None")).ToArray();
 
-            singleAxisActionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            singleAxisActionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.SingleAxis)
                 .Select(action => (int)action.Id)
                 .Prepend(0).ToArray();
 
-            singleAxisActionLabels = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            singleAxisActionLabels = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.SingleAxis)
                 .Select(inputAction => new GUIContent(inputAction.Description))
                 .Prepend(new GUIContent("None")).ToArray();
 
-            dualAxisActionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            dualAxisActionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.DualAxis)
                 .Select(action => (int)action.Id).Prepend(0).ToArray();
 
-            dualAxisActionLabels = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            dualAxisActionLabels = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.DualAxis)
                 .Select(inputAction => new GUIContent(inputAction.Description))
                 .Prepend(new GUIContent("None")).ToArray();
 
-            threeDofPositionActionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            threeDofPositionActionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.ThreeDofPosition)
                 .Select(action => (int)action.Id)
                 .Prepend(0).ToArray();
 
-            threeDofPositionActionLabels = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            threeDofPositionActionLabels = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.ThreeDofPosition)
                 .Select(inputAction => new GUIContent(inputAction.Description))
                 .Prepend(new GUIContent("None")).ToArray();
 
-            threeDofRotationActionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            threeDofRotationActionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.ThreeDofRotation)
                 .Select(action => (int)action.Id)
                 .Prepend(0).ToArray();
 
-            threeDofRotationActionLabels = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            threeDofRotationActionLabels = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.ThreeDofRotation)
                 .Select(inputAction => new GUIContent(inputAction.Description))
                 .Prepend(new GUIContent("None")).ToArray();
 
-            sixDofActionIds = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            sixDofActionIds = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.SixDof)
                 .Select(action => (int)action.Id)
                 .Prepend(0).ToArray();
 
-            sixDofActionLabels = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions
+            sixDofActionLabels = inputSystemProfile.InputActionsProfile.InputActions
                 .Where(inputAction => inputAction.AxisConstraint == AxisType.SixDof)
                 .Select(inputAction => new GUIContent(inputAction.Description))
                 .Prepend(new GUIContent("None")).ToArray();
@@ -192,10 +199,8 @@ namespace XRTK.Inspectors
             #endregion  Interaction Constraint Setup
         }
 
-        public static void Show(SupportedControllerType controllerType, SerializedProperty interactionsList, Handedness handedness = Handedness.None, bool isLocked = false)
+        public static void Show(BaseMixedRealityControllerMappingProfile profile, SupportedControllerType controllerType, SerializedProperty interactionsList, Handedness handedness = Handedness.None, bool isLocked = false)
         {
-            window = (ControllerPopupWindow)GetWindow(typeof(ControllerPopupWindow));
-            window.Close();
             window = (ControllerPopupWindow)CreateInstance(typeof(ControllerPopupWindow));
             var handednessTitleText = handedness != Handedness.None ? $"{handedness} Hand " : string.Empty;
             window.titleContent = new GUIContent($"{controllerType} {handednessTitleText}Input Action Assignment");
@@ -204,7 +209,7 @@ namespace XRTK.Inspectors
             window.isLocked = isLocked;
             window.currentInteractionList = interactionsList;
             isMouseInRects = new bool[interactionsList.arraySize];
-
+            mappingProfile = profile;
             var asset = AssetDatabase.LoadAssetAtPath<TextAsset>(EditorWindowOptionsPath);
 
             if (asset == null)
@@ -492,7 +497,7 @@ namespace XRTK.Inspectors
 
                     if (EditorGUI.EndChangeCheck())
                     {
-                        var inputAction = actionId.intValue == 0 ? MixedRealityInputAction.None : MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
+                        var inputAction = actionId.intValue == 0 ? MixedRealityInputAction.None : inputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
                         actionDescription.stringValue = inputAction.Description;
                         actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
                     }
@@ -732,7 +737,7 @@ namespace XRTK.Inspectors
                     {
                         MixedRealityInputAction inputAction = actionId.intValue == 0 ?
                             MixedRealityInputAction.None :
-                            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
+                           inputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
                         actionId.intValue = (int)inputAction.Id;
                         actionDescription.stringValue = inputAction.Description;
                         actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -345,32 +345,32 @@ namespace XRTK.Inspectors
         public override void AssignNewShaderToMaterial(Material material, Shader oldShader, Shader newShader)
         {
             // Cache old shader properties with potentially different names than the new shader.
-            float? smoothness = GetFloatProperty(material, "_Glossiness");
+            float? smoothnessProperty = GetFloatProperty(material, "_Glossiness");
             float? diffuse = GetFloatProperty(material, "_UseDiffuse");
-            float? specularHighlights = GetFloatProperty(material, "_SpecularHighlights");
-            float? normalMap = null;
+            float? specularHighlightsProperty = GetFloatProperty(material, "_SpecularHighlights");
+            float? normalMapProperty = null;
             Texture normalMapTexture = material.GetTexture(BumpMap);
-            float? normalMapScale = GetFloatProperty(material, "_BumpScale");
+            float? normalMapScaleProperty = GetFloatProperty(material, "_BumpScale");
             float? emission = null;
             Color? emissionColor = GetColorProperty(material, "_EmissionColor");
-            float? reflections = null;
+            float? reflectionsProperty = null;
             float? rimLighting = null;
             Vector4? textureScaleOffset = null;
-            float? cullMode = GetFloatProperty(material, "_Cull");
+            float? cullModeProperty = GetFloatProperty(material, "_Cull");
 
             if (oldShader)
             {
                 if (oldShader.name.Contains("Standard"))
                 {
-                    normalMap = material.IsKeywordEnabled("_NORMALMAP") ? 1.0f : 0.0f;
+                    normalMapProperty = material.IsKeywordEnabled("_NORMALMAP") ? 1.0f : 0.0f;
                     emission = material.IsKeywordEnabled("_EMISSION") ? 1.0f : 0.0f;
-                    reflections = GetFloatProperty(material, "_GlossyReflections");
+                    reflectionsProperty = GetFloatProperty(material, "_GlossyReflections");
                 }
                 else if (oldShader.name.Contains("Fast Configurable"))
                 {
-                    normalMap = material.IsKeywordEnabled("_USEBUMPMAP_ON") ? 1.0f : 0.0f;
+                    normalMapProperty = material.IsKeywordEnabled("_USEBUMPMAP_ON") ? 1.0f : 0.0f;
                     emission = GetFloatProperty(material, "_UseEmissionColor");
-                    reflections = GetFloatProperty(material, "_UseReflections");
+                    reflectionsProperty = GetFloatProperty(material, "_UseReflections");
                     rimLighting = GetFloatProperty(material, "_UseRimLighting");
                     textureScaleOffset = GetVectorProperty(material, "_TextureScaleOffset");
                 }
@@ -379,23 +379,23 @@ namespace XRTK.Inspectors
             base.AssignNewShaderToMaterial(material, oldShader, newShader);
 
             // Apply old shader properties to the new shader.
-            SetFloatProperty(material, null, "_Smoothness", smoothness);
+            SetFloatProperty(material, null, "_Smoothness", smoothnessProperty);
             SetFloatProperty(material, "_DIRECTIONAL_LIGHT", "_DirectionalLight", diffuse);
-            SetFloatProperty(material, "_SPECULAR_HIGHLIGHTS", "_SpecularHighlights", specularHighlights);
-            SetFloatProperty(material, "_NORMAL_MAP", "_EnableNormalMap", normalMap);
+            SetFloatProperty(material, "_SPECULAR_HIGHLIGHTS", "_SpecularHighlights", specularHighlightsProperty);
+            SetFloatProperty(material, "_NORMAL_MAP", "_EnableNormalMap", normalMapProperty);
 
             if (normalMapTexture)
             {
                 material.SetTexture(NormalMap, normalMapTexture);
             }
 
-            SetFloatProperty(material, null, "_NormalMapScale", normalMapScale);
+            SetFloatProperty(material, null, "_NormalMapScale", normalMapScaleProperty);
             SetFloatProperty(material, "_EMISSION", "_EnableEmission", emission);
             SetColorProperty(material, "_EmissiveColor", emissionColor);
-            SetFloatProperty(material, "_REFLECTIONS", "_Reflections", reflections);
+            SetFloatProperty(material, "_REFLECTIONS", "_Reflections", reflectionsProperty);
             SetFloatProperty(material, "_RIM_LIGHT", "_RimLight", rimLighting);
             SetVectorProperty(material, "_MainTex_ST", textureScaleOffset);
-            SetFloatProperty(material, null, "_CullMode", cullMode);
+            SetFloatProperty(material, null, "_CullMode", cullModeProperty);
 
             // Setup the rendering mode based on the old shader.
             if (oldShader == null || !oldShader.name.Contains("Legacy Shaders/"))

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -24,36 +24,42 @@ namespace XRTK.Inspectors.Profiles
         private static BaseMixedRealityProfile profile;
         private static BaseMixedRealityProfile profileToCopy;
 
+        protected BaseMixedRealityProfile thisProfile;
+
         protected virtual void OnEnable()
         {
             targetProfile = serializedObject;
             profile = target as BaseMixedRealityProfile;
+            Debug.Assert(profile != null);
+            thisProfile = profile;
         }
 
         /// <summary>
         /// Renders a <see cref="BaseMixedRealityProfile"/>.
         /// </summary>
+        /// <param name="parentProfile">The <see cref="BaseMixedRealityProfile"/> parent of the profile being rendered.</param>
         /// <param name="property">the <see cref="BaseMixedRealityProfile"/> property.</param>
         /// <param name="guiContent">The GUIContent for the field.</param>
         /// <param name="showAddButton">Optional flag to hide the create button.</param>
         /// <returns>True, if the profile changed.</returns>
-        protected static bool RenderProfile(SerializedProperty property, GUIContent guiContent, bool showAddButton = true)
+        protected static bool RenderProfile(BaseMixedRealityProfile parentProfile, SerializedProperty property, GUIContent guiContent, bool showAddButton = true)
         {
-            return RenderProfileInternal(property, guiContent, showAddButton);
+            return RenderProfileInternal(parentProfile, property, guiContent, showAddButton);
         }
 
         /// <summary>
         /// Renders a <see cref="BaseMixedRealityProfile"/>.
         /// </summary>
+        /// <param name="parentProfile">The <see cref="BaseMixedRealityProfile"/> parent of the profile being rendered.</param>
         /// <param name="property">the <see cref="BaseMixedRealityProfile"/> property.</param>
         /// <param name="showAddButton">Optional flag to hide the create button.</param>
         /// <returns>True, if the profile changed.</returns>
-        protected static bool RenderProfile(SerializedProperty property, bool showAddButton = true)
+        protected static bool RenderProfile(BaseMixedRealityProfile parentProfile, SerializedProperty property, bool showAddButton = true)
         {
-            return RenderProfileInternal(property, null, showAddButton);
+            return RenderProfileInternal(parentProfile, property, null, showAddButton);
         }
 
-        private static bool RenderProfileInternal(SerializedProperty property, GUIContent guiContent, bool showAddButton)
+        private static bool RenderProfileInternal(BaseMixedRealityProfile parentProfile, SerializedProperty property, GUIContent guiContent, bool showAddButton)
         {
             bool changed = false;
             EditorGUILayout.BeginHorizontal();
@@ -104,6 +110,20 @@ namespace XRTK.Inspectors.Profiles
                     property.serializedObject.ApplyModifiedProperties();
                     PasteProfileValuesDelay(newProfile);
                     changed = true;
+                }
+            }
+
+            if (property.objectReferenceValue != null)
+            {
+                var renderedProfile = property.objectReferenceValue as BaseMixedRealityProfile;
+                Debug.Assert(renderedProfile != null);
+
+                if (renderedProfile.ParentProfile == null)
+                {
+                    renderedProfile.ParentProfile = parentProfile;
+                    EditorUtility.SetDirty(renderedProfile);
+                    property.objectReferenceValue = renderedProfile;
+                    property.serializedObject.ApplyModifiedProperties();
                 }
             }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
@@ -5,9 +5,7 @@ using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions;
 using XRTK.Definitions.BoundarySystem;
-using XRTK.Definitions.Utilities;
 using XRTK.Inspectors.Utilities;
-using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles
 {
@@ -44,11 +42,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             boundaryHeight = serializedObject.FindProperty("boundaryHeight");
 
             showFloor = serializedObject.FindProperty("showFloor");
@@ -77,14 +70,10 @@ namespace XRTK.Inspectors.Profiles
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Configuration Profile"))
             {
-                return;
-            }
-
-            if (GUILayout.Button("Back to Configuration Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
             EditorGUILayout.Space();

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -5,7 +5,6 @@ using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions;
 using XRTK.Inspectors.Utilities;
-using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles
 {
@@ -30,11 +29,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             isCameraPersistent = serializedObject.FindProperty("isCameraPersistent");
             opaqueNearClip = serializedObject.FindProperty("nearClipPlaneOpaqueDisplay");
             opaqueClearFlags = serializedObject.FindProperty("cameraClearFlagsOpaqueDisplay");
@@ -50,21 +44,18 @@ namespace XRTK.Inspectors.Profiles
         public override void OnInspectorGUI()
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
-            {
-                return;
-            }
 
-            if (GUILayout.Button("Back to Configuration Profile"))
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Configuration Profile"))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Camera Profile", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("The Camera Profile helps tweak camera settings no matter what platform you're building for.", MessageType.Info);
 
-            (target as BaseMixedRealityProfile).CheckProfileLock();
+            thisProfile.CheckProfileLock();
 
             serializedObject.Update();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityControllerDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityControllerDataProviderProfileInspector.cs
@@ -3,9 +3,8 @@
 
 using UnityEditor;
 using UnityEngine;
-using XRTK.Providers.Controllers;
-using XRTK.Definitions;
 using XRTK.Inspectors.Utilities;
+using XRTK.Providers.Controllers;
 using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles
@@ -25,17 +24,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled ||
-                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
-            {
-                return;
-            }
-
             controllerDataProviders = serializedObject.FindProperty("registeredControllerDataProviders");
             foldouts = new bool[controllerDataProviders.arraySize];
         }
@@ -44,33 +32,17 @@ namespace XRTK.Inspectors.Profiles
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Input Profile"))
             {
-                return;
-            }
-
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
-            {
-                EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
-
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
-
-                return;
-            }
-
-            if (GUILayout.Button("Back to Input Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Controller Data Providers", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("Use this profile to define all the input sources your application can get input data from.", MessageType.Info);
 
-            (target as BaseMixedRealityProfile).CheckProfileLock();
+            thisProfile.CheckProfileLock();
 
             serializedObject.Update();
 
@@ -135,7 +107,7 @@ namespace XRTK.Inspectors.Profiles
                     EditorGUILayout.PropertyField(dataProviderName);
                     EditorGUILayout.PropertyField(priority);
                     EditorGUILayout.PropertyField(runtimePlatform);
-                    RenderProfile(profile, ProfileContent, false);
+                    RenderProfile(thisProfile, profile, ProfileContent, false);
 
                     if (EditorGUI.EndChangeCheck())
                     {
@@ -152,7 +124,7 @@ namespace XRTK.Inspectors.Profiles
 
             serializedObject.ApplyModifiedProperties();
 
-            if (changed)
+            if (changed && MixedRealityToolkit.IsInitialized)
             {
                 EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -3,10 +3,8 @@
 
 using UnityEditor;
 using UnityEngine;
-using XRTK.Definitions;
 using XRTK.Definitions.Diagnostics;
 using XRTK.Inspectors.Utilities;
-using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles
 {
@@ -26,11 +24,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             visible = serializedObject.FindProperty("visible");
             handlerType = serializedObject.FindProperty("handlerType");
             showCpu = serializedObject.FindProperty("showCpu");
@@ -45,17 +38,13 @@ namespace XRTK.Inspectors.Profiles
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Configuration Profile"))
             {
-                return;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
-            if (GUILayout.Button("Back to Configuration Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-            }
-
-            (target as BaseMixedRealityProfile).CheckProfileLock();
+            thisProfile.CheckProfileLock();
 
             serializedObject.Update();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
@@ -3,10 +3,8 @@
 
 using UnityEditor;
 using UnityEngine;
-using XRTK.Definitions;
 using XRTK.Definitions.InputSystem;
 using XRTK.Inspectors.Utilities;
-using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles
 {
@@ -26,11 +24,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             inputActionList = serializedObject.FindProperty("inputActions");
         }
 
@@ -38,27 +31,13 @@ namespace XRTK.Inspectors.Profiles
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Input Profile"))
             {
-                return;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
-            {
-                EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
-
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
-
-                return;
-            }
-
-            if (GUILayout.Button("Back to Input Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
-            }
+            thisProfile.CheckProfileLock();
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Input Actions", EditorStyles.boldLabel);
@@ -66,7 +45,7 @@ namespace XRTK.Inspectors.Profiles
             EditorGUILayout.HelpBox("Input Actions are any/all actions your users will be able to make when interacting with your application.\n\n" +
                                     "After defining all your actions, you can then wire up these actions to hardware sensors, controllers, and other input devices.", MessageType.Info);
 
-            (target as BaseMixedRealityProfile).CheckProfileLock();
+            thisProfile.CheckProfileLock();
 
             serializedObject.Update();
             RenderList(inputActionList);
@@ -77,6 +56,7 @@ namespace XRTK.Inspectors.Profiles
         {
             EditorGUILayout.Space();
             GUILayout.BeginVertical();
+
             if (GUILayout.Button(AddButtonContent, EditorStyles.miniButton))
             {
                 list.arraySize += 1;
@@ -89,7 +69,6 @@ namespace XRTK.Inspectors.Profiles
             }
 
             GUILayout.Space(12f);
-
             GUILayout.BeginVertical();
 
             GUILayout.BeginHorizontal();
@@ -108,8 +87,8 @@ namespace XRTK.Inspectors.Profiles
                 EditorGUILayout.BeginHorizontal();
                 var previousLabelWidth = EditorGUIUtility.labelWidth;
                 EditorGUIUtility.labelWidth = 64f;
-                SerializedProperty inputAction = list.GetArrayElementAtIndex(i);
-                SerializedProperty inputActionDescription = inputAction.FindPropertyRelative("description");
+                var inputAction = list.GetArrayElementAtIndex(i);
+                var inputActionDescription = inputAction.FindPropertyRelative("description");
                 var inputActionConstraint = inputAction.FindPropertyRelative("axisConstraint");
                 EditorGUILayout.PropertyField(inputActionDescription, GUIContent.none);
                 EditorGUILayout.PropertyField(inputActionConstraint, GUIContent.none, GUILayout.Width(96f));

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -3,7 +3,6 @@
 
 using UnityEditor;
 using UnityEngine;
-using XRTK.Definitions;
 using XRTK.Definitions.InputSystem;
 using XRTK.Inspectors.Utilities;
 using XRTK.Services;
@@ -27,11 +26,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             focusProviderType = serializedObject.FindProperty("focusProviderType");
             inputActionsProfile = serializedObject.FindProperty("inputActionsProfile");
             inputActionRulesProfile = serializedObject.FindProperty("inputActionRulesProfile");
@@ -47,21 +41,17 @@ namespace XRTK.Inspectors.Profiles
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Configuration Profile"))
             {
-                return;
-            }
-
-            if (GUILayout.Button("Back to Configuration Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Input System Profile", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("The Input System Profile helps developers configure input no matter what platform you're building for.", MessageType.Info);
 
-            (target as BaseMixedRealityProfile).CheckProfileLock();
+            thisProfile.CheckProfileLock();
 
             serializedObject.Update();
             bool changed = false;
@@ -74,18 +64,18 @@ namespace XRTK.Inspectors.Profiles
                 changed = true;
             }
 
-            changed |= RenderProfile(inputActionsProfile);
-            changed |= RenderProfile(inputActionRulesProfile);
-            changed |= RenderProfile(pointerProfile);
-            changed |= RenderProfile(gesturesProfile);
-            changed |= RenderProfile(speechCommandsProfile);
-            changed |= RenderProfile(controllerVisualizationProfile);
-            changed |= RenderProfile(controllerDataProvidersProfile);
-            changed |= RenderProfile(controllerMappingProfiles);
+            changed |= RenderProfile(thisProfile, inputActionsProfile);
+            changed |= RenderProfile(thisProfile, inputActionRulesProfile);
+            changed |= RenderProfile(thisProfile, pointerProfile);
+            changed |= RenderProfile(thisProfile, gesturesProfile);
+            changed |= RenderProfile(thisProfile, speechCommandsProfile);
+            changed |= RenderProfile(thisProfile, controllerVisualizationProfile);
+            changed |= RenderProfile(thisProfile, controllerDataProvidersProfile);
+            changed |= RenderProfile(thisProfile, controllerMappingProfiles);
 
             serializedObject.ApplyModifiedProperties();
 
-            if (changed)
+            if (changed && MixedRealityToolkit.IsInitialized)
             {
                 EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityNetworkSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityNetworkSystemProfileInspector.cs
@@ -3,7 +3,6 @@
 
 using UnityEditor;
 using UnityEngine;
-using XRTK.Definitions;
 using XRTK.Definitions.NetworkingSystem;
 using XRTK.Inspectors.Utilities;
 using XRTK.Services;
@@ -19,11 +18,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             registeredNetworkDataProviders = serializedObject.FindProperty("registeredNetworkDataProviders");
         }
 
@@ -31,28 +25,24 @@ namespace XRTK.Inspectors.Profiles
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Configuration Profile"))
             {
-                return;
-            }
-
-            if (GUILayout.Button("Back to Configuration Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Network System Profile", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("The Network System Profile helps developers configure networking messages no matter what platform you're building for.", MessageType.Info);
 
-            (target as BaseMixedRealityProfile).CheckProfileLock();
+            thisProfile.CheckProfileLock();
 
             serializedObject.Update();
 
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(registeredNetworkDataProviders, true);
 
-            if (EditorGUI.EndChangeCheck())
+            if (EditorGUI.EndChangeCheck() && MixedRealityToolkit.IsInitialized)
             {
                 EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -4,10 +4,8 @@
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
-using XRTK.Definitions;
 using XRTK.Definitions.InputSystem;
 using XRTK.Inspectors.Utilities;
-using XRTK.Services;
 using XRTK.Utilities;
 
 namespace XRTK.Inspectors.Profiles
@@ -32,11 +30,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             pointingExtent = serializedObject.FindProperty("pointingExtent");
             pointingRaycastLayerMasks = serializedObject.FindProperty("pointingRaycastLayerMasks");
             debugDrawPointingRays = serializedObject.FindProperty("debugDrawPointingRays");
@@ -58,14 +51,11 @@ namespace XRTK.Inspectors.Profiles
         public override void OnInspectorGUI()
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
-            {
-                return;
-            }
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Input Profile"))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
             EditorGUILayout.Space();
@@ -73,7 +63,7 @@ namespace XRTK.Inspectors.Profiles
             EditorGUILayout.HelpBox("Pointers attach themselves onto controllers as they are initialized.", MessageType.Info);
             EditorGUILayout.Space();
 
-            (target as BaseMixedRealityProfile).CheckProfileLock();
+            thisProfile.CheckProfileLock();
             serializedObject.Update();
             currentlySelectedPointerOption = -1;
 
@@ -90,6 +80,7 @@ namespace XRTK.Inspectors.Profiles
             EditorGUILayout.PropertyField(gazeProviderType);
 
             EditorGUILayout.Space();
+
             if (GUILayout.Button("Customize Gaze Provider Settings"))
             {
                 Selection.activeObject = CameraCache.Main.gameObject;

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -21,11 +21,6 @@ namespace XRTK.Inspectors.Profiles
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             configurations = serializedObject.FindProperty("configurations");
 
             configurationList = new ReorderableList(serializedObject, configurations, true, false, true, true)
@@ -42,14 +37,10 @@ namespace XRTK.Inspectors.Profiles
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Configuration Profile"))
             {
-                return;
-            }
-
-            if (GUILayout.Button("Back to Configuration Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
             EditorGUILayout.Space();
@@ -57,7 +48,7 @@ namespace XRTK.Inspectors.Profiles
             EditorGUILayout.HelpBox("This profile defines any additional Services like systems, features, and managers to register with the Mixed Reality Toolkit.\n\n" +
                                     "Note: The order of the list determines the order these services get created.", MessageType.Info);
 
-            (target as BaseMixedRealityProfile).CheckProfileLock();
+            thisProfile.CheckProfileLock();
 
             serializedObject.Update();
             EditorGUILayout.Space();
@@ -107,7 +98,8 @@ namespace XRTK.Inspectors.Profiles
             {
                 serializedObject.ApplyModifiedProperties();
 
-                if (!string.IsNullOrEmpty(componentType.FindPropertyRelative("reference").stringValue))
+                if (MixedRealityToolkit.IsInitialized &&
+                    !string.IsNullOrEmpty(componentType.FindPropertyRelative("reference").stringValue))
                 {
                     MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
                 }
@@ -142,7 +134,11 @@ namespace XRTK.Inspectors.Profiles
             }
 
             serializedObject.ApplyModifiedProperties();
-            EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
+
+            if (MixedRealityToolkit.IsInitialized)
+            {
+                EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
+            }
         }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwareness/BaseMixedRealitySpatialMeshObserverProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwareness/BaseMixedRealitySpatialMeshObserverProfileInspector.cs
@@ -3,7 +3,6 @@
 
 using UnityEditor;
 using XRTK.Providers.SpatialObservers;
-using XRTK.Inspectors.Utilities;
 
 namespace XRTK.Inspectors.Profiles.SpatialAwareness
 {
@@ -27,11 +26,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             meshPhysicsLayerOverride = serializedObject.FindProperty("meshPhysicsLayerOverride");
             meshLevelOfDetail = serializedObject.FindProperty("meshLevelOfDetail");
             meshTrianglesPerCubicMeter = serializedObject.FindProperty("meshTrianglesPerCubicMeter");
@@ -47,10 +41,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         public override void OnInspectorGUI()
         {
             base.OnInspectorGUI();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
 
             serializedObject.Update();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwareness/BaseMixedRealitySpatialObserverProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwareness/BaseMixedRealitySpatialObserverProfileInspector.cs
@@ -3,10 +3,8 @@
 
 using UnityEditor;
 using UnityEngine;
-using XRTK.Providers.SpatialObservers;
-using XRTK.Definitions;
 using XRTK.Inspectors.Utilities;
-using XRTK.Services;
+using XRTK.Providers.SpatialObservers;
 
 namespace XRTK.Inspectors.Profiles.SpatialAwareness
 {
@@ -25,10 +23,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         protected override void OnEnable()
         {
             base.OnEnable();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
 
             startupBehavior = serializedObject.FindProperty("startupBehavior");
             observationExtents = serializedObject.FindProperty("observationExtents");
@@ -42,38 +36,18 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Spatial Awareness Profile"))
             {
-                return;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
-
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsSpatialAwarenessSystemEnabled)
-            {
-                EditorGUILayout.HelpBox("The Spatial Awareness Observer Data Provider requires that the spatial awareness system be enabled.", MessageType.Error);
-
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
-
-                return;
-            }
-
-            if (GUILayout.Button("Back to Spatial Awareness Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessProfile;
-            }
-
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Spatial Observer Options", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("The Spatial Awareness Observer Data Provider supplies the Spatial Awareness system with all the data it needs to understand the world around you.", MessageType.Info);
             EditorGUILayout.Space();
 
-            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
-            {
-                GUI.enabled = false;
-            }
+            thisProfile.CheckProfileLock();
 
             serializedObject.Update();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwareness/BaseMixedRealitySurfaceObserverProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwareness/BaseMixedRealitySurfaceObserverProfileInspector.cs
@@ -4,7 +4,6 @@
 using UnityEditor;
 using UnityEngine;
 using XRTK.Providers.SpatialObservers;
-using XRTK.Inspectors.Utilities;
 
 namespace XRTK.Inspectors.Profiles.SpatialAwareness
 {
@@ -35,11 +34,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             surfacePhysicsLayerOverride = serializedObject.FindProperty("surfacePhysicsLayerOverride");
             surfaceFindingMinimumArea = serializedObject.FindProperty("surfaceFindingMinimumArea");
             displayFloorSurfaces = serializedObject.FindProperty("displayFloorSurfaces");
@@ -56,11 +50,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         public override void OnInspectorGUI()
         {
             base.OnInspectorGUI();
-
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
-            {
-                return;
-            }
 
             serializedObject.Update();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwareness/MixedRealitySpatialAwarenessSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwareness/MixedRealitySpatialAwarenessSystemProfileInspector.cs
@@ -3,10 +3,8 @@
 
 using UnityEditor;
 using UnityEngine;
-using XRTK.Definitions;
 using XRTK.Definitions.SpatialAwarenessSystem;
 using XRTK.Inspectors.Utilities;
-using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles.SpatialAwareness
 {
@@ -25,11 +23,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             registeredSpatialObserverDataProviders = serializedObject.FindProperty("registeredSpatialObserverDataProviders");
             foldouts = new bool[registeredSpatialObserverDataProviders.arraySize];
         }
@@ -39,14 +32,10 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (thisProfile.ParentProfile != null &&
+                GUILayout.Button("Back to Configuration Profile"))
             {
-                return;
-            }
-
-            if (GUILayout.Button("Back to Configuration Profile"))
-            {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                Selection.activeObject = thisProfile.ParentProfile;
             }
 
             EditorGUILayout.Space();
@@ -55,10 +44,7 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
             EditorGUILayout.Space();
             serializedObject.Update();
 
-            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
-            {
-                GUI.enabled = false;
-            }
+            thisProfile.CheckProfileLock();
 
             EditorGUILayout.Space();
 
@@ -116,7 +102,7 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
                     EditorGUILayout.PropertyField(spatialObserverName);
                     EditorGUILayout.PropertyField(priority);
                     EditorGUILayout.PropertyField(runtimePlatform);
-                    RenderProfile(profile, false);
+                    RenderProfile(thisProfile, profile, false);
                     EditorGUI.indentLevel--;
                 }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/InputActionPropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/InputActionPropertyDrawer.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using XRTK.Extensions;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions.InputSystem;
+using XRTK.Extensions;
 using XRTK.Services;
 
 namespace XRTK.Inspectors.PropertyDrawers
@@ -19,37 +19,37 @@ namespace XRTK.Inspectors.PropertyDrawers
 
         public override void OnGUI(Rect rect, SerializedProperty property, GUIContent content)
         {
-            if (!MixedRealityToolkit.IsInitialized || !MixedRealityToolkit.HasActiveProfile)
-            {
-                profile = null;
-                actionLabels = new[] { new GUIContent("Missing Mixed Reality Toolkit") };
-                actionIds = new[] { 0 };
-            }
+            profile = null;
+            actionLabels = new[] { new GUIContent("Missing Mixed Reality Toolkit") };
+            actionIds = new[] { 0 };
 
-            if (profile == null ||
-                (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
-                 profile.InputActions != null &&
-                 profile.InputActions != MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions))
+            if (MixedRealityToolkit.IsInitialized && MixedRealityToolkit.HasActiveProfile)
             {
-                profile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile;
-
-                if (profile != null)
+                if (profile == null ||
+                    (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
+                     profile.InputActions != null &&
+                     profile.InputActions != MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions))
                 {
-                    actionLabels = profile.InputActions.Select(action => new GUIContent(action.Description)).Prepend(new GUIContent("None")).ToArray();
-                    actionIds = profile.InputActions.Select(action => (int)action.Id).Prepend(0).ToArray();
+                    profile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile;
+
+                    if (profile != null)
+                    {
+                        actionLabels = profile.InputActions.Select(action => new GUIContent(action.Description)).Prepend(new GUIContent("None")).ToArray();
+                        actionIds = profile.InputActions.Select(action => (int)action.Id).Prepend(0).ToArray();
+                    }
+                    else
+                    {
+                        actionLabels = new[] { new GUIContent("No input action profile found") };
+                        actionIds = new[] { 0 };
+                    }
                 }
-                else
+
+                if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
                 {
-                    actionLabels = new[] { new GUIContent("No input action profile found") };
+                    profile = null;
+                    actionLabels = new[] { new GUIContent("Input System Disabled") };
                     actionIds = new[] { 0 };
                 }
-            }
-
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
-            {
-                profile = null;
-                actionLabels = new[] { new GUIContent("Input System Disabled") };
-                actionIds = new[] { 0 };
             }
 
             var label = EditorGUI.BeginProperty(rect, content, property);

--- a/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -67,12 +67,10 @@ namespace XRTK.Services.CameraSystem
 
         public override void Enable()
         {
-            if (Application.isPlaying)
+            if (Application.isPlaying && 
+                profile.IsCameraPersistent)
             {
-                if (profile.IsCameraPersistent)
-                {
-                    CameraCache.Main.transform.root.DontDestroyOnLoad();
-                }
+                CameraCache.Main.transform.root.DontDestroyOnLoad();
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
@@ -26,7 +26,7 @@ namespace XRTK.Services
     /// <summary>
     /// This class is responsible for coordinating the operation of the Mixed Reality Toolkit. It is the only Singleton in the entire project.
     /// It provides a service registry for all active services that are used within a project as well as providing the active configuration profile for the project.
-    /// The Profile can be swapped out at any time to meet the needs of your project.
+    /// The <see cref="ActiveProfile"/> can be swapped out at any time to meet the needs of your project.
     /// </summary>
     [ExecuteInEditMode]
     [DisallowMultipleComponent]
@@ -164,12 +164,8 @@ namespace XRTK.Services
                     return instance;
                 }
 
-                if (isGettingInstance)
-                {
-                    return null;
-                }
-
-                if (Application.isPlaying && !searchForInstance)
+                if (isGettingInstance ||
+                   (Application.isPlaying && !searchForInstance))
                 {
                     return null;
                 }
@@ -244,10 +240,7 @@ namespace XRTK.Services
                     DontDestroyOnLoad(instance.transform.root);
                 }
 
-                Application.quitting += () =>
-                {
-                    isApplicationQuitting = true;
-                };
+                Application.quitting += () => isApplicationQuitting = true;
 
 #if UNITY_EDITOR
                 UnityEditor.EditorApplication.hierarchyChanged += OnHierarchyChanged;
@@ -264,12 +257,14 @@ namespace XRTK.Services
 
                 void OnPlayModeStateChanged(UnityEditor.PlayModeStateChange playModeState)
                 {
-                    if (playModeState == UnityEditor.PlayModeStateChange.ExitingEditMode || playModeState == UnityEditor.PlayModeStateChange.EnteredEditMode)
+                    if (playModeState == UnityEditor.PlayModeStateChange.ExitingEditMode ||
+                        playModeState == UnityEditor.PlayModeStateChange.EnteredEditMode)
                     {
                         isApplicationQuitting = false;
                     }
 
-                    if (playModeState == UnityEditor.PlayModeStateChange.ExitingEditMode && activeProfile == null)
+                    if (activeProfile == null &&
+                        playModeState == UnityEditor.PlayModeStateChange.ExitingEditMode)
                     {
                         UnityEditor.EditorApplication.isPlaying = false;
                         UnityEditor.Selection.activeObject = Instance;
@@ -289,7 +284,6 @@ namespace XRTK.Services
         /// Flag to search for instance the first time Instance property is called.
         /// Subsequent attempts will generally switch this flag false, unless the instance was destroyed.
         /// </summary>
-        // ReSharper disable once StaticMemberInGenericType
         private static bool searchForInstance = true;
 
         private static bool isInitializing = false;
@@ -660,7 +654,8 @@ namespace XRTK.Services
 #if UNITY_EDITOR
         private void OnValidate()
         {
-            if (!IsInitialized && !UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
+            if (!IsInitialized &&
+                !UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
             {
                 ConfirmInitialized();
             }


### PR DESCRIPTION
# Overview

This PR covers the required changes to all of the profile inspectors to enable them to not require the Service Locator object be setup and initialed in the scene to configure them.

## Target of the change:

Is this enhancement for:

- Core

## Changes:

All references to the `MixedRealityToolkit.Instance` have been removed for the most part and replaced with a dynamic profile reference.

This will require the profiles to have to be setup at least once in the main configuration profile to get these reference properly set.

- Fixes: #76 
