### PR TITLE
Add a utility to draw a capsure wire gizmo

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -211,6 +211,54 @@ namespace XRTK.Inspectors.Utilities
 
         #endregion Utilities
 
+        #region Gizmos
+
+        /// <summary>
+        /// Renders a capsule wire gizmo.
+        /// </summary>
+        /// <param name="position">Center position of the capsule.</param>
+        /// <param name="rotation">Center rotation of the capsule.</param>
+        /// <param name="radius">Capsule radius.</param>
+        /// <param name="height">Capsule height.</param>
+        /// <param name="color">Optional color override, will use <see cref="Gizmos.color"/> by default.</param>
+        public static void DrawWireCapsule(Vector3 position, Quaternion rotation, float radius, float height, Color color = default)
+        {
+            if (color != default)
+            {
+                Handles.color = color;
+            }
+            else
+            {
+                Handles.color = Gizmos.color;
+            }
+
+            Matrix4x4 angleMatrix = Matrix4x4.TRS(position, rotation, Handles.matrix.lossyScale);
+
+            using (new Handles.DrawingScope(angleMatrix))
+            {
+                var pointOffset = (height - (radius * 2)) / 2;
+
+                // Draw sideways
+                Handles.DrawWireArc(Vector3.up * pointOffset, Vector3.left, Vector3.back, -180, radius);
+                Handles.DrawLine(new Vector3(0, pointOffset, -radius), new Vector3(0, -pointOffset, -radius));
+                Handles.DrawLine(new Vector3(0, pointOffset, radius), new Vector3(0, -pointOffset, radius));
+                Handles.DrawWireArc(Vector3.down * pointOffset, Vector3.left, Vector3.back, 180, radius);
+
+                // Draw frontways
+                Handles.DrawWireArc(Vector3.up * pointOffset, Vector3.back, Vector3.left, 180, radius);
+                Handles.DrawLine(new Vector3(-radius, pointOffset, 0), new Vector3(-radius, -pointOffset, 0));
+                Handles.DrawLine(new Vector3(radius, pointOffset, 0), new Vector3(radius, -pointOffset, 0));
+                Handles.DrawWireArc(Vector3.down * pointOffset, Vector3.back, Vector3.left, -180, radius);
+
+                // Draw center
+                Handles.DrawWireDisc(Vector3.up * pointOffset, Vector3.up, radius);
+                Handles.DrawWireDisc(Vector3.down * pointOffset, Vector3.up, radius);
+
+            }
+        }
+
+        #endregion
+
         #region Colors
 
         public static readonly Color DisabledColor = new Color(0.6f, 0.6f, 0.6f);


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Adds a simple utility to draw a capsule wire gizmo as seen when working with capsule colliders.