### PR TITLE
Fixed a warning during first start

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityPackageSettings.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityPackageSettings.cs
@@ -33,7 +33,11 @@ namespace XRTK.Definitions
 #if UNITY_EDITOR
                 UnityEditor.EditorUtility.SetDirty(this);
                 UnityEditor.AssetDatabase.SaveAssets();
-                UnityEditor.AssetDatabase.Refresh(UnityEditor.ImportAssetOptions.ForceUpdate);
+
+                if (!UnityEditor.EditorApplication.isUpdating)
+                {
+                    UnityEditor.AssetDatabase.Refresh(UnityEditor.ImportAssetOptions.ForceUpdate);
+                }
 #endif
             }
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Editor/MixedRealityEditorSettings.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Editor/MixedRealityEditorSettings.cs
@@ -172,7 +172,11 @@ namespace XRTK.Utilities.Editor
             if (refresh || restart)
             {
                 AssetDatabase.SaveAssets();
-                AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
+
+                if (!EditorApplication.isUpdating)
+                {
+                    AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
+                }
             }
 
             if (restart)


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Fixed a warning when forcing the asset database to refresh during reload. This may or may not fix the first time startup crash we're seeing but worth a test.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

Brief list of the targeted features that are being changed.

- Fixes: Don't force refresh of asset database during startup, per warning from Unity Editor.
