### PR TITLE
Pull BaseController methods to interface

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/Providers/Controllers/IMixedRealityController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/Providers/Controllers/IMixedRealityController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using XRTK.Definitions.Devices;
 using XRTK.Definitions.Utilities;
 using XRTK.Interfaces.InputSystem;
@@ -64,5 +65,20 @@ namespace XRTK.Interfaces.Providers.Controllers
         /// Mapping definition for this controller, linking the Physical inputs to logical Input System Actions
         /// </summary>
         MixedRealityInteractionMapping[] Interactions { get; }
+
+        /// <summary>
+        /// Setups up the configuration based on the Mixed Reality Controller Mapping Profile.
+        /// </summary>
+        /// <param name="controllerType">The type of the controller.</param>
+        bool SetupConfiguration(Type controllerType);
+
+        /// <summary>
+        /// Attempts to load the controller model render settings from the <see cref="Definitions.Controllers.MixedRealityControllerVisualizationProfile"/>
+        /// to render the controllers in the scene.
+        /// </summary>
+        /// <param name="controllerType">The controller type.</param>
+        /// <param name="glbData">The raw binary glb data of the controller model, typically loaded from the driver.</param>
+        /// <returns>True, if controller model is being properly rendered.</returns>
+        void TryRenderControllerModel(Type controllerType, byte[] glbData = null);
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseController.cs
@@ -174,7 +174,7 @@ namespace XRTK.Providers.Controllers
         /// <param name="controllerType">The controller type.</param>
         /// <param name="glbData">The raw binary glb data of the controller model, typically loaded from the driver.</param>
         /// <returns>True, if controller model is being properly rendered.</returns>
-        internal async void TryRenderControllerModel(Type controllerType, byte[] glbData = null) => await TryRenderControllerModelAsync(controllerType, glbData);
+        public async void TryRenderControllerModel(Type controllerType, byte[] glbData = null) => await TryRenderControllerModelAsync(controllerType, glbData);
 
         /// <summary>
         /// Attempts to load the controller model render settings from the <see cref="MixedRealityControllerVisualizationProfile"/>


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Pulling `SetupConfiguration` and `TryRenderControllerModel` into `IMixedRealityController` since those two have proven to be needed in the interface when working with different kinds of controllers.

## Target of the change:
- Core
