### PR TITLE
Ensure we always start a service if only the editor flag is set

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/PlatformUtility.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/PlatformUtility.cs
@@ -85,16 +85,19 @@ namespace XRTK.Utilities
         {
             var isEditorSupported = IsEditorSupported(platforms);
 
-            if ((int)platforms == -1)
+            // If any platform set or if only the editor flag is set
+            if ((int)platforms == -1 || platforms == SupportedPlatforms.Editor)
             {
                 return true;
             }
 
-            if (!isEditorSupported || platforms == 0)
+            // If no platform set or if the editor is not supported
+            if (platforms == 0 || !isEditorSupported)
             {
                 return false;
             }
 
+            // If editor is supported and the current build target is enabled
             var target = GetSupportedPlatformMask(editorBuildTarget);
             return IsPlatformSupported(target, platforms);
         }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

There was one use case for the `PlatformUtility` flags that wasn't covered. Where we only want a service to run in the editor only on any platform.

| Figure | Editor | Rumtime |
|---|---|---|
| 1 | X | |
| 2 | X | X |
| 3 | | X |

1. This should **always** run in the editor regardless of the target build platform but never the build:![image](https://user-images.githubusercontent.com/13334553/65984542-ff65ff00-e44d-11e9-8871-a0c34ebbab82.png)

2. This should run in the editor && build if the build target **IS** enabled:![image](https://user-images.githubusercontent.com/13334553/65984558-08ef6700-e44e-11e9-836f-0b7895db785d.png)

3. This should **never** run in the editor and only runs on the build:![image](https://user-images.githubusercontent.com/13334553/65984700-4eac2f80-e44e-11e9-955b-bb311d15ef83.png)
