### PR TITLE
don't serialize the parent profile, as they're actually dynamic.

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityProfile.cs
@@ -12,16 +12,9 @@ namespace XRTK.Definitions
 
         internal bool IsCustomProfile => isCustomProfile;
 
-        [SerializeField]
-        private BaseMixedRealityProfile parentProfile = null;
-
         /// <summary>
         /// The profile's parent.
         /// </summary>
-        public BaseMixedRealityProfile ParentProfile
-        {
-            get => parentProfile;
-            internal set => parentProfile = value;
-        }
+        public BaseMixedRealityProfile ParentProfile { get; internal set; } = null;
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -85,6 +85,8 @@ namespace XRTK.Inspectors.Profiles
 
                     var instance = CreateInstance(profileTypeName);
                     var newProfile = instance.CreateAsset(AssetDatabase.GetAssetPath(Selection.activeObject)) as BaseMixedRealityProfile;
+                    Debug.Assert(newProfile != null);
+                    newProfile.ParentProfile = parentProfile;
                     property.objectReferenceValue = newProfile;
                     property.serializedObject.ApplyModifiedProperties();
                     changed = true;
@@ -106,6 +108,8 @@ namespace XRTK.Inspectors.Profiles
 
                     var instance = CreateInstance(typeName);
                     var newProfile = instance.CreateAsset(AssetDatabase.GetAssetPath(Selection.activeObject)) as BaseMixedRealityProfile;
+                    Debug.Assert(newProfile != null);
+                    newProfile.ParentProfile = parentProfile;
                     property.objectReferenceValue = newProfile;
                     property.serializedObject.ApplyModifiedProperties();
                     PasteProfileValuesDelay(newProfile);
@@ -118,12 +122,11 @@ namespace XRTK.Inspectors.Profiles
                 var renderedProfile = property.objectReferenceValue as BaseMixedRealityProfile;
                 Debug.Assert(renderedProfile != null);
 
-                if (renderedProfile.ParentProfile == null)
+                if (!(renderedProfile is MixedRealityToolkitConfigurationProfile) &&
+                     (renderedProfile.ParentProfile == null ||
+                      renderedProfile.ParentProfile != parentProfile))
                 {
                     renderedProfile.ParentProfile = parentProfile;
-                    EditorUtility.SetDirty(renderedProfile);
-                    property.objectReferenceValue = renderedProfile;
-                    property.serializedObject.ApplyModifiedProperties();
                 }
             }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Makes the parent profile property more dynamic.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

Brief list of the targeted features that are being changed.

- Fixes: #176 