### PR TITLE
Added a remark to the ArrayExtensions ArrayInitialise function

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/ArrayExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/ArrayExtensions.cs
@@ -59,6 +59,7 @@ namespace XRTK.Extensions
         /// <param name="array">The array to initialise</param>
         /// <param name="newItem">The default item to set all the array items to</param>
         /// <returns></returns>
+        /// <remarks>Please note, this extension should only be used with value types such as structs.  Reference types should not be used.</remarks>
         public static T[] InitialiseArray<T>(this T[] array, T newItem)
         {
             // Initialise the array if it is null


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Added a remark to the ArrayExtensions ArrayInitialise function, to ensure devs are aware to only use value types, such as structs.  Reference types will have adverse effects if used incorrectly.

