### PR TITLE
Warnings as errors cleanup

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/CanvasExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/CanvasExtensions.cs
@@ -3,6 +3,7 @@
 
 using UnityEngine;
 using UnityEngine.UI;
+using XRTK.Utilities;
 
 namespace XRTK.Extensions
 {
@@ -66,7 +67,7 @@ namespace XRTK.Extensions
 
             for (int i = 0; i < 4; i++)
             {
-                viewportCorners[i] = Camera.main.WorldToViewportPoint(worldCorners[i]);
+                viewportCorners[i] = CameraCache.Main.WorldToViewportPoint(worldCorners[i]);
             }
 
             return viewportCorners;
@@ -87,7 +88,7 @@ namespace XRTK.Extensions
 
             for (int i = 0; i < 4; i++)
             {
-                screenCorners[i] = Camera.main.WorldToScreenPoint(worldCorners[i]);
+                screenCorners[i] = CameraCache.Main.WorldToScreenPoint(worldCorners[i]);
             }
 
             return screenCorners;

--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/GameObjectExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/GameObjectExtensions.cs
@@ -13,11 +13,16 @@ namespace XRTK.Extensions
     /// </summary>
     public static class GameObjectExtensions
     {
+        /// <summary>
+        /// Sets the child <see cref="GameObject"/> states.
+        /// </summary>
+        /// <param name="root">The root <see cref="GameObject"/>.</param>
+        /// <param name="isActive">The active value to set.</param>
         public static void SetChildrenActive(this GameObject root, bool isActive)
         {
             for (int i = 0; i < root.transform.childCount; i++)
             {
-                root.transform.GetChild(i).gameObject.SetActive(false);
+                root.transform.GetChild(i).gameObject.SetActive(isActive);
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/PrefabPropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/PrefabPropertyDrawer.cs
@@ -13,6 +13,7 @@ namespace XRTK.Inspectors.PropertyDrawers
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             var prefabAttribute = attribute as PrefabAttribute;
+            Debug.Assert(prefabAttribute != null);
 
             if (property.propertyType == SerializedPropertyType.ObjectReference &&
                (property.objectReferenceValue is GameObject || property.objectReferenceValue == null))
@@ -33,7 +34,9 @@ namespace XRTK.Inspectors.PropertyDrawers
 
                 if (prefabAttribute.Constraint != null)
                 {
-                    var constraint = (property.objectReferenceValue as GameObject).GetComponent(prefabAttribute.Constraint);
+                    var prefabObject = property.objectReferenceValue as GameObject;
+                    Debug.Assert(prefabObject != null);
+                    var constraint = prefabObject.GetComponent(prefabAttribute.Constraint);
 
                     if (constraint == null)
                     {

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -147,7 +147,9 @@ namespace XRTK.Utilities.Build
         public static void SyncSolution()
         {
             var syncVs = Type.GetType("UnityEditor.SyncVS,UnityEditor");
+            Debug.Assert(syncVs != null);
             var syncSolution = syncVs.GetMethod("SyncSolution", BindingFlags.Public | BindingFlags.Static);
+            Debug.Assert(syncSolution != null);
             syncSolution.Invoke(null, null);
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/FastSimplexNoise.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/FastSimplexNoise.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using UnityEngine;
 
 namespace XRTK.Utilities
 {
@@ -127,6 +128,7 @@ namespace XRTK.Utilities
                     previous = current;
                 }
 
+                Debug.Assert(current != null);
                 current.Next = new Contribution2(P2D[i + 1], P2D[i + 2], P2D[i + 3]);
             }
 
@@ -161,6 +163,7 @@ namespace XRTK.Utilities
                     previous = current;
                 }
 
+                Debug.Assert(current != null);
                 current.Next = new Contribution3(P3D[i + 1], P3D[i + 2], P3D[i + 3], P3D[i + 4])
                 {
                     Next = new Contribution3(P3D[i + 5], P3D[i + 6], P3D[i + 7], P3D[i + 8])
@@ -196,6 +199,7 @@ namespace XRTK.Utilities
                     previous = current;
                 }
 
+                Debug.Assert(current != null);
                 current.Next = new Contribution4(P4D[i + 1], P4D[i + 2], P4D[i + 3], P4D[i + 4], P4D[i + 5])
                 {
                     Next = new Contribution4(P4D[i + 6], P4D[i + 7], P4D[i + 8], P4D[i + 9], P4D[i + 10])

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs
@@ -55,6 +55,7 @@ namespace XRTK.Utilities.Gltf.Serialization.Importers
                     if (!gltfTexture.Texture.isReadable)
                     {
                         var textureImporter = AssetImporter.GetAtPath(path) as TextureImporter;
+                        Debug.Assert(textureImporter != null);
                         textureImporter.isReadable = true;
                         textureImporter.SetPlatformTextureSettings(new TextureImporterPlatformSettings { format = TextureImporterFormat.RGBA32 });
                         textureImporter.SaveAndReimport();


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Cleaned up the warnings as error problems and fixed a bug with a GameObject extension

## Changes:

Brief list of the targeted features that are being changed.

- Added null assets to fix the warnings as errors thought out solution.
- Fixed a bug in the SetChildrenActive GameObject extension
