### PR TITLE
Updated Spatial Awareness Parent Object Transform to fix teleporting

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -40,7 +40,15 @@ namespace XRTK.Services.SpatialAwarenessSystem
         /// <returns>
         /// The <see cref="GameObject"/> to which spatial awareness created objects will be parented.
         /// </returns>
-        private GameObject CreateSpatialAwarenessParent => new GameObject("Spatial Awareness System");
+        private GameObject CreateSpatialAwarenessParent
+        {
+            get
+            {
+                var spatialAwarenessSystemObject = new GameObject("Spatial Awareness System");
+                spatialAwarenessSystemObject.transform.parent = MixedRealityToolkit.Instance.MixedRealityPlayspace;
+                return spatialAwarenessSystemObject;
+            }
+        }
 
         private GameObject meshParent = null;
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Parented the SpatialAwarenessParent under the playspace to ensure that the spatial mesh stays in the same place when teleporting

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

- Moved the Spatial Awareness system's root GameObject reference under the Playspace.
