### PR TITLE
Popup the xrtk packages window on new session

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityPackageInfo.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityPackageInfo.cs
@@ -26,7 +26,7 @@ namespace XRTK.Definitions
             this.uri = uri;
             this.isRequiredPackage = isRequiredPackage;
             isDefaultPackage = true;
-            isEnabled = true;
+            isEnabled = false;
         }
 
         [SerializeField]

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Packages/MixedRealityPackagesWindow.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Packages/MixedRealityPackagesWindow.cs
@@ -10,12 +10,24 @@ using XRTK.Utilities.Editor;
 
 namespace XRTK.Inspectors.Utilities.Packages
 {
+    [InitializeOnLoad]
     public class MixedRealityPackagesWindow : EditorWindow
     {
         private static MixedRealityPackagesWindow window;
         private static Tuple<MixedRealityPackageInfo, bool>[] packages;
         private static bool[] isPackageEnabled;
         private static bool isError;
+
+        /// <summary>
+        /// <see cref="InitializeOnLoadAttribute"/>
+        /// </summary>
+        static MixedRealityPackagesWindow()
+        {
+            if (!SessionState.GetBool(MixedRealityEditorSettings.SessionKey, true))
+            {
+                OpenPackagesWindow();
+            }
+        }
 
         [MenuItem("Mixed Reality Toolkit/Packages...", true, 99)]
         static bool OpenPackagesWindowValidation()

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Packages/MixedRealityPackagesWindow.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Packages/MixedRealityPackagesWindow.cs
@@ -23,7 +23,7 @@ namespace XRTK.Inspectors.Utilities.Packages
         /// </summary>
         static MixedRealityPackagesWindow()
         {
-            if (!SessionState.GetBool(MixedRealityEditorSettings.SessionKey, true))
+            if (!MixedRealityEditorSettings.IsFirstSession)
             {
                 OpenPackagesWindow();
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Editor/MixedRealityEditorSettings.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Editor/MixedRealityEditorSettings.cs
@@ -17,7 +17,7 @@ namespace XRTK.Utilities.Editor
     public class MixedRealityEditorSettings : IActiveBuildTargetChanged
     {
         private const string IgnoreKey = "_MixedRealityToolkit_Editor_IgnoreSettingsPrompts";
-        private const string SessionKey = "_MixedRealityToolkit_Editor_ShownSettingsPrompts";
+        public const string SessionKey = "_MixedRealityToolkit_Editor_ShownSettingsPrompts";
 
         private static string Project_AbsolutePath
         {

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Editor/MixedRealityEditorSettings.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Editor/MixedRealityEditorSettings.cs
@@ -17,7 +17,12 @@ namespace XRTK.Utilities.Editor
     public class MixedRealityEditorSettings : IActiveBuildTargetChanged
     {
         private const string IgnoreKey = "_MixedRealityToolkit_Editor_IgnoreSettingsPrompts";
-        public const string SessionKey = "_MixedRealityToolkit_Editor_ShownSettingsPrompts";
+        private const string SessionKey = "_MixedRealityToolkit_Editor_ShownSettingsPrompts";
+
+        /// <summary>
+        /// Is this the first session of the xrtk?
+        /// </summary>
+        public static bool IsFirstSession => SessionState.GetBool(SessionKey, true);
 
         private static string Project_AbsolutePath
         {
@@ -80,7 +85,7 @@ namespace XRTK.Utilities.Editor
         {
             if (Application.isPlaying ||
                 EditorPrefs.GetBool(IgnoreKey, false) ||
-                !SessionState.GetBool(SessionKey, true))
+                !IsFirstSession)
             {
                 return;
             }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

1. Disables all of the packages and only imports the git extension upm package, as it's required.
2. Pops open the package window when a new session is detected.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)
- Platform (new or updated platform)
- Extension
- Component ported from another framework

## Changes:

Brief list of the targeted features that are being changed.

- Fixes: https://github.com/XRTK/XRTK-Core/issues/173
