### PR TITLE
Also checks if an xr device is present for stereoscopic check

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -52,7 +52,7 @@ namespace XRTK.Services.CameraSystem
         }
 
         /// <inheritdoc />
-        public bool IsStereoscopic => UnityEngine.XR.XRSettings.enabled;
+        public bool IsStereoscopic => UnityEngine.XR.XRSettings.enabled && UnityEngine.XR.XRDevice.isPresent;
 
         /// <inheritdoc />
         public IMixedRealityCameraRig CameraRig { get; private set; }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Added `XR.XRDevice.isPresent` to the `IMixedRealityCameraSystem.IsStereoscopic` check.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)
