### PR TITLE
Initial changes for the new camera rig configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [StephenHodgson] # [XRTK, SimonDarksideJ, StephenHodgson]
+github: [StephenHodgson,SimonDarksideJ] # [XRTK, SimonDarksideJ, StephenHodgson]
 ko_fi: xrtk_team
 issuehunt: # simondarksidej
 custom: http://paypal.me/XRTK

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # [XRTK, SimonDarksideJ, StephenHodgson]
+github: [StephenHodgson] # [XRTK, SimonDarksideJ, StephenHodgson]
 ko_fi: xrtk_team
 issuehunt: # simondarksidej
 custom: http://paypal.me/XRTK

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityCameraProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityCameraProfile.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
+using XRTK.Attributes;
 using XRTK.Definitions.Utilities;
+using XRTK.Interfaces;
+using XRTK.Services.CameraSystem;
 
 namespace XRTK.Definitions
 {
@@ -98,5 +101,29 @@ namespace XRTK.Definitions
         /// Set the desired quality for your application for transparent display.
         /// </summary>
         public int TransparentQualityLevel => transparentQualityLevel;
+
+        [SerializeField]
+        [Tooltip("The concrete type to use for the camera rig.")]
+        [Implements(typeof(IMixedRealityCameraRig), TypeGrouping.ByNamespaceFlat)]
+        private SystemType cameraRigType = new SystemType(typeof(DefaultCameraRig));
+
+        /// <summary>
+        /// The concrete type to use for the camera rig.
+        /// </summary>
+        public SystemType CameraRigType
+        {
+            get => cameraRigType;
+            internal set => cameraRigType = value;
+        }
+
+        [SerializeField]
+        [Range(0f, 180f)]
+        [Tooltip("This is the angle that will be used to adjust the player's body rotation in relation to their head position.")]
+        private float bodyAdjustmentAngle = 45f;
+
+        /// <summary>
+        /// This is the angle that will be used to adjust the player's body rotation in relation to their head position.
+        /// </summary>
+        public float BodyAdjustmentAngle => bodyAdjustmentAngle;
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/TrackedObjectType.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/TrackedObjectType.cs
@@ -10,12 +10,16 @@ namespace XRTK.Definitions.Utilities
         /// </summary>
         Head = 0,
         /// <summary>
-        /// Calculates position and orientation from the left motion-tracked controller.
+        /// Calculates position and orientation from the left hand or tracked controller.
         /// </summary>
-        MotionControllerLeft,
+        LeftHandOrController,
         /// <summary>
-        /// Calculates position and orientation from the right motion-tracked controller.
+        /// Calculates position and orientation from the right hand or tracked controller.
         /// </summary>
-        MotionControllerRight
+        RightHandOrController,
+        /// <summary>
+        /// Calculates position and orientation from the playspace.
+        /// </summary>
+        Body
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/TrackedObjectType.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Utilities/TrackedObjectType.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using XRTK.Interfaces;
+
 namespace XRTK.Definitions.Utilities
 {
     public enum TrackedObjectType
     {
         /// <summary>
-        /// Calculates position and orientation from the main camera.
+        /// Calculates position and orientation based on the <see cref="IMixedRealityCameraRig.CameraTransform"/>.
         /// </summary>
         Head = 0,
         /// <summary>
@@ -18,8 +20,12 @@ namespace XRTK.Definitions.Utilities
         /// </summary>
         RightHandOrController,
         /// <summary>
-        /// Calculates position and orientation from the playspace.
+        /// Calculates position and orientation based on the <see cref="IMixedRealityCameraRig.BodyTransform"/>.
         /// </summary>
-        Body
+        Body,
+        /// <summary>
+        /// Calculates position and orientation based on the <see cref="IMixedRealityCameraRig.PlayspaceTransform"/>
+        /// </summary>
+        Playspace,
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityToolkitInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityToolkitInspector.cs
@@ -100,7 +100,7 @@ namespace XRTK.Inspectors
 
             if (changed)
             {
-                MixedRealityToolkit.Instance.ResetConfiguration((MixedRealityToolkitConfigurationProfile)activeProfile.objectReferenceValue);
+                EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration((MixedRealityToolkitConfigurationProfile)activeProfile.objectReferenceValue);
             }
         }
 
@@ -133,8 +133,6 @@ namespace XRTK.Inspectors
 
                 Selection.activeObject = MixedRealityToolkit.Instance;
                 Debug.Assert(MixedRealityToolkit.IsInitialized);
-                var playspace = MixedRealityToolkit.Instance.MixedRealityPlayspace;
-                Debug.Assert(playspace != null);
 
                 var currentScene = SceneManager.GetActiveScene();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions;
 using XRTK.Inspectors.Utilities;
+using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles
 {
@@ -21,6 +22,9 @@ namespace XRTK.Inspectors.Profiles
         private SerializedProperty transparentClearFlags;
         private SerializedProperty transparentBackgroundColor;
         private SerializedProperty transparentQualityLevel;
+
+        private SerializedProperty cameraRigType;
+        private SerializedProperty bodyAdjustmentAngle;
 
         private readonly GUIContent nearClipTitle = new GUIContent("Near Clip");
         private readonly GUIContent clearFlagsTitle = new GUIContent("Clear Flags");
@@ -39,6 +43,9 @@ namespace XRTK.Inspectors.Profiles
             transparentClearFlags = serializedObject.FindProperty("cameraClearFlagsTransparentDisplay");
             transparentBackgroundColor = serializedObject.FindProperty("backgroundColorTransparentDisplay");
             transparentQualityLevel = serializedObject.FindProperty("transparentQualityLevel");
+
+            cameraRigType = serializedObject.FindProperty("cameraRigType");
+            bodyAdjustmentAngle = serializedObject.FindProperty("bodyAdjustmentAngle");
         }
 
         public override void OnInspectorGUI()
@@ -59,9 +66,13 @@ namespace XRTK.Inspectors.Profiles
 
             serializedObject.Update();
 
+            EditorGUI.BeginChangeCheck();
+
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Global Settings:", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(isCameraPersistent);
+            EditorGUILayout.PropertyField(cameraRigType);
+            EditorGUILayout.PropertyField(bodyAdjustmentAngle);
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Opaque Display Settings:", EditorStyles.boldLabel);
@@ -88,6 +99,11 @@ namespace XRTK.Inspectors.Profiles
             transparentQualityLevel.intValue = EditorGUILayout.Popup("Quality Setting", transparentQualityLevel.intValue, QualitySettings.names);
 
             serializedObject.ApplyModifiedProperties();
+
+            if (MixedRealityToolkit.IsInitialized && EditorGUI.EndChangeCheck())
+            {
+                EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
+            }
         }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -71,7 +71,7 @@ namespace XRTK.Inspectors.Profiles
                         "Yes",
                         "Later"))
                     {
-                        var playspace = MixedRealityToolkit.Instance.MixedRealityPlayspace;
+                        var playspace = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform;
                         Debug.Assert(playspace != null);
                         MixedRealityToolkit.Instance.ActiveProfile = configurationProfile;
                     }
@@ -118,6 +118,8 @@ namespace XRTK.Inspectors.Profiles
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
             serializedObject.Update();
+
+            if (!MixedRealityToolkit.IsInitialized) { return; }
 
             if (!configurationProfile.IsCustomProfile)
             {

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/PrefabPropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/PrefabPropertyDrawer.cs
@@ -24,25 +24,30 @@ namespace XRTK.Inspectors.PropertyDrawers
                 if (!EditorGUI.EndChangeCheck()) { return; }
                 if (property.objectReferenceValue == null) { return; }
 
-                PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(property.objectReferenceValue);
+                var prefabAssetType = PrefabUtility.GetPrefabAssetType(property.objectReferenceValue);
 
-                if (prefabAssetType != PrefabAssetType.Regular && prefabAssetType != PrefabAssetType.Variant)
+                if (prefabAssetType != PrefabAssetType.Regular &&
+                    prefabAssetType != PrefabAssetType.Variant)
                 {
                     property.objectReferenceValue = null;
-                    Debug.LogWarning("Assigned GameObject must be a prefab");
+                    Debug.LogWarning("Assigned GameObject must be a prefab!");
                 }
 
-                if (prefabAttribute.Constraint != null)
+                if (prefabAttribute.Constraint == null) { return; }
+
+                if (property.objectReferenceValue is GameObject prefabObject)
                 {
-                    var prefabObject = property.objectReferenceValue as GameObject;
-                    Debug.Assert(prefabObject != null);
                     var constraint = prefabObject.GetComponent(prefabAttribute.Constraint);
 
                     if (constraint == null)
                     {
                         property.objectReferenceValue = null;
-                        Debug.LogWarning($"Assigned GameObject must have {prefabAttribute.Constraint.Name} component");
+                        Debug.LogWarning($"Assigned GameObject must have a {prefabAttribute.Constraint.Name} component.");
                     }
+                }
+                else
+                {
+                    Debug.LogError($"The serialized field {property.name} needs to be serialized as a GameObject type.");
                 }
             }
             else

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/CameraSystem/IMixedRealityCameraSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/CameraSystem/IMixedRealityCameraSystem.cs
@@ -4,11 +4,24 @@
 
 namespace XRTK.Interfaces.CameraSystem
 {
+    /// <summary>
+    /// The base interface for implementing a mixed reality camera system.
+    /// </summary>
     public interface IMixedRealityCameraSystem : IMixedRealityService
     {
         /// <summary>
         /// Is the current camera displaying on an Opaque (AR) device or a VR / immersive device
         /// </summary>
         bool IsOpaque { get; }
+
+        /// <summary>
+        /// Is the current camera displaying on a traditional 2d screen or a stereoscopic display?
+        /// </summary>
+        bool IsStereoscopic { get; }
+
+        /// <summary>
+        /// The <see cref="IMixedRealityCameraRig"/> component used in the current configuration.
+        /// </summary>
+        IMixedRealityCameraRig CameraRig { get; }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/IMixedRealityCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/IMixedRealityCameraRig.cs
@@ -26,7 +26,7 @@ namespace XRTK.Interfaces
         Camera PlayerCamera { get; }
 
         /// <summary>
-        /// The player's body transform. This <see cref="Transform"/> is synced to the player's head X & Z values
+        /// The player's body transform. This <see cref="Transform"/> is synced to the player's head X &amp; Z values
         /// and the <see cref="CameraTransform"/>'s Y value.
         /// </summary>
         Transform BodyTransform { get; }

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/IMixedRealityCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/IMixedRealityCameraRig.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+
+namespace XRTK.Interfaces
+{
+    /// <summary>
+    /// This interface is to be implemented by a <see cref="MonoBehaviour"/> and attached to the playspace root object.
+    /// </summary>
+    public interface IMixedRealityCameraRig
+    {
+        /// <summary>
+        /// The root playspace transform that serves as the root of the camera rig.
+        /// </summary>
+        Transform PlayspaceTransform { get; }
+
+        /// <summary>
+        /// The player's head transform where the <see cref="Camera"/> is located.
+        /// </summary>
+        Transform CameraTransform { get; }
+
+        /// <summary>
+        /// The player's <see cref="Camera"/> reference.
+        /// </summary>
+        Camera PlayerCamera { get; }
+
+        /// <summary>
+        /// The player's body transform. This <see cref="Transform"/> is synced to the player's head X & Z values
+        /// and the <see cref="CameraTransform"/>'s Y value.
+        /// </summary>
+        Transform BodyTransform { get; }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/IMixedRealityCameraRig.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/IMixedRealityCameraRig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c023dce551f1765459b733faa7f78af9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseController.cs
@@ -259,7 +259,7 @@ namespace XRTK.Providers.Controllers
                 if (useSystemDefaultModels && gltfObject != null)
                 {
                     controllerModel.name = $"{controllerType.Name}_Visualization";
-                    controllerModel.transform.SetParent(MixedRealityToolkit.Instance.MixedRealityPlayspace.transform);
+                    controllerModel.transform.SetParent(MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform);
                     var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(controllerType, ControllerHandedness) ??
                                             visualizationProfile.ControllerVisualizationType;
                     controllerModel.AddComponent(visualizationType.Type);
@@ -268,7 +268,7 @@ namespace XRTK.Providers.Controllers
                 //If the model was a prefab
                 else
                 {
-                    var controllerObject = UnityEngine.Object.Instantiate(controllerModel, MixedRealityToolkit.Instance.MixedRealityPlayspace);
+                    var controllerObject = UnityEngine.Object.Instantiate(controllerModel, MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform);
                     controllerObject.name = $"{controllerType.Name}_Visualization";
                     Visualizer = controllerObject.GetComponent<IMixedRealityControllerVisualizer>();
                 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseControllerDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseControllerDataProvider.cs
@@ -50,7 +50,7 @@ namespace XRTK.Providers.Controllers
                     if (((useSpecificType && pointerProfile.ControllerType.Type == controllerType.Type) || (!useSpecificType && pointerProfile.ControllerType.Type == null)) &&
                         (pointerProfile.Handedness == Handedness.Any || pointerProfile.Handedness == Handedness.Both || pointerProfile.Handedness == controllingHand))
                     {
-                        var pointerObject = Object.Instantiate(pointerProfile.PointerPrefab, MixedRealityToolkit.Instance.MixedRealityPlayspace);
+                        var pointerObject = Object.Instantiate(pointerProfile.PointerPrefab, MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform);
                         var pointer = pointerObject.GetComponent<IMixedRealityPointer>();
 
                         if (pointer != null)

--- a/XRTK-Core/Packages/com.xrtk.core/Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -298,7 +298,7 @@ namespace XRTK.Services.BoundarySystem
                 }
 
                 var visualizationParent = new GameObject("Boundary System Visualizations");
-                visualizationParent.transform.parent = MixedRealityToolkit.Instance.MixedRealityPlayspace;
+                visualizationParent.transform.parent = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform;
                 return boundaryVisualizationParent = visualizationParent;
             }
         }
@@ -599,7 +599,7 @@ namespace XRTK.Services.BoundarySystem
             }
 
             // Handle the user teleporting (boundary moves with them).
-            location = MixedRealityToolkit.Instance.MixedRealityPlayspace.InverseTransformPoint(location);
+            location = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform.InverseTransformPoint(location);
 
             if (FloorHeight.Value > location.y ||
                 BoundaryHeight < location.y)
@@ -638,7 +638,7 @@ namespace XRTK.Services.BoundarySystem
             }
 
             // Handle the user teleporting (boundary moves with them).
-            var transformedCenter = MixedRealityToolkit.Instance.MixedRealityPlayspace.TransformPoint(
+            var transformedCenter = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform.TransformPoint(
                 new Vector3(rectangularBounds.Center.x, 0f, rectangularBounds.Center.y));
 
             center = new Vector2(transformedCenter.x, transformedCenter.z);
@@ -665,7 +665,7 @@ namespace XRTK.Services.BoundarySystem
             }
 
             var floorScale = FloorScale;
-            var position = MixedRealityToolkit.Instance.MixedRealityPlayspace.position;
+            var position = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform.position;
 
             // Render the floor.
             currentFloorObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -752,7 +752,7 @@ namespace XRTK.Services.BoundarySystem
                 layer = DefaultIgnoreRaycastLayer
             };
 
-            var position = MixedRealityToolkit.Instance.MixedRealityPlayspace.position;
+            var position = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform.position;
 
             currentTrackedAreaObject.AddComponent<LineRenderer>();
             currentTrackedAreaObject.transform.Translate(

--- a/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/DefaultCameraRig.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+using XRTK.Interfaces;
+using XRTK.Utilities;
+
+namespace XRTK.Services.CameraSystem
+{
+    /// <summary>
+    /// The default <see cref="IMixedRealityCameraRig"/> for the XRTK.
+    /// </summary>
+    [ExecuteAlways]
+    public class DefaultCameraRig : MonoBehaviour, IMixedRealityCameraRig
+    {
+        #region IMixedRealityCameraRig Implementation
+
+        [SerializeField]
+        private string playspaceName = "MixedRealityPlayspace";
+
+        [SerializeField]
+        private Transform playspaceTransform = null;
+
+        /// <inheritdoc />
+        public Transform PlayspaceTransform
+        {
+            get
+            {
+                if (playspaceTransform)
+                {
+                    return playspaceTransform;
+                }
+
+                if (PlayerCamera.transform.parent == null)
+                {
+                    playspaceTransform = new GameObject(playspaceName).transform;
+                    PlayerCamera.transform.SetParent(playspaceTransform);
+                }
+                else
+                {
+                    if (PlayerCamera.transform.parent.name != playspaceName)
+                    {
+                        // Since the scene is set up with a different camera parent, its likely
+                        // that there's an expectation that that parent is going to be used for
+                        // something else. We print a warning to call out the fact that we're
+                        // co-opting this object for use with teleporting and such, since that
+                        // might cause conflicts with the parent's intended purpose.
+                        Debug.LogWarning($"The Mixed Reality Toolkit expected the camera\'s parent to be named {playspaceName}. The existing parent will be renamed and used instead.");
+                        // If we rename it, we make it clearer that why it's being teleported around at runtime.
+                        PlayerCamera.transform.parent.name = playspaceName;
+                    }
+
+                    playspaceTransform = PlayerCamera.transform.parent;
+                }
+
+                // It's very important that the MixedRealityPlayspace align with the tracked space,
+                // otherwise world-locked things like playspace boundaries won't be aligned properly.
+                // For now, we'll just assume that when the playspace is first initialized, the
+                // tracked space origin overlaps with the world space origin. If a platform ever does
+                // something else (i.e, placing the lower left hand corner of the tracked space at world
+                // space 0,0,0), we should compensate for that here.
+                return playspaceTransform;
+            }
+        }
+
+        /// <inheritdoc />
+        public Transform CameraTransform => PlayerCamera.transform;
+
+        [SerializeField]
+        private Camera playerCamera = null;
+
+        /// <inheritdoc />
+        public Camera PlayerCamera
+        {
+            get
+            {
+                // Currently the XRTK only supports a single player/user
+                // So for now we will always reference the tagged MainCamera.
+                if (playerCamera == null)
+                {
+                    playerCamera = CameraCache.Main;
+                }
+
+                return playerCamera;
+            }
+        }
+
+        [SerializeField]
+        private string playerBodyName = "PlayerBody";
+
+        [SerializeField]
+        private Transform bodyTransform = null;
+
+        /// <inheritdoc />
+        public Transform BodyTransform
+        {
+            get
+            {
+                if (bodyTransform == null)
+                {
+                    bodyTransform = PlayspaceTransform.Find(playerBodyName);
+                }
+
+                if (bodyTransform == null)
+                {
+                    bodyTransform = new GameObject(playerBodyName).transform;
+                    bodyTransform.transform.SetParent(PlayspaceTransform);
+                }
+
+                return bodyTransform;
+            }
+        }
+
+        #endregion IMixedRealityCameraRig Implementation
+
+        #region MonoBehaviour Implementation
+
+        private void OnValidate()
+        {
+            if (playspaceTransform != null &&
+                !playspaceTransform.name.Equals(playspaceName))
+            {
+                playspaceTransform.name = playspaceName;
+            }
+
+            if (bodyTransform != null &&
+                !bodyTransform.name.Equals(playerBodyName))
+            {
+                bodyTransform.name = playerBodyName;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (bodyTransform != null)
+            {
+                if (Application.isPlaying)
+                {
+                    Destroy(bodyTransform.gameObject);
+                }
+                else
+                {
+                    DestroyImmediate(bodyTransform.gameObject);
+                }
+            }
+        }
+
+        #endregion MonoBehaviour Implementation
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/DefaultCameraRig.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/DefaultCameraRig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62d15896ce4d28b4dacfb72d68447759
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/XRTK-Core/Packages/com.xrtk.core/Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -234,7 +234,7 @@ namespace XRTK.Services.DiagnosticsSystem
         private void CreateVisualizations()
         {
             diagnosticVisualizationParent = new GameObject("Diagnostics");
-            diagnosticVisualizationParent.transform.parent = MixedRealityToolkit.Instance.MixedRealityPlayspace;
+            diagnosticVisualizationParent.transform.parent = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform;
             diagnosticVisualizationParent.SetActive(ShowDiagnostics);
 
             // visual profiler settings

--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
@@ -283,10 +283,7 @@ namespace XRTK.Services
 
                 if (HasActiveProfile)
                 {
-#if UNITY_EDITOR
-                    UnityEditor.EditorApplication.delayCall += () =>
-#endif // UNITY_EDITOR
-                        InitializeServiceLocator();
+                    InitializeServiceLocator();
                 }
             }
         }
@@ -300,6 +297,11 @@ namespace XRTK.Services
         private static bool isInitializing = false;
 
         private static bool isApplicationQuitting = false;
+
+        /// <summary>
+        /// Flag stating if the application is currently attempting to quit.
+        /// </summary>
+        public static bool IsApplicationQuitting => isApplicationQuitting;
 
         /// <summary>
         /// Expose an assertion whether the MixedRealityToolkit class is initialized.
@@ -1499,7 +1501,7 @@ namespace XRTK.Services
         public static bool TryGetService<T>(out T service, bool showLogs = true) where T : IMixedRealityService
         {
             service = GetService<T>(showLogs);
-            return service == null ? false : true;
+            return service != null;
         }
 
         /// <summary>
@@ -1525,7 +1527,7 @@ namespace XRTK.Services
         public static bool TryGetService<T>(string serviceName, out T service, bool showLogs = true) where T : IMixedRealityService
         {
             service = (T)GetService(typeof(T), serviceName, showLogs);
-            return service == null ? false : true;
+            return service != null;
         }
 
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
@@ -98,6 +98,12 @@ namespace XRTK.Services
                 return;
             }
 
+            if (isInitializing)
+            {
+                Debug.LogWarning("Already attempting to initialize the configurations!");
+                return;
+            }
+
             isResetting = true;
 
             if (activeProfile != null)
@@ -277,7 +283,10 @@ namespace XRTK.Services
 
                 if (HasActiveProfile)
                 {
-                    InitializeServiceLocator();
+#if UNITY_EDITOR
+                    UnityEditor.EditorApplication.delayCall += () =>
+#endif // UNITY_EDITOR
+                        InitializeServiceLocator();
                 }
             }
         }
@@ -321,7 +330,11 @@ namespace XRTK.Services
         /// </summary>
         private void InitializeServiceLocator()
         {
-            if (isInitializing) { return; }
+            if (isInitializing)
+            {
+                Debug.LogWarning("Already attempting to initialize the configurations!");
+                return;
+            }
 
             isInitializing = true;
 
@@ -350,12 +363,12 @@ namespace XRTK.Services
 
             #region Services Registration
 
-            if (ActiveProfile.IsCameraSystemEnabled)
+            if (ActiveProfile.IsCameraSystemEnabled &&
+                (!CreateAndRegisterService<IMixedRealityCameraSystem>(ActiveProfile.CameraSystemType, ActiveProfile.CameraProfile) || CameraSystem == null))
             {
-                if (!CreateAndRegisterService<IMixedRealityCameraSystem>(ActiveProfile.CameraSystemType, ActiveProfile.CameraProfile) || CameraSystem == null)
-                {
-                    Debug.LogError("Failed to start the Camera System!");
-                }
+                Debug.LogError("Failed to start the Camera System!");
+                isInitializing = false;
+                return;
             }
 
             if (ActiveProfile.IsInputSystemEnabled)
@@ -549,9 +562,9 @@ namespace XRTK.Services
             var orderedServices = registeredMixedRealityServices.OrderBy(service => service.Item2.Priority).ToArray();
             registeredMixedRealityServices.Clear();
 
-            foreach (var service in orderedServices)
+            foreach (var (interfaceType, mixedRealityService) in orderedServices)
             {
-                RegisterService(service.Item1, service.Item2);
+                RegisterService(interfaceType, mixedRealityService);
             }
 
             InitializeAllServices();
@@ -560,56 +573,6 @@ namespace XRTK.Services
 
             isInitializing = false;
         }
-
-        /// <summary>
-        /// Returns the MixedRealityPlayspace for the local player
-        /// </summary>
-        public Transform MixedRealityPlayspace
-        {
-            get
-            {
-                AssertIsInitialized();
-
-                if (mixedRealityPlayspace)
-                {
-                    return mixedRealityPlayspace;
-                }
-
-                if (CameraCache.Main.transform.parent == null)
-                {
-                    mixedRealityPlayspace = new GameObject(MixedRealityPlayspaceName).transform;
-                    CameraCache.Main.transform.SetParent(mixedRealityPlayspace);
-                }
-                else
-                {
-                    if (CameraCache.Main.transform.parent.name != MixedRealityPlayspaceName)
-                    {
-                        // Since the scene is set up with a different camera parent, its likely
-                        // that there's an expectation that that parent is going to be used for
-                        // something else. We print a warning to call out the fact that we're
-                        // co-opting this object for use with teleporting and such, since that
-                        // might cause conflicts with the parent's intended purpose.
-                        Debug.LogWarning($"The Mixed Reality Toolkit expected the camera\'s parent to be named {MixedRealityPlayspaceName}. The existing parent will be renamed and used instead.");
-                        // If we rename it, we make it clearer that why it's being teleported around at runtime.
-                        CameraCache.Main.transform.parent.name = MixedRealityPlayspaceName;
-                    }
-
-                    mixedRealityPlayspace = CameraCache.Main.transform.parent;
-                }
-
-                // It's very important that the MixedRealityPlayspace align with the tracked space,
-                // otherwise world-locked things like playspace boundaries won't be aligned properly.
-                // For now, we'll just assume that when the playspace is first initialized, the
-                // tracked space origin overlaps with the world space origin. If a platform ever does
-                // something else (i.e, placing the lower left hand corner of the tracked space at world
-                // space 0,0,0), we should compensate for that here.
-                return mixedRealityPlayspace;
-            }
-        }
-
-        private Transform mixedRealityPlayspace;
-
-        private const string MixedRealityPlayspaceName = "MixedRealityPlayspace";
 
         private static void EnsureMixedRealityRequirements()
         {

--- a/XRTK-Core/Packages/com.xrtk.core/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -45,7 +45,7 @@ namespace XRTK.Services.SpatialAwarenessSystem
             get
             {
                 var spatialAwarenessSystemObject = new GameObject("Spatial Awareness System");
-                spatialAwarenessSystemObject.transform.parent = MixedRealityToolkit.Instance.MixedRealityPlayspace;
+                spatialAwarenessSystemObject.transform.parent = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform;
                 return spatialAwarenessSystemObject;
             }
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -220,7 +220,7 @@ namespace XRTK.Services.Teleportation
         {
             isProcessingTeleportRequest = true;
 
-            var cameraParent = MixedRealityToolkit.Instance.MixedRealityPlayspace;
+            var cameraParent = MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform;
 
             targetRotation = Vector3.zero;
             targetRotation.y = eventData.Pointer.PointerOrientation;

--- a/XRTK-Core/Packages/com.xrtk.core/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -33,11 +33,6 @@ namespace XRTK.Services.Teleportation
         private Vector3 targetPosition = Vector3.zero;
         private Vector3 targetRotation = Vector3.zero;
 
-        /// <summary>
-        /// only used to clean up event system when shutting down if this system created one.
-        /// </summary>
-        private GameObject eventSystemReference = null;
-
         #region IMixedRealityService Implementation
 
         /// <inheritdoc />
@@ -48,24 +43,6 @@ namespace XRTK.Services.Teleportation
             if (!Application.isPlaying) { return; }
 
             teleportEventData = new TeleportEventData(EventSystem.current);
-        }
-
-        /// <inheritdoc />
-        public override void Destroy()
-        {
-            base.Destroy();
-
-            if (eventSystemReference != null)
-            {
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(eventSystemReference);
-                }
-                else
-                {
-                    Object.Destroy(eventSystemReference);
-                }
-            }
         }
 
         #endregion IMixedRealityService Implementation
@@ -237,7 +214,7 @@ namespace XRTK.Services.Teleportation
             }
 
             var height = targetPosition.y;
-            var cameraTransform = CameraCache.Main.transform;
+            var cameraTransform = MixedRealityToolkit.CameraSystem.CameraRig.CameraTransform;
             var cameraPosition = cameraTransform.position;
             targetPosition -= cameraPosition - cameraParent.position;
             targetPosition.y = height;

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/Orbital.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/Orbital.cs
@@ -4,6 +4,7 @@
 using XRTK.Definitions.Utilities;
 using XRTK.Utilities;
 using UnityEngine;
+using XRTK.Services;
 
 namespace XRTK.SDK.Utilities.Solvers
 {
@@ -87,16 +88,20 @@ namespace XRTK.SDK.Utilities.Solvers
             set => tetherAngleSteps = Mathf.Clamp(value, 2, 24);
         }
 
+        /// <inheritdoc />
         public override void SolverUpdate()
         {
-            Vector3 desiredPos = SolverHandler.TransformTarget != null ? SolverHandler.TransformTarget.position : Vector3.zero;
+            var desiredPos = SolverHandler.TransformTarget != null
+                ? SolverHandler.TransformTarget.position
+                : Vector3.zero;
+            var targetRot = SolverHandler.TransformTarget != null
+                ? SolverHandler.TransformTarget.rotation
+                : Quaternion.Euler(0, 1, 0);
+            var yawOnlyRot = Quaternion.Euler(0, targetRot.eulerAngles.y, 0);
+            desiredPos += (SnapToTetherAngleSteps(targetRot) * LocalOffset);
+            desiredPos += (SnapToTetherAngleSteps(yawOnlyRot) * WorldOffset);
 
-            Quaternion targetRot = SolverHandler.TransformTarget != null ? SolverHandler.TransformTarget.rotation : Quaternion.Euler(0, 1, 0);
-            Quaternion yawOnlyRot = Quaternion.Euler(0, targetRot.eulerAngles.y, 0);
-            desiredPos = desiredPos + (SnapToTetherAngleSteps(targetRot) * LocalOffset);
-            desiredPos = desiredPos + (SnapToTetherAngleSteps(yawOnlyRot) * WorldOffset);
-
-            Quaternion desiredRot = CalculateDesiredRotation(desiredPos);
+            var desiredRot = CalculateDesiredRotation(desiredPos);
 
             GoalPosition = desiredPos;
             GoalRotation = desiredRot;
@@ -113,38 +118,46 @@ namespace XRTK.SDK.Utilities.Solvers
                 return rotationToSnap;
             }
 
-            float stepAngle = 360f / tetherAngleSteps;
-            int numberOfSteps = Mathf.RoundToInt(SolverHandler.TransformTarget.transform.eulerAngles.y / stepAngle);
+            var stepAngle = 360f / tetherAngleSteps;
+            var numberOfSteps = Mathf.RoundToInt(SolverHandler.TransformTarget.transform.eulerAngles.y / stepAngle);
 
-            float newAngle = stepAngle * numberOfSteps;
+            var newAngle = stepAngle * numberOfSteps;
 
             return Quaternion.Euler(rotationToSnap.eulerAngles.x, newAngle, rotationToSnap.eulerAngles.z);
         }
 
         private Quaternion CalculateDesiredRotation(Vector3 desiredPos)
         {
-            Quaternion desiredRot = Quaternion.identity;
+            var desiredRot = Quaternion.identity;
 
             switch (orientationType)
             {
                 case SolverOrientationType.YawOnly:
-                    float targetYRotation = SolverHandler.TransformTarget != null ? SolverHandler.TransformTarget.eulerAngles.y : 0.0f;
+                    var targetYRotation = SolverHandler.TransformTarget != null
+                        ? SolverHandler.TransformTarget.eulerAngles.y
+                        : 0.0f;
                     desiredRot = Quaternion.Euler(0f, targetYRotation, 0f);
                     break;
                 case SolverOrientationType.Unmodified:
                     desiredRot = transform.rotation;
                     break;
                 case SolverOrientationType.CameraAligned:
-                    desiredRot = CameraCache.Main.transform.rotation;
+                    desiredRot = MixedRealityToolkit.CameraSystem.CameraRig.CameraTransform.rotation;
                     break;
                 case SolverOrientationType.FaceTrackedObject:
-                    desiredRot = SolverHandler.TransformTarget != null ? Quaternion.LookRotation(SolverHandler.TransformTarget.position - desiredPos) : Quaternion.identity;
+                    desiredRot = SolverHandler.TransformTarget != null
+                        ? Quaternion.LookRotation(SolverHandler.TransformTarget.position - desiredPos)
+                        : Quaternion.identity;
                     break;
                 case SolverOrientationType.CameraFacing:
-                    desiredRot = SolverHandler.TransformTarget != null ? Quaternion.LookRotation(CameraCache.Main.transform.position - desiredPos) : Quaternion.identity;
+                    desiredRot = SolverHandler.TransformTarget != null
+                        ? Quaternion.LookRotation(MixedRealityToolkit.CameraSystem.CameraRig.CameraTransform.position - desiredPos)
+                        : Quaternion.identity;
                     break;
                 case SolverOrientationType.FollowTrackedObject:
-                    desiredRot = SolverHandler.TransformTarget != null ? SolverHandler.TransformTarget.rotation : Quaternion.identity;
+                    desiredRot = SolverHandler.TransformTarget != null
+                        ? SolverHandler.TransformTarget.rotation
+                        : Quaternion.identity;
                     break;
                 default:
                     Debug.LogError($"Invalid OrientationType for Orbital Solver on {gameObject.name}");

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using XRTK.Definitions.Utilities;
 using XRTK.Services;
-using XRTK.Utilities;
 
 namespace XRTK.SDK.Utilities.Solvers
 {
@@ -121,7 +121,7 @@ namespace XRTK.SDK.Utilities.Solvers
 
         private bool RequiresOffset => !AdditionalOffset.sqrMagnitude.Equals(0) || !AdditionalRotation.sqrMagnitude.Equals(0);
 
-        protected readonly List<Solver> solvers = new List<Solver>();
+        private readonly List<Solver> solvers = new List<Solver>();
 
         private float lastUpdateTime;
         private GameObject transformWithOffset;
@@ -210,12 +210,12 @@ namespace XRTK.SDK.Utilities.Solvers
 
         protected virtual void AttachToNewTrackedObject()
         {
+            Handedness = Handedness.None;
+
             switch (TrackedObjectToReference)
             {
                 case TrackedObjectType.Head:
-                    // No need to search for a controller if we've already attached to the head.
-                    Handedness = Handedness.None;
-                    TrackTransform(CameraCache.Main.transform);
+                    TrackTransform(MixedRealityToolkit.CameraSystem.CameraRig.CameraTransform);
                     break;
                 case TrackedObjectType.LeftHandOrController:
                     Handedness = Handedness.Left;
@@ -224,9 +224,13 @@ namespace XRTK.SDK.Utilities.Solvers
                     Handedness = Handedness.Right;
                     break;
                 case TrackedObjectType.Body:
-                    Handedness = Handedness.None;
+                    TrackTransform(MixedRealityToolkit.CameraSystem.CameraRig.BodyTransform);
+                    break;
+                case TrackedObjectType.Playspace:
                     TrackTransform(MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform);
                     break;
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
 
@@ -245,7 +249,7 @@ namespace XRTK.SDK.Utilities.Solvers
 
             transformWithOffset.transform.localPosition = Vector3.Scale(AdditionalOffset, transformWithOffset.transform.localScale);
             transformWithOffset.transform.localRotation = Quaternion.Euler(AdditionalRotation);
-            transformWithOffset.name = $"{gameObject.name} on {TrackedObjectToReference.ToString()} with offset {AdditionalOffset}, {AdditionalRotation}";
+            transformWithOffset.name = $"SolverOffset_{gameObject.name}_{TrackedObjectToReference.ToString()}";
             return transformWithOffset.transform;
         }
     }

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using XRTK.Definitions.Utilities;
+using XRTK.Services;
 using XRTK.Utilities;
 
 namespace XRTK.SDK.Utilities.Solvers
@@ -216,11 +217,15 @@ namespace XRTK.SDK.Utilities.Solvers
                     Handedness = Handedness.None;
                     TrackTransform(CameraCache.Main.transform);
                     break;
-                case TrackedObjectType.MotionControllerLeft:
+                case TrackedObjectType.LeftHandOrController:
                     Handedness = Handedness.Left;
                     break;
-                case TrackedObjectType.MotionControllerRight:
+                case TrackedObjectType.RightHandOrController:
                     Handedness = Handedness.Right;
+                    break;
+                case TrackedObjectType.Body:
+                    Handedness = Handedness.None;
+                    TrackTransform(MixedRealityToolkit.Instance.MixedRealityPlayspace);
                     break;
             }
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Solvers/SolverHandler.cs
@@ -225,7 +225,7 @@ namespace XRTK.SDK.Utilities.Solvers
                     break;
                 case TrackedObjectType.Body:
                     Handedness = Handedness.None;
-                    TrackTransform(MixedRealityToolkit.Instance.MixedRealityPlayspace);
+                    TrackTransform(MixedRealityToolkit.CameraSystem.CameraRig.PlayspaceTransform);
                     break;
             }
         }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

After updating the solvers in the last PR I did, I realized that I didn't actually make the solvers body locked but playspace locked. This PR aims to correct the body locking features by extending the `IMixedRealityCameraSystem` to include options for a `IMixedRealityCameraRig` that can be implemented on a `MonoBehavior` and used to reference the camera rig components and transforms.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

Brief list of the targeted features that are being changed.

- Fixes: Body Locked/Playspace Locked behavior in the solver system.

## Breaking Changes:

- Added a few new component types to the `IMixedRealityCameraSystem`:
  - `IMixedRealityCameraRig` which keeps track of the playspace, camera, and body transforms.
  - `MixedRealityCameraProfile` now has two additional configuration options:
    - `CameraRigType` to specify the concrete type of `IMixedRealityCameraRig` to use
    - `bodyAdjustmentAngle` to turn the player's body when the angle between the head and body has reached this threshold.
- Updated `TrackedObjectType` to include `Playspace`
- Updated `SolverHandler` to properly setup and track the `Body` and `Playspace` tracked objects