### PR TITLE
Added body tracking to solver handler

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/TrackedObjectType.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/TrackedObjectType.cs
@@ -16,6 +16,10 @@ namespace XRTK.Definitions.Utilities
         /// <summary>
         /// Calculates position and orientation from the right motion-tracked controller.
         /// </summary>
-        MotionControllerRight
+        MotionControllerRight,
+        /// <summary>
+        /// Calculates position and orientation from the playspace.
+        /// </summary>
+        Body
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/TrackedObjectType.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/TrackedObjectType.cs
@@ -10,13 +10,13 @@ namespace XRTK.Definitions.Utilities
         /// </summary>
         Head = 0,
         /// <summary>
-        /// Calculates position and orientation from the left motion-tracked controller.
+        /// Calculates position and orientation from the left hand or tracked controller.
         /// </summary>
-        MotionControllerLeft,
+        LeftHandOrController,
         /// <summary>
-        /// Calculates position and orientation from the right motion-tracked controller.
+        /// Calculates position and orientation from the right hand or tracked controller.
         /// </summary>
-        MotionControllerRight,
+        RightHandOrController,
         /// <summary>
         /// Calculates position and orientation from the playspace.
         /// </summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
@@ -217,10 +217,10 @@ namespace XRTK.SDK.Utilities.Solvers
                     Handedness = Handedness.None;
                     TrackTransform(CameraCache.Main.transform);
                     break;
-                case TrackedObjectType.MotionControllerLeft:
+                case TrackedObjectType.LeftHandOrController:
                     Handedness = Handedness.Left;
                     break;
-                case TrackedObjectType.MotionControllerRight:
+                case TrackedObjectType.RightHandOrController:
                     Handedness = Handedness.Right;
                     break;
                 case TrackedObjectType.Body:

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using XRTK.Definitions.Utilities;
+using XRTK.Services;
 using XRTK.Utilities;
 
 namespace XRTK.SDK.Utilities.Solvers
@@ -221,6 +222,10 @@ namespace XRTK.SDK.Utilities.Solvers
                     break;
                 case TrackedObjectType.MotionControllerRight:
                     Handedness = Handedness.Right;
+                    break;
+                case TrackedObjectType.Body:
+                    Handedness = Handedness.None;
+                    TrackTransform(MixedRealityToolkit.Instance.MixedRealityPlayspace);
                     break;
             }
         }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Added the ability to specify the body (the mixed reality playspace) as a tracked object to solve the position and rotation against. Used for body locked solvers.

## Breaking Changes:
- Renamed `TrackedObjectType.MotionControllerLeft` to `TrackedObjectType.LeftHandOrController`
- Renamed `TrackedObjectType.MotionControllerRight` to `TrackedObjectType.RightHandOrController`