### PR TITLE
Add Android and iOS targets to supported platforms

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/SupportedPlatforms.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/SupportedPlatforms.cs
@@ -16,5 +16,7 @@ namespace XRTK.Definitions.Utilities
         LinuxStandalone = 1 << 2,
         WindowsUniversal = 1 << 3,
         Lumin = 1 << 4,
+        Android = 1 << 5,
+        iOS = 1 << 6
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/PlatformUtility.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/PlatformUtility.cs
@@ -20,6 +20,12 @@ namespace XRTK.Utilities
 
             switch (runtimePlatform)
             {
+                case RuntimePlatform.Android:
+                    supportedPlatforms |= SupportedPlatforms.Android;
+                    break;
+                case RuntimePlatform.IPhonePlayer:
+                    supportedPlatforms |= SupportedPlatforms.iOS;
+                    break;
                 case RuntimePlatform.WindowsPlayer:
                 case RuntimePlatform.WindowsEditor:
                     supportedPlatforms |= SupportedPlatforms.WindowsStandalone;
@@ -48,7 +54,7 @@ namespace XRTK.Utilities
 
         private static bool IsPlatformSupported(SupportedPlatforms target, SupportedPlatforms supported)
         {
-            return ((target & supported) == target);
+            return (target & supported) == target;
         }
 
 #if UNITY_EDITOR
@@ -64,6 +70,12 @@ namespace XRTK.Utilities
 
             switch (editorBuildTarget)
             {
+                case UnityEditor.BuildTarget.Android:
+                    supportedPlatforms |= SupportedPlatforms.Android;
+                    break;
+                case UnityEditor.BuildTarget.iOS:
+                    supportedPlatforms |= SupportedPlatforms.iOS;
+                    break;
                 case UnityEditor.BuildTarget.StandaloneWindows:
                 case UnityEditor.BuildTarget.StandaloneWindows64:
                     supportedPlatforms |= SupportedPlatforms.WindowsStandalone;


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Solves #187.

## Target of the change:

- Core (core framework, interfaces and definitions)

## Changes:

- Added Android and iOS as selectable Targets for supported platforms when configuring components and services
