### PR TITLE
Added SetMeshVisibility convenience method to SpatialAwarenessSystem

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -30,6 +30,8 @@ namespace XRTK.Interfaces.SpatialAwarenessSystem
         /// </summary>
         GameObject SurfacesParent { get; }
 
+        #region Observers Utilities
+
         /// <summary>
         /// Indicates the current running state of the spatial awareness observer.
         /// </summary>
@@ -59,6 +61,10 @@ namespace XRTK.Interfaces.SpatialAwarenessSystem
         /// </summary>
         HashSet<IMixedRealitySpatialObserverDataProvider> DetectedSpatialObservers { get; }
 
+        #endregion Observer Utilities
+
+        #region Observer Events
+
         /// <summary>
         /// Raise the event that a <see cref="IMixedRealitySpatialObserverDataProvider"/> has been detected.
         /// </summary>
@@ -68,6 +74,14 @@ namespace XRTK.Interfaces.SpatialAwarenessSystem
         /// Raise the event that a <see cref="IMixedRealitySpatialObserverDataProvider"/> has been lost.
         /// </summary>
         void RaiseSpatialAwarenessObserverLost(IMixedRealitySpatialObserverDataProvider observer);
+
+        #endregion Observer Events
+
+        /// <summary>
+        /// Sets the provided mesh <see cref="SpatialMeshDisplayOptions"/> on all the <see cref="DetectedSpatialObservers"/>
+        /// </summary>
+        /// <param name="displayOptions"></param>
+        void SetMeshVisibility(SpatialMeshDisplayOptions displayOptions);
 
         #region Mesh Events
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -10,6 +10,7 @@ using XRTK.EventDatum.SpatialAwarenessSystem;
 using XRTK.Interfaces.Providers.SpatialObservers;
 using XRTK.Interfaces.SpatialAwarenessSystem;
 using XRTK.Interfaces.SpatialAwarenessSystem.Handlers;
+using XRTK.Providers.SpatialObservers;
 
 namespace XRTK.Services.SpatialAwarenessSystem
 {
@@ -135,6 +136,18 @@ namespace XRTK.Services.SpatialAwarenessSystem
         public void RaiseSpatialAwarenessObserverLost(IMixedRealitySpatialObserverDataProvider observer)
         {
             DetectedSpatialObservers.Remove(observer);
+        }
+
+        /// <inheritdoc />
+        public void SetMeshVisibility(SpatialMeshDisplayOptions displayOptions)
+        {
+            foreach (var observer in DetectedSpatialObservers)
+            {
+                if (observer is BaseMixedRealitySpatialMeshObserver meshObserver)
+                {
+                    meshObserver.MeshDisplayOption = displayOptions;
+                }
+            }
         }
 
         #endregion IMixedRealitySpatialAwarenessSystem Implementation


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Adds a convince method to the `SpatialAwarenessSystem` to change the mesh visibility for all spatial observers.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)
