### PR TITLE
Unity 2019.2 Pre-Fixes

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/XRTK.Inspectors.asmdef
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/XRTK.Inspectors.asmdef
@@ -4,7 +4,8 @@
         "XRTK",
         "XRTK.Extensions.EditorClassExtensions",
         "XRTK.Utilities.Build",
-        "XRTK.Utilities.Editor"
+        "XRTK.Utilities.Editor",
+        "Unity.ugui"        
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/XRTK-Core/Packages/com.xrtk.core/XRTK.asmdef
+++ b/XRTK-Core/Packages/com.xrtk.core/XRTK.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "XRTK",
     "references": [
-        "XRTK.Utilities.Editor"
+        "XRTK.Utilities.Editor",
+        "Unity.ugui"        
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Pre-resolves an issue in 2019.2 whereby the UI system has been moved out of the editor in to a package.

Confirmed adding this reference (even though earlier versions don't recognise it) does not impact operation.

## Target of the change:

- Core (core framework, interfaces and definitions)

## Changes:

Adds an asmdef reference to the Unity.ugui package in the Core / Inspectors definitions
