### PR TITLE
Fix copy paste error in windows api checker

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/WindowsApiChecker.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/WindowsApiChecker.cs
@@ -16,8 +16,8 @@ namespace XRTK.Utilities
         public static void CheckApiContracts()
         {
 #if WINDOWS_UWP
-            UniversalApiContractV6_IsAvailable = Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8);
-            UniversalApiContractV6_IsAvailable = Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7);
+            UniversalApiContractV8_IsAvailable = Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8);
+            UniversalApiContractV7_IsAvailable = Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7);
             UniversalApiContractV6_IsAvailable = Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 6);
             UniversalApiContractV5_IsAvailable = Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 5);
             UniversalApiContractV4_IsAvailable = Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 4);


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Fixes a copy paste error in the `WindowsApiChecker` which led to API v7 and v8 always being `false`

## Target of the change:

Is this enhancement for:

- Core