### PR TITLE
Dev/editor platform flag

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Devices/MixedRealityInteractionMapping.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Devices/MixedRealityInteractionMapping.cs
@@ -591,6 +591,5 @@ namespace XRTK.Definitions.Devices
         }
 
         #endregion Data Properties
-
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/SupportedPlatforms.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/SupportedPlatforms.cs
@@ -11,12 +11,37 @@ namespace XRTK.Definitions.Utilities
     [Flags]
     public enum SupportedPlatforms
     {
-        WindowsStandalone = 1 << 0,
-        MacStandalone = 1 << 1,
-        LinuxStandalone = 1 << 2,
-        WindowsUniversal = 1 << 3,
-        Lumin = 1 << 4,
-        Android = 1 << 5,
-        iOS = 1 << 6
+        /// <summary>
+        /// Editor.
+        /// </summary>
+        Editor = 1 << 0,
+        /// <summary>
+        /// Windows Standalone platforms.
+        /// </summary>
+        WindowsStandalone = 1 << 1,
+        /// <summary>
+        /// Mac OSX standalone platforms.
+        /// </summary>
+        MacStandalone = 1 << 2,
+        /// <summary>
+        /// Linux standalone platforms.
+        /// </summary>
+        LinuxStandalone = 1 << 3,
+        /// <summary>
+        /// Windows UWP platforms.
+        /// </summary>
+        WindowsUniversal = 1 << 4,
+        /// <summary>
+        /// Magic Leap platform.
+        /// </summary>
+        Lumin = 1 << 5,
+        /// <summary>
+        /// Android mobile platforms
+        /// </summary>
+        Android = 1 << 6,
+        /// <summary>
+        /// Mac iOS mobile platforms.
+        /// </summary>
+        iOS = 1 << 7
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseController.cs
@@ -213,11 +213,10 @@ namespace XRTK.Providers.Controllers
 
             if (!visualizationProfile.RenderMotionControllers) { return; }
 
-            GameObject controllerModel = null;
             GltfObject gltfObject = null;
 
             // If a specific controller template exists, check if it wants to override the global model, or use the system default specifically (in case global default is not used)
-            bool useSystemDefaultModels = visualizationProfile.GetControllerModelOverride(controllerType, ControllerHandedness, out controllerModel);
+            bool useSystemDefaultModels = visualizationProfile.GetControllerModelOverride(controllerType, ControllerHandedness, out var controllerModel);
 
             // If an override is not configured for defaults and has no model, then use the system default check
             if (!useSystemDefaultModels && controllerModel == null)

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/PlatformUtility.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/PlatformUtility.cs
@@ -79,7 +79,7 @@ namespace XRTK.Utilities
 
         private static SupportedPlatforms GetSupportedPlatformMask(UnityEditor.BuildTarget editorBuildTarget)
         {
-            SupportedPlatforms supportedPlatforms = 0;
+            var supportedPlatforms = SupportedPlatforms.Editor;
 
             switch (editorBuildTarget)
             {


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Added editor platform flag to the supported platform enum to specify editor only services

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Breaking Changes:

Are there any breaking changes included in this change that would prevent or cause issue for existing projects.

- Breaks: All existing data provider profiles. All profiles will need to add the `Editor` flag to run in the editor by default, and update their platforms.
