### PR TITLE
Remove unused profile from BaseControllerDataProvider

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseControllerDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseControllerDataProvider.cs
@@ -22,7 +22,7 @@ namespace XRTK.Providers.Controllers
         /// <param name="name"></param>
         /// <param name="priority"></param>
         /// <param name="profile"></param>
-        public BaseControllerDataProvider(string name, uint priority, BaseMixedRealityControllerDataProviderProfile profile) : base(name, priority) { }
+        public BaseControllerDataProvider(string name, uint priority) : base(name, priority) { }
 
         /// <inheritdoc />
         public virtual IMixedRealityController[] GetActiveControllers() => new IMixedRealityController[0];

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseDictationDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseDictationDataProvider.cs
@@ -16,7 +16,7 @@ namespace XRTK.Providers.Controllers
         /// <param name="priority"></param>
         /// <param name="profile"></param>
         protected BaseDictationDataProvider(string name, uint priority, BaseMixedRealityControllerDataProviderProfile profile)
-            : base(name, priority, profile)
+            : base(name, priority)
         {
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseSpeechDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseSpeechDataProvider.cs
@@ -14,7 +14,7 @@ namespace XRTK.Providers.Controllers
         /// <param name="priority"></param>
         /// <param name="profile"></param>
         protected BaseSpeechDataProvider(string name, uint priority, BaseMixedRealityControllerDataProviderProfile profile)
-            : base(name, priority, profile)
+            : base(name, priority)
         {
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/MouseDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/MouseDataProvider.cs
@@ -22,7 +22,7 @@ namespace XRTK.Providers.Controllers.UnityInput
         /// <param name="priority"></param>
         /// <param name="profile"></param>
         public MouseDataProvider(string name, uint priority, BaseMixedRealityControllerDataProviderProfile profile)
-            : base(name, priority, profile)
+            : base(name, priority)
         {
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/UnityJoystickDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/UnityJoystickDataProvider.cs
@@ -24,7 +24,7 @@ namespace XRTK.Providers.Controllers.UnityInput
         /// <param name="priority"></param>
         /// <param name="profile"></param>
         public UnityJoystickDataProvider(string name, uint priority, BaseMixedRealityControllerDataProviderProfile profile)
-            : base(name, priority, profile)
+            : base(name, priority)
         {
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/UnityTouchDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/UnityTouchDataProvider.cs
@@ -23,7 +23,7 @@ namespace XRTK.Providers.Controllers.UnityInput
         /// <param name="priority"></param>
         /// <param name="profile"></param>
         public UnityTouchDataProvider(string name, uint priority, BaseMixedRealityControllerDataProviderProfile profile)
-            : base(name, priority, profile)
+            : base(name, priority)
         {
         }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Remove unused profile parameter required by `BaseControllerDataProvider` to increase flexibility.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)
- Platform Lumin / WMR

## Changes:

Brief list of the targeted features that are being changed.

- Removed the parameters from the base constructor and updated data providers to omit it