### PR TITLE
Fixed the ambiguous interaction mapping constructors

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Devices/MixedRealityInteractionMapping.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Devices/MixedRealityInteractionMapping.cs
@@ -91,7 +91,7 @@ namespace XRTK.Definitions.Devices
         /// <param name="axisType">The axis that the mapping operates on, also denotes the data type for the mapping</param>
         /// <param name="inputType">The physical input device / control</param>
         /// <param name="inputName">Optional inputName value to get input for a coded input identity from a provider</param>
-        public MixedRealityInteractionMapping(uint id, string description, AxisType axisType, DeviceInputType inputType, string inputName)
+        public MixedRealityInteractionMapping(uint id, string description, AxisType axisType, string inputName, DeviceInputType inputType)
         {
             this.id = id;
             this.description = description;
@@ -165,7 +165,7 @@ namespace XRTK.Definitions.Devices
         /// <param name="axisCodeY">Optional vertical axis value to get axis data from Unity's old input system.</param>
         /// <param name="invertXAxis">Optional horizontal axis invert option.</param>
         /// <param name="invertYAxis">Optional vertical axis invert option.</param> 
-        public MixedRealityInteractionMapping(uint id, string description, AxisType axisType, DeviceInputType inputType, MixedRealityInputAction inputAction, string inputName, string axisCodeX = "", string axisCodeY = "", bool invertXAxis = false, bool invertYAxis = false)
+        public MixedRealityInteractionMapping(uint id, string description, AxisType axisType, DeviceInputType inputType, string inputName, MixedRealityInputAction inputAction, string axisCodeX = "", string axisCodeY = "", bool invertXAxis = false, bool invertYAxis = false)
         {
             this.id = id;
             this.description = description;
@@ -189,6 +189,10 @@ namespace XRTK.Definitions.Devices
             keyCode = KeyCode.None;
         }
 
+        /// <summary>
+        /// Creates a copy of a <see cref="MixedRealityGestureMapping"/>
+        /// </summary>
+        /// <param name="mixedRealityInteractionMapping"></param>
         public MixedRealityInteractionMapping(MixedRealityInteractionMapping mixedRealityInteractionMapping)
         {
             id = mixedRealityInteractionMapping.id;

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/GenericJoystickController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/GenericJoystickController.cs
@@ -89,6 +89,7 @@ namespace XRTK.Providers.Controllers.UnityInput
             switch (interactionMapping.InputType)
             {
                 case DeviceInputType.TriggerPress:
+                    Debug.Assert(!string.IsNullOrEmpty(interactionMapping.AxisCodeX), $"[{interactionMapping.Description}] Axis mapping does not have an Axis defined");
                     interactionMapping.BoolData = Input.GetAxisRaw(interactionMapping.AxisCodeX).Equals(1);
                     break;
                 case DeviceInputType.TriggerNearTouch:
@@ -97,6 +98,7 @@ namespace XRTK.Providers.Controllers.UnityInput
                 case DeviceInputType.MiddleFingerNearTouch:
                 case DeviceInputType.RingFingerNearTouch:
                 case DeviceInputType.PinkyFingerNearTouch:
+                    Debug.Assert(!string.IsNullOrEmpty(interactionMapping.AxisCodeX), $"[{interactionMapping.Description}] Axis mapping does not have an Axis defined");
                     interactionMapping.BoolData = !Input.GetAxisRaw(interactionMapping.AxisCodeX).Equals(0);
                     break;
                 default:
@@ -135,6 +137,7 @@ namespace XRTK.Providers.Controllers.UnityInput
         protected void UpdateSingleAxisData(MixedRealityInteractionMapping interactionMapping)
         {
             Debug.Assert(interactionMapping.AxisType == AxisType.SingleAxis);
+            Debug.Assert(!string.IsNullOrEmpty(interactionMapping.AxisCodeX), $"[{interactionMapping.Description}] Single Axis mapping does not have an Axis defined");
 
             var singleAxisValue = Input.GetAxisRaw(interactionMapping.AxisCodeX);
 
@@ -178,6 +181,8 @@ namespace XRTK.Providers.Controllers.UnityInput
         protected void UpdateDualAxisData(MixedRealityInteractionMapping interactionMapping)
         {
             Debug.Assert(interactionMapping.AxisType == AxisType.DualAxis);
+            Debug.Assert(!string.IsNullOrEmpty(interactionMapping.AxisCodeX), $"[{interactionMapping.Description}] Dual Axis mapping does not have an Axis defined for X Axis");
+            Debug.Assert(!string.IsNullOrEmpty(interactionMapping.AxisCodeY), $"[{interactionMapping.Description}] Dual Axis mapping does not have an Axis defined for Y Axis");
 
             dualAxisPosition.x = Input.GetAxis(interactionMapping.AxisCodeX);
             dualAxisPosition.y = Input.GetAxis(interactionMapping.AxisCodeY);


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Fixed the ambiguous interaction mapping constructors.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

Brief list of the targeted features that are being changed.

- Fixes: #345 
- Fixes: #336
- Supersedes: #346 

## Breaking Changes:

- Update the `MixedRealityInteractonMapping` constructors but afaik the Oculus package is the only one taking advantage of it atm.