### PR TITLE
Platforms cleanup

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/PlatformUtility.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/PlatformUtility.cs
@@ -100,9 +100,7 @@ namespace XRTK.Utilities
                 case UnityEditor.BuildTarget.StandaloneOSX:
                     supportedPlatforms |= SupportedPlatforms.MacStandalone;
                     break;
-                case UnityEditor.BuildTarget.StandaloneLinux:
                 case UnityEditor.BuildTarget.StandaloneLinux64:
-                case UnityEditor.BuildTarget.StandaloneLinuxUniversal:
                     supportedPlatforms |= SupportedPlatforms.LinuxStandalone;
                     break;
                 case UnityEditor.BuildTarget.Lumin:


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Removed:

* StandaloneLinux
* StandaloneLinuxUniversal

Platforms as they have been deprecated in 2019.2.  StandaloneLinux64 remains for Linux systems

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)
- Platform (new or updated platform)

## Changes:

Brief list of the targeted features that are being changed.

- Resolves: #268