### PR TITLE
Dev/poco input events

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using XRTK.Definitions.Devices;
 using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.Utilities;
+using XRTK.EventDatum.Input;
 using XRTK.Interfaces.Providers.Controllers;
 using XRTK.Interfaces.Events;
 
@@ -121,6 +122,15 @@ namespace XRTK.Interfaces.InputSystem
         #endregion IMixedRealityController Utilities
 
         #region Input Events
+
+        /// <summary>
+        /// Raised when an input event is triggered.
+        /// </summary>
+        /// <remarks>
+        /// WARNING: This event should not be subscribed to by MonoBehaviours!
+        /// Use the InputHandler interfaces instead.
+        /// </remarks>
+        event Action<BaseInputEventData> OnInputEvent;
 
         #region Input Source Events
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
@@ -233,6 +233,11 @@ namespace XRTK.Services.InputSystem
                 return;
             }
 
+            // Sent the event to any POCO classes that have subscribed for events.
+            // WARNING: This event should not be subscribed to by MonoBehaviours!
+            // Use the InputHandler interfaces instead.
+            OnInputEvent?.Invoke(baseInputEventData);
+
             // Send the event to global listeners
             base.HandleEvent(eventData, eventHandler);
 
@@ -476,7 +481,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public bool TryGetController(IMixedRealityInputSource inputSource, out IMixedRealityController controller)
         {
-            foreach (IMixedRealityController mixedRealityController in DetectedControllers)
+            foreach (var mixedRealityController in DetectedControllers)
             {
                 if (inputSource.SourceId == mixedRealityController.InputSource.SourceId)
                 {
@@ -492,6 +497,9 @@ namespace XRTK.Services.InputSystem
         #endregion IMixedRealityController Utilities
 
         #region Input Events
+
+        /// <inheritdoc />
+        public event Action<BaseInputEventData> OnInputEvent;
 
         #region Input Source Events
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Several requests have been made to provide a way to consume input events in POCO classes and services. This gives a way to do that, but with some warnings:

- This should **NOT** be used in MonoBehaviour classes.
- Events cannot be consumed. `eventData.Used` would not apply here.
- There's no way to properly route events to subscribers in any specific order which may or may not cause race conditions in implementations that use it.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Breaking Changes:

Are there any breaking changes included in this change that would prevent or cause issue for existing projects.

- Added `Action<BaseInputEventData> OnInputEvent` to the `IMixedRealityInputSystem`