### PR TITLE
Added SetRedneringActive game object extension

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/GameObjectExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/GameObjectExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace XRTK.Extensions
 {
@@ -131,6 +132,39 @@ namespace XRTK.Extensions
             foreach (T i in gameObject.GetComponents<T>())
             {
                 action(i);
+            }
+        }
+
+        /// <summary>
+        /// Sets the <see cref="Renderer"/>s and optionally <see cref="Collider"/>s in this <see cref="GameObject"/> to the provided <see cref="bool"/> state.
+        /// </summary>
+        /// <remarks>If the GameObject or it's children are inactive, they will be set active, but the GameObjects will not be set inactive.</remarks>
+        /// <param name="gameObject"></param>
+        /// <param name="isActive"></param>
+        /// <param name="includeColliders"></param>
+        public static void SetRenderingActive(this GameObject gameObject, bool isActive, bool includeColliders = true)
+        {
+            if (isActive)
+            {
+                gameObject.SetActive(true);
+            }
+
+            foreach (var renderer in gameObject.GetComponentsInChildren<Renderer>())
+            {
+                renderer.enabled = isActive;
+            }
+
+            foreach (var graphic in gameObject.GetComponentsInChildren<Graphic>())
+            {
+                graphic.enabled = isActive;
+            }
+
+            if (includeColliders)
+            {
+                foreach (var collider in gameObject.GetComponentsInChildren<Collider>())
+                {
+                    collider.enabled = isActive;
+                }
             }
         }
     }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Adds an additional `GameObject` extension to help set renderers, graphics and colliders active or inactive without setting the `GameObject` itself inactive so that scripts still run on them, but they're effectively disabled to the input system.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)
