### PR TITLE
Should be able to use digital axis type when setting float data

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Devices/MixedRealityInteractionMapping.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Devices/MixedRealityInteractionMapping.cs
@@ -471,10 +471,10 @@ namespace XRTK.Definitions.Devices
 
             set
             {
-                if (AxisType != AxisType.SingleAxis)
+                if (AxisType != AxisType.Digital &&
+                    AxisType != AxisType.SingleAxis)
                 {
-                    Debug.LogError(
-                        $"SetFloatValue is only valid for AxisType.SingleAxis InteractionMappings\nPlease check the {inputType} mapping for the current controller");
+                    Debug.LogError($"SetFloatValue is only valid for AxisType.SingleAxis & AxisType.Digital InteractionMappings\nPlease check the {inputType} mapping for the current controller");
                 }
 
                 var newValue = value;


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Throwing errors for setting float data on digital axis. Part of the changes in #363

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

- Fixed error checking for axis type.