### PR TITLE
Ensure that the detected input sources and detected controller's are readonly from the system

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -32,7 +32,7 @@ namespace XRTK.Interfaces.InputSystem
         /// <summary>
         /// List of the Interaction Input Sources as detected by the input manager like hands or motion controllers.
         /// </summary>
-        HashSet<IMixedRealityInputSource> DetectedInputSources { get; }
+        IReadOnlyCollection<IMixedRealityInputSource> DetectedInputSources { get; }
 
         /// <summary>
         /// List of <see cref="IMixedRealityController"/>s currently detected by the input manager.
@@ -40,7 +40,7 @@ namespace XRTK.Interfaces.InputSystem
         /// <remarks>
         /// This property is similar to <see cref="DetectedInputSources"/>, as this is a subset of those <see cref="IMixedRealityInputSource"/>s in that list.
         /// </remarks>
-        HashSet<IMixedRealityController> DetectedControllers { get; }
+        IReadOnlyCollection<IMixedRealityController> DetectedControllers { get; }
 
         /// <summary>
         /// The current Focus Provider that's been implemented by this Input System.

--- a/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/InputSystem/MixedRealityInputSystem.cs
@@ -51,11 +51,15 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public event Action InputDisabled;
 
-        /// <inheritdoc />
-        public HashSet<IMixedRealityInputSource> DetectedInputSources { get; } = new HashSet<IMixedRealityInputSource>();
+        private readonly HashSet<IMixedRealityInputSource> detectedInputSources = new HashSet<IMixedRealityInputSource>();
 
         /// <inheritdoc />
-        public HashSet<IMixedRealityController> DetectedControllers { get; } = new HashSet<IMixedRealityController>();
+        public IReadOnlyCollection<IMixedRealityInputSource> DetectedInputSources => detectedInputSources;
+
+        private readonly HashSet<IMixedRealityController> detectedControllers = new HashSet<IMixedRealityController>();
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<IMixedRealityController> DetectedControllers => detectedControllers;
 
         private IMixedRealityFocusProvider focusProvider = null;
 
@@ -376,7 +380,7 @@ namespace XRTK.Services.InputSystem
         }
 
         /// <summary>
-        /// Pop disabled input state. When the last disabled state is 
+        /// Pop disabled input state. When the last disabled state is
         /// popped off the stack input will be re-enabled.
         /// </summary>
         public void PopInputDisable()
@@ -485,7 +489,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public bool TryGetController(IMixedRealityInputSource inputSource, out IMixedRealityController controller)
         {
-            foreach (var mixedRealityController in DetectedControllers)
+            foreach (var mixedRealityController in detectedControllers)
             {
                 if (inputSource.SourceId == mixedRealityController.InputSource.SourceId)
                 {
@@ -512,7 +516,7 @@ namespace XRTK.Services.InputSystem
         {
             var newId = (uint)UnityEngine.Random.Range(1, int.MaxValue);
 
-            foreach (var inputSource in DetectedInputSources)
+            foreach (var inputSource in detectedInputSources)
             {
                 if (inputSource.SourceId == newId)
                 {
@@ -534,13 +538,13 @@ namespace XRTK.Services.InputSystem
             // Create input event
             sourceStateEventData.Initialize(source, controller);
 
-            Debug.Assert(!DetectedInputSources.Contains(source), $"{source.SourceName} has already been registered with the Input Manager!");
+            Debug.Assert(!detectedInputSources.Contains(source), $"{source.SourceName} has already been registered with the Input Manager!");
 
-            DetectedInputSources.Add(source);
+            detectedInputSources.Add(source);
 
             if (controller != null)
             {
-                DetectedControllers.Add(controller);
+                detectedControllers.Add(controller);
             }
 
             FocusProvider?.OnSourceDetected(sourceStateEventData);
@@ -562,13 +566,13 @@ namespace XRTK.Services.InputSystem
             // Create input event
             sourceStateEventData.Initialize(source, controller);
 
-            Debug.Assert(DetectedInputSources.Contains(source), $"{source.SourceName} was never registered with the Input Manager!");
+            Debug.Assert(detectedInputSources.Contains(source), $"{source.SourceName} was never registered with the Input Manager!");
 
-            DetectedInputSources.Remove(source);
+            detectedInputSources.Remove(source);
 
             if (controller != null)
             {
-                DetectedControllers.Remove(controller);
+                detectedControllers.Remove(controller);
             }
 
             // Pass handler through HandleEvent to perform modal/fallback logic
@@ -1011,7 +1015,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseOnInputDown(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, true);
 
@@ -1035,7 +1039,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseOnInputPressed(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, true);
 
@@ -1055,7 +1059,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseOnInputPressed(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, float pressAmount)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, pressAmount);
 
@@ -1086,7 +1090,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseOnInputUp(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, false);
 
@@ -1117,7 +1121,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaisePositionInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, float inputPosition)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, inputPosition);
 
@@ -1144,7 +1148,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaisePositionInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, Vector2 inputPosition)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, inputPosition);
 
@@ -1171,7 +1175,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaisePositionInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, Vector3 position)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, position);
 
@@ -1202,7 +1206,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseRotationInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, Quaternion rotation)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, rotation);
 
@@ -1233,7 +1237,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaisePoseInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, MixedRealityPose inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             inputAction = ProcessRules(inputAction, inputData);
 
@@ -1260,7 +1264,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureStarted(IMixedRealityController controller, MixedRealityInputAction action)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
 
             action = ProcessRules(action, true);
             inputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action);
@@ -1277,7 +1281,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureUpdated(IMixedRealityController controller, MixedRealityInputAction action)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, true);
             inputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action);
             HandleEvent(inputEventData, OnGestureUpdated);
@@ -1293,7 +1297,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureUpdated(IMixedRealityController controller, MixedRealityInputAction action, Vector2 inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, inputData);
             vector2InputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action, inputData);
             HandleEvent(vector2InputEventData, OnGestureVector2PositionUpdated);
@@ -1309,7 +1313,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureUpdated(IMixedRealityController controller, MixedRealityInputAction action, Vector3 inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, inputData);
             positionInputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action, inputData);
             HandleEvent(positionInputEventData, OnGesturePositionUpdated);
@@ -1325,7 +1329,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureUpdated(IMixedRealityController controller, MixedRealityInputAction action, Quaternion inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, inputData);
             rotationInputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action, inputData);
             HandleEvent(rotationInputEventData, OnGestureRotationUpdated);
@@ -1341,7 +1345,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureUpdated(IMixedRealityController controller, MixedRealityInputAction action, MixedRealityPose inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, inputData);
             poseInputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action, inputData);
             HandleEvent(poseInputEventData, OnGesturePoseUpdated);
@@ -1357,7 +1361,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureCompleted(IMixedRealityController controller, MixedRealityInputAction action)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, false);
             inputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action);
             HandleEvent(inputEventData, OnGestureCompleted);
@@ -1373,7 +1377,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureCompleted(IMixedRealityController controller, MixedRealityInputAction action, Vector2 inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, inputData);
             vector2InputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action, inputData);
             HandleEvent(vector2InputEventData, OnGestureVector2PositionCompleted);
@@ -1389,7 +1393,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureCompleted(IMixedRealityController controller, MixedRealityInputAction action, Vector3 inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, inputData);
             positionInputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action, inputData);
             HandleEvent(positionInputEventData, OnGesturePositionCompleted);
@@ -1405,7 +1409,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureCompleted(IMixedRealityController controller, MixedRealityInputAction action, Quaternion inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, inputData);
             rotationInputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action, inputData);
             HandleEvent(rotationInputEventData, OnGestureRotationCompleted);
@@ -1421,7 +1425,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureCompleted(IMixedRealityController controller, MixedRealityInputAction action, MixedRealityPose inputData)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, inputData);
             poseInputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action, inputData);
             HandleEvent(poseInputEventData, OnGesturePoseCompleted);
@@ -1437,7 +1441,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseGestureCanceled(IMixedRealityController controller, MixedRealityInputAction action)
         {
-            Debug.Assert(DetectedInputSources.Contains(controller.InputSource));
+            Debug.Assert(detectedInputSources.Contains(controller.InputSource));
             action = ProcessRules(action, false);
             inputEventData.Initialize(controller.InputSource, controller.ControllerHandedness, action);
             HandleEvent(inputEventData, OnGestureCanceled);
@@ -1457,7 +1461,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseSpeechCommandRecognized(IMixedRealityInputSource source, MixedRealityInputAction inputAction, RecognitionConfidenceLevel confidence, TimeSpan phraseDuration, DateTime phraseStartTime, string text)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             // Create input event
             speechEventData.Initialize(source, inputAction, confidence, phraseDuration, phraseStartTime, text);
@@ -1480,7 +1484,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseDictationHypothesis(IMixedRealityInputSource source, string dictationHypothesis, AudioClip dictationAudioClip = null)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             // Create input event
             dictationEventData.Initialize(source, dictationHypothesis, dictationAudioClip);
@@ -1499,7 +1503,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseDictationResult(IMixedRealityInputSource source, string dictationResult, AudioClip dictationAudioClip = null)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             // Create input event
             dictationEventData.Initialize(source, dictationResult, dictationAudioClip);
@@ -1518,7 +1522,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseDictationComplete(IMixedRealityInputSource source, string dictationResult, AudioClip dictationAudioClip)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             // Create input event
             dictationEventData.Initialize(source, dictationResult, dictationAudioClip);
@@ -1537,7 +1541,7 @@ namespace XRTK.Services.InputSystem
         /// <inheritdoc />
         public void RaiseDictationError(IMixedRealityInputSource source, string dictationResult, AudioClip dictationAudioClip = null)
         {
-            Debug.Assert(DetectedInputSources.Contains(source));
+            Debug.Assert(detectedInputSources.Contains(source));
 
             // Create input event
             dictationEventData.Initialize(source, dictationResult, dictationAudioClip);


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Collections from any interface should only return readonly values.

## Breaking changes

- `IMixedRealityInputSystem.DetectedInputSources` is now a `IReadOnlyCollection<IMixedRealityInputSource>`
- `IMixedRealityInputSystem.DetectedControllers` is now a `IReadOnlyCollection<IMixedRealityController>`

If anyone was adding to these collections before they should use the proper method via `IMixedRealityInputSystem.RaiseSourceDetected(IMixedRealityInputSource source, IMixedRealityController controller = null)` or `IMixedRealityInputSystem.RaiseSourceLost(IMixedRealityInputSource source, IMixedRealityController controller = null)` respectively.