### PR TITLE
Ensure we set the scene in the build settings if no scenes are available

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityPreferences.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityPreferences.cs
@@ -398,20 +398,42 @@ namespace XRTK.Inspectors
 
         private static SceneAsset GetSceneObject(string sceneName, SceneAsset asset = null)
         {
-            if (string.IsNullOrEmpty(sceneName) || EditorBuildSettings.scenes == null || EditorBuildSettings.scenes.Length < 1)
+            if (string.IsNullOrEmpty(sceneName) ||
+                EditorBuildSettings.scenes == null)
             {
                 return null;
             }
 
             EditorBuildSettingsScene editorScene = null;
 
-            try
+            if (EditorBuildSettings.scenes.Length < 1f)
             {
-                editorScene = EditorBuildSettings.scenes.First(scene => scene.path.IndexOf(sceneName, StringComparison.Ordinal) != -1);
+                if (asset == null)
+                {
+                    Debug.Log($"{sceneName} scene not found in build settings!");
+                    return null;
+                }
+
+                editorScene = new EditorBuildSettingsScene
+                {
+                    path = AssetDatabase.GetAssetOrScenePath(asset),
+                };
+
+                editorScene.guid = new GUID(AssetDatabase.AssetPathToGUID(editorScene.path));
+
+                EditorBuildSettings.scenes = new[] { editorScene };
             }
-            catch
+            else
             {
-                // ignored
+
+                try
+                {
+                    editorScene = EditorBuildSettings.scenes.First(scene => scene.path.IndexOf(sceneName, StringComparison.Ordinal) != -1);
+                }
+                catch
+                {
+                    // ignored
+                }
             }
 
             if (editorScene != null)

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityPreferences.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityPreferences.cs
@@ -406,7 +406,7 @@ namespace XRTK.Inspectors
 
             EditorBuildSettingsScene editorScene = null;
 
-            if (EditorBuildSettings.scenes.Length < 1f)
+            if (EditorBuildSettings.scenes.Length < 1)
             {
                 if (asset == null)
                 {


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

When no scenes are in the editor build settings the preferences window wasn't allowing me to set the scene I wanted in the XRTK start scene object inspector. This PR should fix this if no scenes are present.

This PR may also fix #174 but needs to be tested.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)