### PR TITLE
broke out the changes from the diagnostics PR

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using UnityEngine;
@@ -12,7 +12,7 @@ namespace XRTK.Definitions
     {
         [SerializeField]
         [Tooltip("Currently registered IMixedRealityDataProvider configurations for this extension service.")]
-        private DataModelConfiguration[] registeredDataProviders = null;
+        private DataModelConfiguration[] registeredDataProviders = new DataModelConfiguration[0];
 
         /// <summary>
         /// Currently registered <see cref="Interfaces.IMixedRealityDataProvider"/> configurations for this extension service.
@@ -20,7 +20,7 @@ namespace XRTK.Definitions
         public DataModelConfiguration[] RegisteredDataProviders
         {
             get => registeredDataProviders;
-            set => registeredDataProviders = value;
+            internal set => registeredDataProviders = value;
         }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/NetworkingSystem/MixedRealityNetworkSystemProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/NetworkingSystem/MixedRealityNetworkSystemProfile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
@@ -13,7 +13,7 @@ namespace XRTK.Definitions.NetworkingSystem
     public class MixedRealityNetworkSystemProfile : BaseMixedRealityProfile
     {
         [SerializeField]
-        private NetworkDataProviderConfiguration[] registeredNetworkDataProviders = null;
+        private NetworkDataProviderConfiguration[] registeredNetworkDataProviders = new NetworkDataProviderConfiguration[0];
 
         /// <summary>
         /// The list of registered network data providers.

--- a/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/BaseInputEventData.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/EventDatum/Input/BaseInputEventData.cs
@@ -44,7 +44,7 @@ namespace XRTK.EventDatum.Input
         {
             if (eventSystem == null)
             {
-                throw new Exception("Event system cannot be null!");
+                throw new Exception($"{nameof(EventSystem)} cannot be null!");
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/EnumerableExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/EnumerableExtensions.cs
@@ -17,7 +17,7 @@ namespace XRTK.Extensions
         /// <returns>Max or default value of T</returns>
         public static T MaxOrDefault<T>(this IEnumerable<T> items, IComparer<T> comparer = null)
         {
-            if (items == null) { throw new ArgumentNullException("items"); }
+            if (items == null) { throw new ArgumentNullException(nameof(items)); }
             comparer = comparer ?? Comparer<T>.Default;
 
             using (var enumerator = items.GetEnumerator())

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/EventSystem/IMixedRealityEventSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/EventSystem/IMixedRealityEventSystem.cs
@@ -15,7 +15,7 @@ namespace XRTK.Interfaces.Events
         /// <summary>
         /// List of event listeners that are registered to this Event System.
         /// </summary>
-        List<GameObject> EventListeners { get; }
+        IReadOnlyList<GameObject> EventListeners { get; }
 
         /// <summary>
         /// The main function for handling and forwarding all events to their intended recipients.

--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/IMixedRealityService.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/IMixedRealityService.cs
@@ -16,7 +16,7 @@ namespace XRTK.Interfaces
         string Name { get; }
 
         /// <summary>
-        /// Optional Priority to reorder registered managers based on their respective priority, reduces the risk of race conditions by prioritizing the order in which managers are evaluated.
+        /// Optional Priority to reorder registered managers based on their respective priority, reduces the risk of race conditions by prioritizing the order in which services are evaluated.
         /// </summary>
         uint Priority { get; }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/BaseEventSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/BaseEventSystem.cs
@@ -29,8 +29,10 @@ namespace XRTK.Services
 
         private static int eventExecutionDepth = 0;
 
+        private readonly List<GameObject> eventListeners = new List<GameObject>();
+
         /// <inheritdoc />
-        public List<GameObject> EventListeners { get; } = new List<GameObject>();
+        public IReadOnlyList<GameObject> EventListeners => eventListeners;
 
         /// <inheritdoc />
         public virtual void HandleEvent<T>(BaseEventData eventData, ExecuteEvents.EventFunction<T> eventHandler) where T : IEventSystemHandler
@@ -49,7 +51,7 @@ namespace XRTK.Services
         /// <inheritdoc />
         public virtual async void Register(GameObject listener)
         {
-            if (EventListeners.Contains(listener)) { return; }
+            if (eventListeners.Contains(listener)) { return; }
 
             if (eventExecutionDepth > 0)
             {
@@ -64,13 +66,13 @@ namespace XRTK.Services
                 }
             }
 
-            EventListeners.Add(listener);
+            eventListeners.Add(listener);
         }
 
         /// <inheritdoc />
         public virtual async void Unregister(GameObject listener)
         {
-            if (!EventListeners.Contains(listener)) { return; }
+            if (!eventListeners.Contains(listener)) { return; }
 
             if (eventExecutionDepth > 0)
             {
@@ -85,7 +87,7 @@ namespace XRTK.Services
                 }
             }
 
-            EventListeners.Remove(listener);
+            eventListeners.Remove(listener);
         }
 
         #endregion IMixedRealityEventSystem Implementation

--- a/XRTK-Core/Packages/com.xrtk.core/Services/BaseServiceWithConstructor.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/BaseServiceWithConstructor.cs
@@ -13,9 +13,9 @@ namespace XRTK.Services
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public BaseServiceWithConstructor(string name = "", uint priority = 10)
+        /// <param name="name">The name of the service.</param>
+        /// <param name="priority">The priority of the service.</param>
+        protected BaseServiceWithConstructor(string name = "", uint priority = 10)
         {
             if (string.IsNullOrWhiteSpace(name))
             {

--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
@@ -131,6 +131,7 @@ namespace XRTK.Services
 
         #region Mixed Reality runtime service registry
 
+        // ReSharper disable once InconsistentNaming
         private static readonly Dictionary<Type, IMixedRealityService> activeSystems = new Dictionary<Type, IMixedRealityService>();
 
         /// <summary>
@@ -141,6 +142,7 @@ namespace XRTK.Services
         /// </remarks>
         public static IReadOnlyDictionary<Type, IMixedRealityService> ActiveSystems => activeSystems;
 
+        // ReSharper disable once InconsistentNaming
         private static readonly List<Tuple<Type, IMixedRealityService>> registeredMixedRealityServices = new List<Tuple<Type, IMixedRealityService>>();
 
         /// <summary>
@@ -204,7 +206,7 @@ namespace XRTK.Services
                     return null;
                 }
 
-                if (!isApplicationQuitting)
+                if (!IsApplicationQuitting)
                 {
                     // Setup any additional things the instance needs.
                     newInstance.InitializeInstance();
@@ -247,7 +249,7 @@ namespace XRTK.Services
                     DontDestroyOnLoad(instance.transform.root);
                 }
 
-                Application.quitting += () => isApplicationQuitting = true;
+                Application.quitting += () => IsApplicationQuitting = true;
 
 #if UNITY_EDITOR
                 UnityEditor.EditorApplication.hierarchyChanged += OnHierarchyChanged;
@@ -267,7 +269,7 @@ namespace XRTK.Services
                     if (playModeState == UnityEditor.PlayModeStateChange.ExitingEditMode ||
                         playModeState == UnityEditor.PlayModeStateChange.EnteredEditMode)
                     {
-                        isApplicationQuitting = false;
+                        IsApplicationQuitting = false;
                     }
 
                     if (activeProfile == null &&
@@ -296,12 +298,10 @@ namespace XRTK.Services
 
         private static bool isInitializing = false;
 
-        private static bool isApplicationQuitting = false;
-
         /// <summary>
         /// Flag stating if the application is currently attempting to quit.
         /// </summary>
-        public static bool IsApplicationQuitting => isApplicationQuitting;
+        public static bool IsApplicationQuitting { get; private set; } = false;
 
         /// <summary>
         /// Expose an assertion whether the MixedRealityToolkit class is initialized.
@@ -384,26 +384,23 @@ namespace XRTK.Services
                 {
                     if (CreateAndRegisterService<IMixedRealityFocusProvider>(ActiveProfile.InputSystemProfile.FocusProviderType))
                     {
-                        if (ActiveProfile.InputSystemProfile.ControllerDataProvidersProfile != null)
+                        foreach (var controllerDataProvider in ActiveProfile.InputSystemProfile.ControllerDataProvidersProfile.RegisteredControllerDataProviders)
                         {
-                            foreach (var controllerDataProvider in ActiveProfile.InputSystemProfile.ControllerDataProvidersProfile.RegisteredControllerDataProviders)
+                            //If the DataProvider cannot be resolved, this is likely just a configuration / package missmatch.  User simply needs to be warned, not errored.
+                            if (controllerDataProvider.DataProviderType.Type == null)
                             {
-                                //If the DataProvider cannot be resolved, this is likely just a configuration / package missmatch.  User simply needs to be warned, not errored.
-                                if (controllerDataProvider.DataProviderType.Type == null)
-                                {
-                                    Debug.LogWarning($"Could not load the configured provider ({controllerDataProvider.DataProviderName})\n\nThis is most likely because the XRTK UPM package for that provider is currently not registered\nCheck the installed packages in the Unity Package Manager\n\n");
-                                    continue;
-                                }
+                                Debug.LogWarning($"Could not load the configured provider ({controllerDataProvider.DataProviderName})\n\nThis is most likely because the XRTK UPM package for that provider is currently not registered\nCheck the installed packages in the Unity Package Manager\n\n");
+                                continue;
+                            }
 
-                                if (!CreateAndRegisterService<IMixedRealityControllerDataProvider>(
-                                    controllerDataProvider.DataProviderType,
-                                    controllerDataProvider.RuntimePlatform,
-                                    controllerDataProvider.DataProviderName,
-                                    controllerDataProvider.Priority,
-                                    controllerDataProvider.Profile))
-                                {
-                                    Debug.LogError($"Failed to start {controllerDataProvider.DataProviderName}!");
-                                }
+                            if (!CreateAndRegisterService<IMixedRealityControllerDataProvider>(
+                                controllerDataProvider.DataProviderType,
+                                controllerDataProvider.RuntimePlatform,
+                                controllerDataProvider.DataProviderName,
+                                controllerDataProvider.Priority,
+                                controllerDataProvider.Profile))
+                            {
+                                Debug.LogError($"Failed to start {controllerDataProvider.DataProviderName}!");
                             }
                         }
                     }
@@ -442,19 +439,16 @@ namespace XRTK.Services
 #endif
                 if (CreateAndRegisterService<IMixedRealitySpatialAwarenessSystem>(ActiveProfile.SpatialAwarenessSystemSystemType, ActiveProfile.SpatialAwarenessProfile) && SpatialAwarenessSystem != null)
                 {
-                    if (ActiveProfile.SpatialAwarenessProfile.RegisteredSpatialObserverDataProviders != null)
+                    foreach (var spatialObserver in ActiveProfile.SpatialAwarenessProfile.RegisteredSpatialObserverDataProviders)
                     {
-                        foreach (var spatialObserver in ActiveProfile.SpatialAwarenessProfile.RegisteredSpatialObserverDataProviders)
+                        if (!CreateAndRegisterService<IMixedRealitySpatialObserverDataProvider>(
+                            spatialObserver.SpatialObserverType,
+                            spatialObserver.RuntimePlatform,
+                            spatialObserver.SpatialObserverName,
+                            spatialObserver.Priority,
+                            spatialObserver.Profile))
                         {
-                            if (!CreateAndRegisterService<IMixedRealitySpatialObserverDataProvider>(
-                                spatialObserver.SpatialObserverType,
-                                spatialObserver.RuntimePlatform,
-                                spatialObserver.SpatialObserverName,
-                                spatialObserver.Priority,
-                                spatialObserver.Profile))
-                            {
-                                Debug.LogError($"Failed to start {spatialObserver.SpatialObserverName}!");
-                            }
+                            Debug.LogError($"Failed to start {spatialObserver.SpatialObserverName}!");
                         }
                     }
                 }
@@ -486,19 +480,16 @@ namespace XRTK.Services
             {
                 if (CreateAndRegisterService<IMixedRealityNetworkingSystem>(ActiveProfile.NetworkingSystemSystemType, ActiveProfile.NetworkingSystemProfile) && NetworkingSystem != null)
                 {
-                    if (ActiveProfile.NetworkingSystemProfile.RegisteredNetworkDataProviders != null)
+                    foreach (var networkProvider in ActiveProfile.NetworkingSystemProfile.RegisteredNetworkDataProviders)
                     {
-                        foreach (var networkProvider in ActiveProfile.NetworkingSystemProfile.RegisteredNetworkDataProviders)
+                        if (!CreateAndRegisterService<IMixedRealityNetworkDataProvider>(
+                            networkProvider.DataProviderType,
+                            networkProvider.RuntimePlatform,
+                            networkProvider.DataProviderName,
+                            networkProvider.Priority,
+                            networkProvider.Profile))
                         {
-                            if (!CreateAndRegisterService<IMixedRealityNetworkDataProvider>(
-                                networkProvider.DataProviderType,
-                                networkProvider.RuntimePlatform,
-                                networkProvider.DataProviderName,
-                                networkProvider.Priority,
-                                networkProvider.Profile))
-                            {
-                                Debug.LogError($"Failed to start {networkProvider.DataProviderName}!");
-                            }
+                            Debug.LogError($"Failed to start {networkProvider.DataProviderName}!");
                         }
                     }
                 }
@@ -795,7 +786,7 @@ namespace XRTK.Services
         /// <returns>True, if the service was successfully created and registered.</returns>
         public static bool CreateAndRegisterService<T>(Type concreteType, SupportedPlatforms supportedPlatforms, params object[] args) where T : IMixedRealityService
         {
-            if (isApplicationQuitting)
+            if (IsApplicationQuitting)
             {
                 return false;
             }
@@ -1680,7 +1671,7 @@ namespace XRTK.Services
         /// <returns></returns>
         private static bool CanGetService(Type interfaceType, string serviceName)
         {
-            if (isApplicationQuitting)
+            if (IsApplicationQuitting)
             {
                 return false;
             }
@@ -1716,7 +1707,7 @@ namespace XRTK.Services
             get
             {
                 if (!IsInitialized ||
-                    isApplicationQuitting ||
+                    IsApplicationQuitting ||
                     instance.activeProfile == null ||
                     (instance.activeProfile != null && !instance.activeProfile.IsCameraSystemEnabled))
                 {
@@ -1748,7 +1739,7 @@ namespace XRTK.Services
             get
             {
                 if (!IsInitialized ||
-                    isApplicationQuitting ||
+                    IsApplicationQuitting ||
                     instance.activeProfile == null ||
                     (instance.activeProfile != null && !instance.activeProfile.IsInputSystemEnabled))
                 {
@@ -1780,7 +1771,7 @@ namespace XRTK.Services
             get
             {
                 if (!IsInitialized ||
-                    isApplicationQuitting ||
+                    IsApplicationQuitting ||
                     instance.activeProfile == null ||
                     (instance.activeProfile != null && !instance.activeProfile.IsBoundarySystemEnabled))
                 {
@@ -1812,7 +1803,7 @@ namespace XRTK.Services
             get
             {
                 if (!IsInitialized ||
-                    isApplicationQuitting ||
+                    IsApplicationQuitting ||
                     instance.activeProfile == null ||
                     (instance.activeProfile != null && !instance.activeProfile.IsSpatialAwarenessSystemEnabled))
                 {
@@ -1844,7 +1835,7 @@ namespace XRTK.Services
             get
             {
                 if (!IsInitialized ||
-                    isApplicationQuitting ||
+                    IsApplicationQuitting ||
                     instance.activeProfile == null ||
                     (instance.activeProfile != null && !instance.activeProfile.IsTeleportSystemEnabled))
                 {
@@ -1876,7 +1867,7 @@ namespace XRTK.Services
             get
             {
                 if (!IsInitialized ||
-                    isApplicationQuitting ||
+                    IsApplicationQuitting ||
                     instance.activeProfile == null ||
                     (instance.activeProfile != null && !instance.activeProfile.IsNetworkingSystemEnabled))
                 {
@@ -1908,7 +1899,7 @@ namespace XRTK.Services
             get
             {
                 if (!IsInitialized ||
-                    isApplicationQuitting ||
+                    IsApplicationQuitting ||
                     instance.activeProfile == null ||
                     (instance.activeProfile != null && !instance.activeProfile.IsDiagnosticsSystemEnabled))
                 {

--- a/XRTK-Core/Packages/com.xrtk.core/package.json
+++ b/XRTK-Core/Packages/com.xrtk.core/package.json
@@ -10,7 +10,7 @@
     "Mixed Reality",
     "DI"
   ],
-  "version": "0.1.27",
+  "version": "0.1.28",
   "unity": "2019.1",
   "license": "MIT",
   "author": "XRTK Team (https://github.com/XRTK)",


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Broke out a few of the braking changes from the Diagnostics PR.

Mainly this is just a cleanup pass.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

Some of the biggest changes:

- Updated the `MixedRealityToolkit` service registration to no longer check if a profile is null, as these services require the profiles they're checking. (in fact the `IsServiceEnabled` flag is typically bundled with this profile null check anyway.)
- updated a few of the headers to be XRTK as they're probably nothing like the MRTK counterpart.
- Misc formatting and style changes.
  - naming
  - accessors

## Breaking Changes:

Are there any breaking changes included in this change that would prevent or cause issue for existing projects.

- `IMixedRealityBaseEventSystem.EventListeners` is now a readonly type: `IReadonlyList<GameObject>`
