### PR TITLE
Find common root for GameObject and Transforms

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/GameObjectExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/GameObjectExtensions.cs
@@ -167,5 +167,39 @@ namespace XRTK.Extensions
                 }
             }
         }
+
+        /// <summary>
+        /// Given 2 GameObjects, return a common root GameObject (or null).
+        /// </summary>
+        /// <param name="g1">GameObject to compare</param>
+        /// <param name="g2">GameObject to compare</param>
+        public static GameObject FindCommonRoot(this GameObject g1, GameObject g2)
+        {
+            if (g1 == null || g2 == null)
+            {
+                return null;
+            }
+
+            var t1 = g1.transform;
+
+            while (t1 != null)
+            {
+                var t2 = g2.transform;
+
+                while (t2 != null)
+                {
+                    if (t1 == t2)
+                    {
+                        return t1.gameObject;
+                    }
+
+                    t2 = t2.parent;
+                }
+
+                t1 = t1.parent;
+            }
+
+            return null;
+        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/TransformExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/TransformExtensions.cs
@@ -96,7 +96,7 @@ namespace XRTK.Extensions
         /// Calculates the bounds of all the colliders attached to this GameObject and all it's children
         /// </summary>
         /// <param name="transform">Transform of root GameObject the colliders are attached to </param>
-        /// <returns>The total bounds of all colliders attached to this GameObject. 
+        /// <returns>The total bounds of all colliders attached to this GameObject.
         /// If no colliders attached, returns a bounds of center and extents 0</returns>
         public static Bounds GetColliderBounds(this Transform transform)
         {
@@ -254,6 +254,36 @@ namespace XRTK.Extensions
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Given 2 Transforms, return a common root Transform (or null).
+        /// </summary>
+        /// <param name="t1">Transform to compare</param>
+        /// <param name="t2">Transform to compare</param>
+        public static Transform FindCommonRoot(this Transform t1, Transform t2)
+        {
+            if (t1 == null || t2 == null)
+            {
+                return null;
+            }
+
+            while (t1 != null)
+            {
+                while (t2 != null)
+                {
+                    if (t1 == t2)
+                    {
+                        return t1;
+                    }
+
+                    t2 = t2.parent;
+                }
+
+                t1 = t1.parent;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Adds a way to easily find the common root of two GameObjects or Transforms. Will be used in subsequent changes to the event routing.

## Target of the change:

Is this enhancement for:

- Extension
