### PR TITLE
Add simple camera controls when running in editor to camera system

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityCameraProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityCameraProfile.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
+using XRTK.Definitions.Devices;
 using XRTK.Definitions.Utilities;
 
 namespace XRTK.Definitions
@@ -98,5 +99,76 @@ namespace XRTK.Definitions
         /// Set the desired quality for your application for transparent display.
         /// </summary>
         public int TransparentQualityLevel => transparentQualityLevel;
+
+        #region Editor Camera Controls
+
+        [SerializeField]
+        [Tooltip("Enable manual camera control")]
+        private bool isCameraControlEnabled = true;
+        public bool IsCameraControlEnabled => isCameraControlEnabled;
+
+        [SerializeField]
+        private float extraMouseSensitivityScale = 3.0f;
+        public float ExtraMouseSensitivityScale => extraMouseSensitivityScale;
+        [SerializeField]
+        private float defaultMouseSensitivity = 0.1f;
+        public float DefaultMouseSensitivity => defaultMouseSensitivity;
+
+        [SerializeField]
+        [Tooltip("Controls how mouse look control is activated.")]
+        private EditorCameraControlMouseButton mouseLookButton = EditorCameraControlMouseButton.Right;
+        public EditorCameraControlMouseButton MouseLookButton => mouseLookButton;
+        [SerializeField]
+        private bool isControllerLookInverted = true;
+        public bool IsControllerLookInverted => isControllerLookInverted;
+
+        [SerializeField]
+        private EditorCameraControlMode currentControlMode = EditorCameraControlMode.Fly;
+        public EditorCameraControlMode CurrentControlMode => currentControlMode;
+        [SerializeField]
+        private KeyCode fastControlKey = KeyCode.RightControl;
+        public KeyCode FastControlKey => fastControlKey;
+        [SerializeField]
+        private float controlSlowSpeed = 0.1f;
+        public float ControlSlowSpeed => controlSlowSpeed;
+        [SerializeField]
+        private float controlFastSpeed = 1.0f;
+        public float ControlFastSpeed => controlFastSpeed;
+
+        // Input axes  to coordinate with the Input Manager (Project Settings -> Input)
+
+        // Horizontal movement string for keyboard and left stick of game controller
+        [SerializeField]
+        [Tooltip("Horizontal movement Axis ")]
+        private string moveHorizontal = "Horizontal";
+        public string MoveHorizontal => moveHorizontal;
+        // Vertical movement string for keyboard and left stick of game controller 
+        [SerializeField]
+        [Tooltip("Vertical movement Axis ")]
+        private string moveVertical = "Vertical";
+        public string MoveVertical => moveVertical;
+        // Mouse movement string for the x-axis
+        [SerializeField]
+        [Tooltip("Mouse Movement X-axis")]
+        private string mouseX = "Mouse X";
+        public string MouseX => mouseX;
+        // Mouse movement string for the y-axis
+        [SerializeField]
+        [Tooltip("Mouse Movement Y-axis")]
+        private string mouseY = "Mouse Y";
+        public string MouseY => mouseY;
+        // Look horizontal string for right stick of game controller
+        // The right stick has no default settings in the Input Manager and will need to be setup for a game controller to look
+        [SerializeField]
+        [Tooltip("Look Horizontal Axis - Right Stick On Controller")]
+        private string lookHorizontal = ControllerMappingLibrary.AXIS_4;
+        public string LookHorizontal => lookHorizontal;
+        // Look vertical string for right stick of game controller
+        [SerializeField]
+        [Tooltip("Look Vertical Axis - Right Stick On Controller ")]
+        private string lookVertical = ControllerMappingLibrary.AXIS_5;
+        public string LookVertical => lookVertical;
+
+        #endregion
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/EditorCameraControlMode.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/EditorCameraControlMode.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace XRTK.Definitions.Utilities
+{
+    public enum EditorCameraControlMode
+    {
+        // Move in the main camera forward direction
+        Fly,
+        // Move on a X/Z plane
+        Walk,
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/EditorCameraControlMode.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/EditorCameraControlMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6a7ca489070ec346a7272240de463e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/EditorCameraControlMouseButton.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/EditorCameraControlMouseButton.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace XRTK.Definitions.Utilities
+{
+    /// <summary>
+    /// This enum is used to customize how/when users will look around in the Unity player
+    /// using the mouse.
+    /// </summary>
+    public enum EditorCameraControlMouseButton
+    {
+        Left,       // Left mouse button
+        Right,      // Right mouse button
+        Middle,     // Middle or scroll wheel button
+        Control,    // Control on keyboard
+        Shift,      // Shift on keyboard
+        Focused,    // When Unity player has focus
+        None        // No mouse look functionality
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/EditorCameraControlMouseButton.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/EditorCameraControlMouseButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e18ea6f8f5f471a4a80af1af25700d24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -25,6 +25,22 @@ namespace XRTK.Inspectors.Profiles
         private readonly GUIContent nearClipTitle = new GUIContent("Near Clip");
         private readonly GUIContent clearFlagsTitle = new GUIContent("Clear Flags");
 
+        private SerializedProperty isCameraControlEnabled;
+        private SerializedProperty extraMouseSensitivityScale;
+        private SerializedProperty defaultMouseSensitivity;
+        private SerializedProperty mouseLookButton;
+        private SerializedProperty isControllerLookInverted;
+        private SerializedProperty currentControlMode;
+        private SerializedProperty fastControlKey;
+        private SerializedProperty controlSlowSpeed;
+        private SerializedProperty controlFastSpeed;
+        private SerializedProperty moveHorizontal;
+        private SerializedProperty moveVertical;
+        private SerializedProperty mouseX;
+        private SerializedProperty mouseY;
+        private SerializedProperty lookHorizontal;
+        private SerializedProperty lookVertical;
+
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -39,6 +55,22 @@ namespace XRTK.Inspectors.Profiles
             transparentClearFlags = serializedObject.FindProperty("cameraClearFlagsTransparentDisplay");
             transparentBackgroundColor = serializedObject.FindProperty("backgroundColorTransparentDisplay");
             transparentQualityLevel = serializedObject.FindProperty("transparentQualityLevel");
+
+            isCameraControlEnabled = serializedObject.FindProperty("isCameraControlEnabled");
+            extraMouseSensitivityScale = serializedObject.FindProperty("extraMouseSensitivityScale");
+            defaultMouseSensitivity = serializedObject.FindProperty("defaultMouseSensitivity");
+            mouseLookButton = serializedObject.FindProperty("mouseLookButton");
+            isControllerLookInverted = serializedObject.FindProperty("isControllerLookInverted");
+            currentControlMode = serializedObject.FindProperty("currentControlMode");
+            fastControlKey = serializedObject.FindProperty("fastControlKey");
+            controlSlowSpeed = serializedObject.FindProperty("controlSlowSpeed");
+            controlFastSpeed = serializedObject.FindProperty("controlFastSpeed");
+            moveHorizontal = serializedObject.FindProperty("moveHorizontal");
+            moveVertical = serializedObject.FindProperty("moveVertical");
+            mouseX = serializedObject.FindProperty("mouseX");
+            mouseY = serializedObject.FindProperty("mouseY");
+            lookHorizontal = serializedObject.FindProperty("lookHorizontal");
+            lookVertical = serializedObject.FindProperty("lookVertical");
         }
 
         public override void OnInspectorGUI()
@@ -86,6 +118,31 @@ namespace XRTK.Inspectors.Profiles
             }
 
             transparentQualityLevel.intValue = EditorGUILayout.Popup("Quality Setting", transparentQualityLevel.intValue, QualitySettings.names);
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Editor Controls Settings:", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(isCameraControlEnabled);
+            {
+                EditorGUILayout.BeginVertical("Label");
+
+                EditorGUILayout.PropertyField(extraMouseSensitivityScale);
+                EditorGUILayout.PropertyField(defaultMouseSensitivity);
+                EditorGUILayout.PropertyField(mouseLookButton);
+                EditorGUILayout.PropertyField(isControllerLookInverted);
+                EditorGUILayout.PropertyField(currentControlMode);
+                EditorGUILayout.PropertyField(fastControlKey);
+                EditorGUILayout.PropertyField(controlSlowSpeed);
+                EditorGUILayout.PropertyField(controlFastSpeed);
+                EditorGUILayout.PropertyField(moveHorizontal);
+                EditorGUILayout.PropertyField(moveVertical);
+                EditorGUILayout.PropertyField(mouseX);
+                EditorGUILayout.PropertyField(mouseY);
+                EditorGUILayout.PropertyField(lookHorizontal);
+                EditorGUILayout.PropertyField(lookVertical);
+
+                EditorGUILayout.EndVertical();
+
+            }
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/Providers/InputSystem.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/Providers/InputSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5126a296582a91448ec660a17b92287
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/CameraEditorControls.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/CameraEditorControls.cs
@@ -1,0 +1,291 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+using XRTK.Definitions;
+using XRTK.Definitions.Utilities;
+using XRTK.Utilities;
+
+namespace XRTK.Services.CameraSystem
+{
+    public class CameraEditorControls
+    {
+        private MixedRealityCameraProfile profile;
+        private bool isMouseJumping = false;
+        private bool isGamepadLookEnabled = true;
+        private bool isFlyKeypressEnabled = true;
+        private Vector3 lastMousePosition = Vector3.zero;
+        private Vector3 lastTrackerToUnityTranslation = Vector3.zero;
+        private Quaternion lastTrackerToUnityRotation = Quaternion.identity;
+        private bool wasLooking = false;
+        private bool wasCursorVisible = true;
+
+        public CameraEditorControls(MixedRealityCameraProfile profile)
+        {
+            this.profile = profile;
+        }
+
+        public void Update()
+        {
+            if (profile.IsCameraControlEnabled && CameraCache.Main)
+            {
+                UpdateTransform(CameraCache.Main.transform);
+            }
+        }
+
+        private static float InputCurve(float x)
+        {
+            // smoothing input curve, converts from [-1,1] to [-2,2]
+            return Mathf.Sign(x) * (1.0f - Mathf.Cos(0.5f * Mathf.PI * Mathf.Clamp(x, -1.0f, 1.0f)));
+        }
+
+        public void UpdateTransform(Transform transform)
+        {
+            // Undo the last tracker to Unity transforms applied
+            transform.Translate(-lastTrackerToUnityTranslation, Space.World);
+            transform.Rotate(-lastTrackerToUnityRotation.eulerAngles, Space.World);
+
+            // Calculate and apply the camera control movement this frame
+            Vector3 rotate = GetCameraControlRotation();
+            Vector3 translate = GetCameraControlTranslation(transform);
+
+            transform.Rotate(rotate.x, 0.0f, 0.0f);
+            transform.Rotate(0.0f, rotate.y, 0.0f, Space.World);
+            transform.Translate(translate, Space.World);
+
+            transform.Rotate(lastTrackerToUnityRotation.eulerAngles, Space.World);
+            transform.Translate(lastTrackerToUnityTranslation, Space.World);
+        }
+
+        private static float GetKeyDir(string neg, string pos)
+        {
+            return Input.GetKey(neg) ? -1.0f : Input.GetKey(pos) ? 1.0f : 0.0f;
+        }
+
+        private Vector3 GetCameraControlTranslation(Transform transform)
+        {
+            Vector3 deltaPosition = Vector3.zero;
+
+            // Support fly up/down keypresses if the current project maps it. This isn't a standard
+            // Unity InputManager mapping, so it has to gracefully fail if unavailable.
+            if (isFlyKeypressEnabled)
+            {
+                try
+                {
+                    deltaPosition += InputCurve(Input.GetAxis("Fly")) * transform.up;
+                }
+                catch (System.Exception)
+                {
+                    isFlyKeypressEnabled = false;
+                }
+            }
+            else
+            {
+                // use page up/down in this case
+                deltaPosition += GetKeyDir("page down", "page up") * Vector3.up;
+            }
+
+            deltaPosition += InputCurve(Input.GetAxis(profile.MoveHorizontal)) * transform.right;
+
+            if (profile.CurrentControlMode == EditorCameraControlMode.Walk)
+            {
+                deltaPosition += InputCurve(Input.GetAxis(profile.MoveVertical)) * new Vector3(transform.forward.x, 0, transform.forward.z).normalized;
+            }
+            else
+            {
+                deltaPosition += InputCurve(Input.GetAxis(profile.MoveVertical)) * transform.forward;
+            }
+
+            float accel = Input.GetKey(profile.FastControlKey) ? profile.ControlFastSpeed : profile.ControlSlowSpeed;
+            return accel * deltaPosition;
+        }
+
+        private Vector3 GetCameraControlRotation()
+        {
+            float inversionFactor = profile.IsControllerLookInverted ? -1.0f : 1.0f;
+
+            Vector3 rot = Vector3.zero;
+
+            if (isGamepadLookEnabled)
+            {
+                try
+                {
+                    // Get the axes information from the right stick of X360 controller
+                    rot.x += InputCurve(Input.GetAxis(profile.LookVertical)) * inversionFactor;
+                    rot.y += InputCurve(Input.GetAxis(profile.LookHorizontal));
+                }
+                catch (System.Exception)
+                {
+                    isGamepadLookEnabled = false;
+                }
+            }
+
+            if (ShouldMouseLook)
+            {
+                if (!wasLooking)
+                {
+                    OnStartMouseLook();
+                }
+
+                ManualCameraControl_MouseLookTick(ref rot);
+
+                wasLooking = true;
+            }
+            else
+            {
+                if (wasLooking)
+                {
+                    OnEndMouseLook();
+                }
+
+                wasLooking = false;
+            }
+
+            rot *= profile.ExtraMouseSensitivityScale;
+
+            return rot;
+        }
+
+        private void OnStartMouseLook()
+        {
+            if (profile.MouseLookButton <= EditorCameraControlMouseButton.Middle)
+            {
+                // if mousebutton is either left, right or middle
+                SetWantsMouseJumping(true);
+            }
+            else if (profile.MouseLookButton <= EditorCameraControlMouseButton.Focused)
+            {
+                // if mousebutton is either control, shift or focused
+                Cursor.lockState = CursorLockMode.Locked;
+                // save current cursor visibility before hiding it
+                wasCursorVisible = Cursor.visible;
+                Cursor.visible = false;
+            }
+
+            // do nothing if (this.MouseLookButton == MouseButton.None)
+        }
+
+        private void OnEndMouseLook()
+        {
+            if (profile.MouseLookButton <= EditorCameraControlMouseButton.Middle)
+            {
+                // if mousebutton is either left, right or middle
+                SetWantsMouseJumping(false);
+            }
+            else if (profile.MouseLookButton <= EditorCameraControlMouseButton.Focused)
+            {
+                // if mousebutton is either control, shift or focused
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = wasCursorVisible;
+            }
+
+            // do nothing if (this.MouseLookButton == MouseButton.None)
+        }
+
+        private void ManualCameraControl_MouseLookTick(ref Vector3 rot)
+        {
+            // Use frame-to-frame mouse delta in pixels to determine mouse rotation. The traditional
+            // GetAxis("Mouse X") method doesn't work under Remote Desktop.
+            Vector3 mousePositionDelta = Input.mousePosition - lastMousePosition;
+            lastMousePosition = Input.mousePosition;
+
+            if (Cursor.lockState == CursorLockMode.Locked)
+            {
+                mousePositionDelta.x = Input.GetAxis(profile.MouseX);
+                mousePositionDelta.y = Input.GetAxis(profile.MouseY);
+            }
+            else
+            {
+                mousePositionDelta.x *= profile.DefaultMouseSensitivity;
+                mousePositionDelta.y *= profile.DefaultMouseSensitivity;
+            }
+
+            rot.x += -InputCurve(mousePositionDelta.y);
+            rot.y += InputCurve(mousePositionDelta.x);
+        }
+
+        private bool ShouldMouseLook
+        {
+            get
+            {
+                // Only allow the mouse to control rotation when Unity has focus. This enables
+                // the player to temporarily alt-tab away without having the player look around randomly
+                // back in the Unity Game window.
+                if (!Application.isFocused)
+                {
+                    return false;
+                }
+                else if (profile.MouseLookButton == EditorCameraControlMouseButton.None)
+                {
+                    return true;
+                }
+                else if (profile.MouseLookButton <= EditorCameraControlMouseButton.Middle)
+                {
+                    return Input.GetMouseButton((int)profile.MouseLookButton);
+                }
+                else if (profile.MouseLookButton == EditorCameraControlMouseButton.Control)
+                {
+                    return Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+                }
+                else if (profile.MouseLookButton == EditorCameraControlMouseButton.Shift)
+                {
+                    return Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+                }
+                else if (profile.MouseLookButton == EditorCameraControlMouseButton.Focused)
+                {
+                    if (!wasLooking)
+                    {
+                        // any kind of click will capture focus
+                        return Input.GetMouseButtonDown((int)EditorCameraControlMouseButton.Left) || Input.GetMouseButtonDown((int)EditorCameraControlMouseButton.Right) || Input.GetMouseButtonDown((int)EditorCameraControlMouseButton.Middle);
+                    }
+                    else
+                    {
+                        // pressing escape will stop capture
+                        return !Input.GetKeyDown(KeyCode.Escape);
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Mouse jumping is where the mouse cursor appears outside the Unity game window, but
+        /// disappears when it enters the Unity game window.
+        /// </summary>
+        /// <param name="wantsJumping">Show the cursor</param>
+        private void SetWantsMouseJumping(bool wantsJumping)
+        {
+            if (wantsJumping != isMouseJumping)
+            {
+                isMouseJumping = wantsJumping;
+
+                if (wantsJumping)
+                {
+                    // unlock the cursor if it was locked
+                    Cursor.lockState = CursorLockMode.None;
+
+                    // save original state of cursor before hiding
+                    wasCursorVisible = Cursor.visible;
+                    // hide the cursor
+                    Cursor.visible = false;
+
+                    lastMousePosition = Input.mousePosition;
+                }
+                else
+                {
+                    // recenter the cursor (setting lockCursor has side-effects under the hood)
+                    Cursor.lockState = CursorLockMode.Locked;
+                    Cursor.lockState = CursorLockMode.None;
+
+                    // restore the cursor
+                    Cursor.visible = wasCursorVisible;
+                }
+
+#if UNITY_EDITOR
+                UnityEditor.EditorGUIUtility.SetWantsMouseJumping(wantsJumping ? 1 : 0);
+#endif
+            }
+        }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/CameraEditorControls.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/CameraEditorControls.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2357139a2537934488caf8762931b3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -11,6 +11,8 @@ namespace XRTK.Services.CameraSystem
 {
     public class MixedRealityCameraSystem : BaseSystem, IMixedRealityCameraSystem
     {
+        private CameraEditorControls editorControls;
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -53,6 +55,11 @@ namespace XRTK.Services.CameraSystem
         /// <inheritdoc />
         public override void Initialize()
         {
+            if (Application.isEditor && profile.IsCameraControlEnabled)
+            {
+                editorControls = new CameraEditorControls(profile);
+            }
+
             cameraOpaqueLastFrame = IsOpaque;
 
             if (IsOpaque)
@@ -67,7 +74,7 @@ namespace XRTK.Services.CameraSystem
 
         public override void Enable()
         {
-            if (Application.isPlaying && 
+            if (Application.isPlaying &&
                 profile.IsCameraPersistent)
             {
                 CameraCache.Main.transform.root.DontDestroyOnLoad();
@@ -77,6 +84,11 @@ namespace XRTK.Services.CameraSystem
         /// <inheritdoc />
         public override void Update()
         {
+            if (Application.isEditor && profile.IsCameraControlEnabled)
+            {
+                editorControls.Update();
+            }
+
             if (IsOpaque != cameraOpaqueLastFrame)
             {
                 cameraOpaqueLastFrame = IsOpaque;


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

This PR will add simple camera control options to the camera system profile, when running in editor. It allows to move the camera rig in the scene using keyboard and mouse. Direct port of MRTK's camera controls for the Unity Editor with minor adjustments.

## Target of the change:

Is this enhancement for:

- Core

## Changes:

Brief list of the targeted features that are being changed.

- Adds camera editor controls configuration options to the camera system profile.

## Breaking Changes:

- None
