### PR TITLE
Fix to resolve Git Tag sorting issue #300

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Packages/MixedRealityPackageUtilities.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Packages/MixedRealityPackageUtilities.cs
@@ -209,6 +209,7 @@ namespace XRTK.Inspectors.Utilities.Packages
 
         private static async Task AddPackageAsync(MixedRealityPackageInfo packageInfo)
         {
+            var versionSeperator = new char[] { '.' };
             var tag = (await GitUtilities.GetAllTagsFromRemoteAsync(packageInfo.Uri)).OrderBy(value => int.Parse(value.Split(versionSeperator)[0])).ThenBy(value => int.Parse(value.Split(versionSeperator)[1])).ThenBy(value => int.Parse(value.Split(versionSeperator)[2])).LastOrDefault();
             var addRequest = Client.Add($"{packageInfo.Name}@{packageInfo.Uri}#{tag}");
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Packages/MixedRealityPackageUtilities.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Packages/MixedRealityPackageUtilities.cs
@@ -209,7 +209,7 @@ namespace XRTK.Inspectors.Utilities.Packages
 
         private static async Task AddPackageAsync(MixedRealityPackageInfo packageInfo)
         {
-            var tag = (await GitUtilities.GetAllTagsFromRemoteAsync(packageInfo.Uri)).LastOrDefault();
+            var tag = (await GitUtilities.GetAllTagsFromRemoteAsync(packageInfo.Uri)).OrderBy(value => int.Parse(value.Split(versionSeperator)[0])).ThenBy(value => int.Parse(value.Split(versionSeperator)[1])).ThenBy(value => int.Parse(value.Split(versionSeperator)[2])).LastOrDefault();
             var addRequest = Client.Add($"{packageInfo.Name}@{packageInfo.Uri}#{tag}");
 
             await addRequest.WaitUntil(request => request.IsCompleted, timeout: 30);


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

fix to resolve #300, properly sorts the tag versions returned by Git based on a 3 digit version code.  Select the actual latest version based on:

x.x.x version number

Previously, last was determined by the double value parsed value, which is incorrectly sorted by .NET.  Now sorts by each individual version identifier to locate the latest.
## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

Updates Git Tag version sort to sort by each individual version identifier

- Fixes: #300
