### PR TITLE
Dev/pointer dragging events

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerDragEventData.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerDragEventData.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+using UnityEngine.EventSystems;
+using XRTK.Definitions.InputSystem;
+using XRTK.Interfaces.InputSystem;
+
+namespace XRTK.EventDatum.Input
+{
+    /// <summary>
+    /// Describes a <see cref="MixedRealityPointerEventData"/> with dragging data.
+    /// </summary>
+    public class MixedRealityPointerDragEventData : MixedRealityPointerEventData
+    {
+        /// <summary>
+        /// The distance this pointer has been dragged since the last event was raised.
+        /// </summary>
+        public Vector3 DragDelta { get; private set; }
+
+        /// <inheritdoc />
+        public MixedRealityPointerDragEventData(EventSystem eventSystem) : base(eventSystem) { }
+
+        /// <summary>
+        /// Used to initialize/reset the event and populate the data.
+        /// </summary>
+        /// <param name="pointer"></param>
+        /// <param name="inputAction"></param>
+        /// <param name="dragDelta"></param>
+        /// <param name="inputSource"></param>
+        public void Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, Vector3 dragDelta, IMixedRealityInputSource inputSource = null)
+        {
+            Initialize(pointer, inputAction, inputSource);
+            DragDelta = dragDelta;
+        }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerDragEventData.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerDragEventData.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerDragEventData.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerDragEventData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2a5c9cae7847a64799949b831ce0e76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerEventData.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerEventData.cs
@@ -8,7 +8,7 @@ using XRTK.Interfaces.InputSystem;
 namespace XRTK.EventDatum.Input
 {
     /// <summary>
-    /// Describes an Input Event that involves a tap, click, or touch.
+    /// Describes a pointer event that involves a tap, click, or touch.
     /// </summary>
     public class MixedRealityPointerEventData : BaseInputEventData
     {
@@ -16,11 +16,6 @@ namespace XRTK.EventDatum.Input
         /// Pointer for the Input Event
         /// </summary>
         public IMixedRealityPointer Pointer { get; private set; }
-
-        /// <summary>
-        /// Number of Clicks, Taps, or Presses that triggered the event.
-        /// </summary>
-        public int Count { get; private set; }
 
         /// <inheritdoc />
         public MixedRealityPointerEventData(EventSystem eventSystem) : base(eventSystem) { }
@@ -31,12 +26,10 @@ namespace XRTK.EventDatum.Input
         /// <param name="pointer"></param>
         /// <param name="inputAction"></param>
         /// <param name="inputSource"></param>
-        /// <param name="count"></param>
-        public void Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null, int count = 0)
+        public void Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)
         {
             BaseInitialize(inputSource ?? pointer.InputSourceParent, inputAction);
             Pointer = pointer;
-            Count = count;
         }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerScrollEventData.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerScrollEventData.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+using UnityEngine.EventSystems;
+using XRTK.Definitions.InputSystem;
+using XRTK.Interfaces.InputSystem;
+
+namespace XRTK.EventDatum.Input
+{
+    /// <summary>
+    /// Describes a <see cref="MixedRealityPointerEventData"/> with scroll data.
+    /// </summary>
+    public class MixedRealityPointerScrollEventData : MixedRealityPointerEventData
+    {
+        /// <summary>
+        /// The distance this pointer has been scrolled since the last event was raised.
+        /// </summary>
+        public Vector2 ScrollDelta { get; private set; }
+
+        /// <inheritdoc />
+        public MixedRealityPointerScrollEventData(EventSystem eventSystem) : base(eventSystem) { }
+
+        /// <summary>
+        /// Used to initialize/reset the event and populate the data.
+        /// </summary>
+        /// <param name="pointer"></param>
+        /// <param name="inputAction"></param>
+        /// <param name="scrollDelta"></param>
+        /// <param name="inputSource"></param>
+        public void Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, Vector2 scrollDelta, IMixedRealityInputSource inputSource = null)
+        {
+            Initialize(pointer, inputAction, inputSource);
+            ScrollDelta = scrollDelta;
+        }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerScrollEventData.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/MixedRealityPointerScrollEventData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2095a9728db118242a2386a04849d8d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerDragHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerDragHandler.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine.EventSystems;
+using XRTK.EventDatum.Input;
+
+namespace XRTK.Interfaces.InputSystem.Handlers
+{
+    /// <summary>
+    /// Interface to implement to react to pointer drag input.
+    /// </summary>
+    public interface IMixedRealityPointerDragHandler : IEventSystemHandler
+    {
+        /// <summary>
+        /// When a pointer drag begin event is raised, this method is used to pass along the event data to the input handler.
+        /// </summary>
+        /// <param name="eventData"></param>
+        void OnPointerDragBegin(MixedRealityPointerDragEventData eventData);
+
+        /// <summary>
+        /// When a pointer dragged event is raised, this method is used to pass along the event data to the input handler.
+        /// </summary>
+        /// <param name="eventData"></param>
+        void OnPointerDrag(MixedRealityPointerDragEventData eventData);
+
+        /// <summary>
+        /// When a pointer drag end event is raised, this method is used to pass along the event data to the input handler.
+        /// </summary>
+        /// <param name="eventData"></param>
+        void OnPointerDragEnd(MixedRealityPointerDragEventData eventData);
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerDragHandler.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerDragHandler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerDragHandler.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerDragHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37e9bc0ff13666947bb7a9d18fba1b5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerScrollHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerScrollHandler.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine.EventSystems;
+using XRTK.EventDatum.Input;
+
+namespace XRTK.Interfaces.InputSystem.Handlers
+{
+    /// <summary>
+    /// Interface to implement to react to pointer scroll input.
+    /// </summary>
+    public interface IMixedRealityPointerScrollHandler : IEventSystemHandler
+    {
+        /// <summary>
+        /// When a pointer scroll is raised, this method is used to pass along the event data to the input handler.
+        /// </summary>
+        /// <param name="eventData"></param>
+        void OnPointerScroll(MixedRealityPointerScrollEventData eventData);
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerScrollHandler.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/Handlers/IMixedRealityPointerScrollHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de34b7760c5c62a48a9f337c19e3c857
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -248,8 +248,8 @@ namespace XRTK.Interfaces.InputSystem
         /// Raise the pointer down event.
         /// </summary>
         /// <param name="pointer">The pointer where the event originates.</param>
-        /// <param name="inputAction"></param>
-        /// <param name="inputSource"></param>
+        /// <param name="inputAction">The action associated with this event.</param>
+        /// <param name="inputSource">The input source this event is associated to, if null, the pointer's parent input source is used.</param>
         void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null);
 
         #endregion Pointer Down
@@ -259,11 +259,10 @@ namespace XRTK.Interfaces.InputSystem
         /// <summary>
         /// Raise the pointer clicked event.
         /// </summary>
-        /// <param name="pointer"></param>
-        /// <param name="inputAction"></param>
-        /// <param name="count"></param>
-        /// <param name="inputSource"></param>
-        void RaisePointerClicked(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count, IMixedRealityInputSource inputSource = null);
+        /// <param name="pointer">The pointer where the event originates.</param>
+        /// <param name="inputAction">The action associated with this event.</param>
+        /// <param name="inputSource">The input source this event is associated to, if null, the pointer's parent input source is used.</param>
+        void RaisePointerClicked(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null);
 
         #endregion Pointer Click
 
@@ -272,21 +271,52 @@ namespace XRTK.Interfaces.InputSystem
         /// <summary>
         /// Raise the pointer up event.
         /// </summary>
-        /// <param name="pointer"></param>
-        /// <param name="inputAction"></param>
-        /// <param name="inputSource"></param>
+        /// <param name="pointer">The pointer where the event originates.</param>
+        /// <param name="inputAction">The action associated with this event.</param>
+        /// <param name="inputSource">The input source this event is associated to, if null, the pointer's parent input source is used.</param>
         void RaisePointerUp(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null);
 
         #endregion Pointer Up
 
         /// <summary>
-        /// Raise teh pointer scroll event.
+        /// Raise the pointer scroll event.
         /// </summary>
-        /// <param name="pointer"></param>
-        /// <param name="scrollAction"></param>
-        /// <param name="scrollDelta"></param>
-        /// <param name="inputSource"></param>
+        /// <param name="pointer">The pointer where the event originates.</param>
+        /// <param name="scrollAction">The action associated with this event.</param>
+        /// <param name="scrollDelta">The distance this pointer has scrolled since the scroll event was last raised.</param>
+        /// <param name="inputSource">The input source this event is associated to, if null, the pointer's parent input source is used.</param>
         void RaisePointerScroll(IMixedRealityPointer pointer, MixedRealityInputAction scrollAction, Vector2 scrollDelta, IMixedRealityInputSource inputSource = null);
+
+        #region Pointer Dragging
+
+        /// <summary>
+        /// Raise the pointer drag begin event.
+        /// </summary>
+        /// <param name="pointer">The pointer where the event originates.</param>
+        /// <param name="draggedAction">The action associated with this event.</param>
+        /// <param name="dragDelta">The distance this pointer has been moved since the last time the dragged event was last raised.</param>
+        /// <param name="inputSource">The input source this event is associated to, if null, the pointer's parent input source is used.</param>
+        void RaisePointerDragBegin(IMixedRealityPointer pointer, MixedRealityInputAction draggedAction, Vector3 dragDelta, IMixedRealityInputSource inputSource = null);
+
+        /// <summary>
+        /// Raise the pointer drag event.
+        /// </summary>
+        /// <param name="pointer">The pointer where the event originates.</param>
+        /// <param name="draggedAction">The action associated with this event.</param>
+        /// <param name="dragDelta">The distance this pointer has been moved since the last time the dragged event was last raised.</param>
+        /// <param name="inputSource">The input source this event is associated to, if null, the pointer's parent input source is used.</param>
+        void RaisePointerDrag(IMixedRealityPointer pointer, MixedRealityInputAction draggedAction, Vector3 dragDelta, IMixedRealityInputSource inputSource = null);
+
+        /// <summary>
+        /// Raise the pointer drag end event.
+        /// </summary>
+        /// <param name="pointer">The pointer where the event originates.</param>
+        /// <param name="draggedAction">The action associated with this event.</param>
+        /// <param name="dragDelta">The distance this pointer has been moved since the last time the dragged event was last raised.</param>
+        /// <param name="inputSource">The input source this event is associated to, if null, the pointer's parent input source is used.</param>
+        void RaisePointerDragEnd(IMixedRealityPointer pointer, MixedRealityInputAction draggedAction, Vector3 dragDelta, IMixedRealityInputSource inputSource = null);
+
+        #endregion Pointer Dragging
 
         #endregion Pointers
 

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/UnityTouchController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/UnityTouchController.cs
@@ -101,7 +101,7 @@ namespace XRTK.Providers.Controllers.UnityInput
         public void Update()
         {
             UpdateController();
-            
+
             if (!isTouched) { return; }
 
             Lifetime += Time.deltaTime;
@@ -186,7 +186,7 @@ namespace XRTK.Providers.Controllers.UnityInput
                         isManipulating = false;
                     }
 
-                    MixedRealityToolkit.InputSystem?.RaisePointerClicked(InputSource.Pointers[0], Interactions[2].MixedRealityInputAction, TouchData.tapCount);
+                    MixedRealityToolkit.InputSystem?.RaisePointerClicked(InputSource.Pointers[0], Interactions[2].MixedRealityInputAction);
                 }
 
                 if (isHolding)

--- a/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
@@ -84,6 +84,7 @@ namespace XRTK.Services.InputSystem
 
         private InputEventData inputEventData;
         private MixedRealityPointerEventData pointerEventData;
+        private MixedRealityPointerDragEventData pointerDragEventData;
 
         private InputEventData<float> floatInputEventData;
         private InputEventData<Vector2> vector2InputEventData;
@@ -158,6 +159,7 @@ namespace XRTK.Services.InputSystem
 
                 inputEventData = new InputEventData(eventSystem);
                 pointerEventData = new MixedRealityPointerEventData(eventSystem);
+                pointerDragEventData = new MixedRealityPointerDragEventData(eventSystem);
 
                 floatInputEventData = new InputEventData<float>(eventSystem);
                 vector2InputEventData = new InputEventData<Vector2>(eventSystem);
@@ -903,12 +905,19 @@ namespace XRTK.Services.InputSystem
 
         #region Pointer Dragging
 
+        private static readonly ExecuteEvents.EventFunction<IMixedRealityPointerDragHandler> OnPointerDragBegin =
+            delegate (IMixedRealityPointerDragHandler handler, BaseEventData eventData)
+            {
+                var casted = ExecuteEvents.ValidateEventData<MixedRealityPointerDragEventData>(eventData);
+                handler.OnPointerDragBegin(casted);
+            };
+
         /// <inheritdoc />
         public void RaisePointerDragBegin(IMixedRealityPointer pointer, MixedRealityInputAction draggedAction, Vector3 dragDelta, IMixedRealityInputSource inputSource = null)
         {
-            positionInputEventData.Initialize(inputSource ?? pointer.InputSourceParent, pointer.Controller?.ControllerHandedness ?? Handedness.None, draggedAction, dragDelta);
+            pointerDragEventData.Initialize(pointer, draggedAction, dragDelta);
 
-            HandleEvent(positionInputEventData, OnPositionInputChanged);
+            HandleEvent(pointerDragEventData, OnPointerDragBegin);
 
             var focusedObject = pointer.Result.CurrentPointerTarget;
 
@@ -922,12 +931,19 @@ namespace XRTK.Services.InputSystem
             }
         }
 
+        private static readonly ExecuteEvents.EventFunction<IMixedRealityPointerDragHandler> OnPointerDrag =
+            delegate (IMixedRealityPointerDragHandler handler, BaseEventData eventData)
+            {
+                var casted = ExecuteEvents.ValidateEventData<MixedRealityPointerDragEventData>(eventData);
+                handler.OnPointerDrag(casted);
+            };
+
         /// <inheritdoc />
         public void RaisePointerDrag(IMixedRealityPointer pointer, MixedRealityInputAction draggedAction, Vector3 dragDelta, IMixedRealityInputSource inputSource = null)
         {
-            positionInputEventData.Initialize(inputSource ?? pointer.InputSourceParent, pointer.Controller?.ControllerHandedness ?? Handedness.None, draggedAction, dragDelta);
+            pointerDragEventData.Initialize(pointer, draggedAction, dragDelta);
 
-            HandleEvent(positionInputEventData, OnPositionInputChanged);
+            HandleEvent(pointerDragEventData, OnPointerDrag);
 
             var focusedObject = pointer.Result.CurrentPointerTarget;
 
@@ -938,12 +954,19 @@ namespace XRTK.Services.InputSystem
             }
         }
 
+        private static readonly ExecuteEvents.EventFunction<IMixedRealityPointerDragHandler> OnPointerDragEnd =
+            delegate (IMixedRealityPointerDragHandler handler, BaseEventData eventData)
+            {
+                var casted = ExecuteEvents.ValidateEventData<MixedRealityPointerDragEventData>(eventData);
+                handler.OnPointerDragEnd(casted);
+            };
+
         /// <inheritdoc />
         public void RaisePointerDragEnd(IMixedRealityPointer pointer, MixedRealityInputAction draggedAction, Vector3 dragDelta, IMixedRealityInputSource inputSource = null)
         {
-            positionInputEventData.Initialize(inputSource ?? pointer.InputSourceParent, pointer.Controller?.ControllerHandedness ?? Handedness.None, draggedAction, dragDelta);
+            pointerDragEventData.Initialize(pointer, draggedAction, dragDelta);
 
-            HandleEvent(positionInputEventData, OnPositionInputChanged);
+            HandleEvent(pointerDragEventData, OnPointerDragEnd);
 
             var focusedObject = pointer.Result.CurrentPointerTarget;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
@@ -85,6 +85,7 @@ namespace XRTK.Services.InputSystem
         private InputEventData inputEventData;
         private MixedRealityPointerEventData pointerEventData;
         private MixedRealityPointerDragEventData pointerDragEventData;
+        private MixedRealityPointerScrollEventData pointerScrollEventData;
 
         private InputEventData<float> floatInputEventData;
         private InputEventData<Vector2> vector2InputEventData;
@@ -160,6 +161,7 @@ namespace XRTK.Services.InputSystem
                 inputEventData = new InputEventData(eventSystem);
                 pointerEventData = new MixedRealityPointerEventData(eventSystem);
                 pointerDragEventData = new MixedRealityPointerDragEventData(eventSystem);
+                pointerScrollEventData = new MixedRealityPointerScrollEventData(eventSystem);
 
                 floatInputEventData = new InputEventData<float>(eventSystem);
                 vector2InputEventData = new InputEventData<Vector2>(eventSystem);
@@ -886,12 +888,19 @@ namespace XRTK.Services.InputSystem
 
         #endregion Pointer Up
 
+        private static readonly ExecuteEvents.EventFunction<IMixedRealityPointerScrollHandler> OnPointerScroll =
+            delegate (IMixedRealityPointerScrollHandler handler, BaseEventData eventData)
+            {
+                var casted = ExecuteEvents.ValidateEventData<MixedRealityPointerScrollEventData>(eventData);
+                handler.OnPointerScroll(casted);
+            };
+
         /// <inheritdoc />
         public void RaisePointerScroll(IMixedRealityPointer pointer, MixedRealityInputAction scrollAction, Vector2 scrollDelta, IMixedRealityInputSource inputSource = null)
         {
-            vector2InputEventData.Initialize(inputSource ?? pointer.InputSourceParent, pointer.Controller?.ControllerHandedness ?? Handedness.None, scrollAction, scrollDelta);
+            pointerScrollEventData.Initialize(pointer, scrollAction, scrollDelta);
 
-            HandleEvent(vector2InputEventData, OnTwoDoFInputChanged);
+            HandleEvent(pointerScrollEventData, OnPointerScroll);
 
             var focusedObject = pointer.Result.CurrentPointerTarget;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
@@ -915,6 +915,9 @@ namespace XRTK.Services.InputSystem
             if (focusedObject != null &&
                 FocusProvider.TryGetSpecificPointerGraphicEventData(pointer, out var graphicInputEventData))
             {
+                graphicInputEventData.pointerDrag = focusedObject;
+                graphicInputEventData.useDragThreshold = false;
+                graphicInputEventData.dragging = true;
                 ExecuteEvents.ExecuteHierarchy(focusedObject, graphicInputEventData, ExecuteEvents.beginDragHandler);
             }
         }
@@ -947,6 +950,7 @@ namespace XRTK.Services.InputSystem
             if (focusedObject != null &&
                 FocusProvider.TryGetSpecificPointerGraphicEventData(pointer, out var graphicInputEventData))
             {
+                graphicInputEventData.dragging = false;
                 ExecuteEvents.ExecuteHierarchy(focusedObject, graphicInputEventData, ExecuteEvents.endDragHandler);
             }
         }

--- a/XRTK-Core/Packages/com.xrtk.core/package.json
+++ b/XRTK-Core/Packages/com.xrtk.core/package.json
@@ -10,7 +10,7 @@
     "Mixed Reality",
     "DI"
   ],
-  "version": "0.1.22",
+  "version": "0.1.23",
   "unity": "2019.1",
   "license": "MIT",
   "author": "XRTK Team (https://github.com/XRTK)",


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Adds pointer drag events to the XRTK and ensure's they are properly forwarding events to the uGUI elements if they're being used.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Breaking Changes:

Are there any breaking changes included in this change that would prevent or cause issue for existing projects.

- `MixedRealityPointerEventData.Count` was removed, and will be replaced in the upcoming input action refactor work to address #258.
- Adds `MixedRealityPointerScrollEventData`
- Adds `IMixedRealityPointerScrollHandler`
- Adds `MixedRealityPointerDragEventData`
- Adds `IMixedRealityPointerDragHandler`
- Updated the `IMixedRealityInputSystem`:
  - `RaisePointerDragBegin`
  - `RaisePointerDrag`
  - `RaisePointerDragEnd`
  - `RaisePointerClicked` removed the `count` int parameter
  - `RaisePointerScroll` now properly initialized event data for its event type