### PR TITLE
Fixed diagnostics data provider memory limit reporting

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Services/DiagnosticsSystem/MixedRealityMemoryDiagnosticsDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/DiagnosticsSystem/MixedRealityMemoryDiagnosticsDataProvider.cs
@@ -22,7 +22,6 @@ namespace XRTK.Services.DiagnosticsSystem
         {
         }
 
-        private ulong lastSystemMemorySize;
         private ulong lastMemoryUsage;
         private ulong peakMemoryUsage;
         private ulong lastMemoryLimit;
@@ -36,16 +35,12 @@ namespace XRTK.Services.DiagnosticsSystem
 
             var systemMemorySize = (ulong)Profiler.GetTotalReservedMemoryLong();
 
-            if (lastSystemMemorySize != systemMemorySize)
+            if (lastMemoryUsage != systemMemorySize)
             {
-                lastSystemMemorySize = systemMemorySize;
-
-                var currentMemoryLimit = lastSystemMemorySize;
-
-                if (currentMemoryLimit != lastMemoryLimit)
+                if (systemMemorySize > lastMemoryLimit)
                 {
-                    MixedRealityToolkit.DiagnosticsSystem.RaiseMemoryLimitChanged(new MemoryLimit(currentMemoryLimit));
-                    lastMemoryLimit = currentMemoryLimit;
+                    MixedRealityToolkit.DiagnosticsSystem.RaiseMemoryLimitChanged(new MemoryLimit(systemMemorySize));
+                    lastMemoryLimit = systemMemorySize;
                 }
             }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/DiagnosticsSystem/MixedRealityMemoryDiagnosticsDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/DiagnosticsSystem/MixedRealityMemoryDiagnosticsDataProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using UnityEngine;
 using UnityEngine.Profiling;
 using XRTK.Definitions.DiagnosticsSystem;
 
@@ -23,8 +22,7 @@ namespace XRTK.Services.DiagnosticsSystem
         {
         }
 
-        private int systemMemorySize;
-        private int lastSystemMemorySize;
+        private ulong lastSystemMemorySize;
         private ulong lastMemoryUsage;
         private ulong peakMemoryUsage;
         private ulong lastMemoryLimit;
@@ -36,13 +34,13 @@ namespace XRTK.Services.DiagnosticsSystem
         {
             base.LateUpdate();
 
-            systemMemorySize = SystemInfo.systemMemorySize;
+            var systemMemorySize = (ulong)Profiler.GetTotalReservedMemoryLong();
 
             if (lastSystemMemorySize != systemMemorySize)
             {
                 lastSystemMemorySize = systemMemorySize;
 
-                var currentMemoryLimit = DiagnosticsUtils.ConvertMegabytesToBytes(lastSystemMemorySize);
+                var currentMemoryLimit = lastSystemMemorySize;
 
                 if (currentMemoryLimit != lastMemoryLimit)
                 {


### PR DESCRIPTION
XRTK - Mixed Reality Toolkit Change Request

## Overview

Fixed the issue with the diagnostics data provider not reporting the correct memory limit

## Changes

- Fixes: #437 