### PR TITLE
Fix wrong UWP preprocessor directive

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/Platforms/UniversalWindowsPlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/Platforms/UniversalWindowsPlatform.cs
@@ -13,7 +13,7 @@ namespace XRTK.Definitions.Platforms
         {
             get
             {
-#if UNITY_WSA
+#if WINDOWS_UWP
                 return true;
 #else
                 return false;


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Fixed the preprocessor directive for the Universal Windows Platform. The used one `UNITY_UWP` will run even when in editor and thus services will run even if the `Editor` platform was not configured.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)