### PR TITLE
Pull UpdateController to interface

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/Providers/Controllers/IMixedRealityController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/Providers/Controllers/IMixedRealityController.cs
@@ -80,5 +80,10 @@ namespace XRTK.Interfaces.Providers.Controllers
         /// <param name="glbData">The raw binary glb data of the controller model, typically loaded from the driver.</param>
         /// <returns>True, if controller model is being properly rendered.</returns>
         void TryRenderControllerModel(Type controllerType, byte[] glbData = null);
+
+        /// <summary>
+        /// Updates the controller's state.
+        /// </summary>
+        void UpdateController();
     }
 }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Forgot to pull `UpdateController` to `IMixedRealityController` interface as well in previous PR. `UpdateController` is used to update a controllers state and implemented in `BaseControlller`. Usually overriden to add platform specifics if needed.

## Target of the change:

- Core

## Changes:

- Pulled `UpdateController` to `IMixedRealityController` interface
