### PR TITLE
Fixes to correctly filter for nested services/data providers in the new configuraitons inspector

### DIFF
--- a/XRTK-Core/Assets/XRTK.Tests/Services/ITestDataProvider1.cs
+++ b/XRTK-Core/Assets/XRTK.Tests/Services/ITestDataProvider1.cs
@@ -5,7 +5,7 @@ using XRTK.Interfaces;
 
 namespace XRTK.Tests.Services
 {
-    internal interface ITestDataProvider1 : IMixedRealityDataProvider, ITestService
+    internal interface ITestDataProvider1 : IMixedRealityDataProvider
     {
     }
 }

--- a/XRTK-Core/Assets/XRTK.Tests/Services/ITestExtensionServiceProvider1.cs
+++ b/XRTK-Core/Assets/XRTK.Tests/Services/ITestExtensionServiceProvider1.cs
@@ -3,5 +3,5 @@
 
 namespace XRTK.Tests.Services
 {
-    internal interface ITestExtensionServiceProvider1 : ITestDataProvider1, ITestExtensionService1 { }
+    internal interface ITestExtensionServiceProvider1 : ITestDataProvider1 { }
 }

--- a/XRTK-Core/Assets/XRTK.Tests/Services/ITestExtensionServiceProvider1.cs
+++ b/XRTK-Core/Assets/XRTK.Tests/Services/ITestExtensionServiceProvider1.cs
@@ -3,5 +3,5 @@
 
 namespace XRTK.Tests.Services
 {
-    internal interface ITestExtensionServiceProvider1 : ITestDataProvider1 { }
+    internal interface ITestExtensionServiceProvider1 : ITestService { }
 }

--- a/XRTK-Core/Assets/XRTK.Tests/Services/TestExtensionService1.cs
+++ b/XRTK-Core/Assets/XRTK.Tests/Services/TestExtensionService1.cs
@@ -8,7 +8,7 @@ namespace XRTK.Tests.Services
 {
     internal class TestExtensionService1 : BaseExtensionService, ITestExtensionService1
     {
-        public TestExtensionService1(string name, uint priority = 10, MixedRealityRegisteredServiceProvidersProfile profile = null) : base(name, priority, profile) { }
+        public TestExtensionService1(string name, uint priority = 10, BaseMixedRealityExtensionServiceProfile profile = null) : base(name, priority, profile) { }
 
         public bool IsEnabled { get; private set; }
 

--- a/XRTK-Core/Assets/XRTK.Tests/Services/TestExtensionServiceProvider1.cs
+++ b/XRTK-Core/Assets/XRTK.Tests/Services/TestExtensionServiceProvider1.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using XRTK.Definitions;
+using XRTK.Services;
 
 namespace XRTK.Tests.Services
 {
-    internal class TestExtensionServiceProvider1 : TestExtensionService1, ITestExtensionServiceProvider1
+    internal class TestExtensionServiceProvider1 : BaseDataProvider, ITestExtensionServiceProvider1
     {
-        public TestExtensionServiceProvider1(string name, uint priority = 10, MixedRealityRegisteredServiceProvidersProfile profile = null) : base(name, priority, profile)
+        public TestExtensionServiceProvider1(string name, uint priority = 10, BaseMixedRealityExtensionDataProviderProfile profile = null) : base(name, priority)
         {
         }
     }

--- a/XRTK-Core/Assets/XRTK.Tests/Services/TestExtensionServiceProvider1.cs
+++ b/XRTK-Core/Assets/XRTK.Tests/Services/TestExtensionServiceProvider1.cs
@@ -11,5 +11,21 @@ namespace XRTK.Tests.Services
         public TestExtensionServiceProvider1(string name, uint priority = 10, BaseMixedRealityExtensionDataProviderProfile profile = null) : base(name, priority)
         {
         }
+
+        public bool IsEnabled { get; private set; }
+
+        public override void Enable()
+        {
+            base.Enable();
+
+            IsEnabled = true;
+        }
+
+        public override void Disable()
+        {
+            base.Disable();
+
+            IsEnabled = false;
+        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using XRTK.Interfaces;
+
 namespace XRTK.Definitions
 {
     public abstract class BaseMixedRealityExtensionServiceProfile : BaseMixedRealityServiceProfile<IMixedRealityExtensionService>

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace XRTK.Definitions
+{
+    public abstract class BaseMixedRealityExtensionServiceProfile : BaseMixedRealityProfile
+    {
+
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs
@@ -5,7 +5,7 @@ using XRTK.Interfaces;
 
 namespace XRTK.Definitions
 {
-    public abstract class BaseMixedRealityExtensionServiceProfile : BaseMixedRealityServiceProfile<IMixedRealityExtensionService>
+    public abstract class BaseMixedRealityExtensionServiceProfile : BaseMixedRealityServiceProfile<IMixedRealityService>
     {
 
     }

--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityExtensionServiceProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d8fde0e02be338498bed88b4690f1a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 6e2e9d716bbb4d8382bd53f11996b90e, type: 3}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/TypeExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/TypeExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+using System;
+using UnityEngine;
+
+namespace XRTK.Extensions
+{
+    /// <summary>
+    /// Extension methods for Unity's Vector struct
+    /// </summary>
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Recursively looks for generic type arguments in type hierarchy, starting with the
+        /// root type provided. If no generic type arguments are found on a type, it's base
+        /// type is checked.
+        /// </summary>
+        /// <param name="root">Root type to start looking for generic type arguments at.</param>
+        /// <param name="maxRecursionDepth">The maximum recursion depth until execution gets canceled even if no results found.</param>
+        /// <returns>Found gneneric type arguments array or null, if none found.</returns>
+        public static Type[] FindTopmostGenericTypeArguments(this Type root, int maxRecursionDepth = 5)
+        {
+            Type[] genericTypeArgs = root?.GenericTypeArguments;
+            if (genericTypeArgs != null && genericTypeArgs.Length > 0)
+            {
+                return genericTypeArgs;
+            }
+
+            if (maxRecursionDepth > 0 && root != null)
+            {
+                return FindTopmostGenericTypeArguments(root.BaseType, --maxRecursionDepth);
+            }
+
+            Debug.LogError($"FindTopmostGenericTypeArguments - Maximum recursion depth reached without finding generic type arguments.");
+            return null;
+        }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/TypeExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/TypeExtensions.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace XRTK.Extensions
 {
     /// <summary>
-    /// Extension methods for Unity's Vector struct
+    /// Extension methods for <see cref="Type"/> instances.
     /// </summary>
     public static class TypeExtensions
     {

--- a/XRTK-Core/Packages/com.xrtk.core/Extensions/TypeExtensions.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Extensions/TypeExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb09faddba8df5448a5f1b78744f0acf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityServiceProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityServiceProviderProfileInspector.cs
@@ -21,7 +21,12 @@ namespace XRTK.Inspectors.Profiles
 
         private SerializedProperty configurations;
 
-        protected Type ServiceConstraint { get; private set; } = null;
+        /// <summary>
+        /// Gets the service constraint used to filter options listed in the
+        /// <see cref="configurations"/> instance type dropdown. Set after
+        /// <see cref="OnEnable"/> was called to override.
+        /// </summary>
+        protected Type ServiceConstraint { get; set; } = null;
 
         protected override void OnEnable()
         {

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityServiceProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityServiceProviderProfileInspector.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using XRTK.Definitions;
 using XRTK.Inspectors.PropertyDrawers;
 using XRTK.Services;
+using XRTK.Extensions;
 
 namespace XRTK.Inspectors.Profiles
 {
@@ -30,7 +31,7 @@ namespace XRTK.Inspectors.Profiles
 
             Debug.Assert(configurations != null);
             var baseType = ThisProfile.GetType().BaseType;
-            var genericTypeArgs = baseType?.GenericTypeArguments;
+            var genericTypeArgs = baseType.FindTopmostGenericTypeArguments();
 
             Debug.Assert(genericTypeArgs != null);
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/BaseExtensionService.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/BaseExtensionService.cs
@@ -20,6 +20,6 @@ namespace XRTK.Services
         /// <param name="name"></param>
         /// <param name="priority"></param>
         /// <param name="profile"></param>
-        public BaseExtensionService(string name, uint priority, MixedRealityRegisteredServiceProvidersProfile profile) : base(name, priority) { }
+        public BaseExtensionService(string name, uint priority, BaseMixedRealityExtensionServiceProfile profile) : base(name, priority) { }
     }
 }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

The new configurations inspector depends on generic type args to be found in order to correctly derive the "Instanced Type" selectable values. Currently it will only look for those on the base type of the profile selected, this PR adds a recursive lookup for generic type args to solve that problem.



## Target of the change:

- Core (core framework, interfaces and definitions)