### PR TITLE
Make use of DefaultHeadHeight setting in editor

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -110,6 +110,8 @@ namespace XRTK.Services.CameraSystem
                 Debug.Assert(CameraRig != null);
                 ResetRigTransforms();
             }
+            
+            ApplySettingsForDefaultHeadHeight();
         }
 
         /// <inheritdoc />
@@ -124,6 +126,8 @@ namespace XRTK.Services.CameraSystem
             {
                 CameraCache.Main.transform.root.DontDestroyOnLoad();
             }
+            
+            ApplySettingsForDefaultHeadHeight();
         }
 
         /// <inheritdoc />
@@ -191,6 +195,25 @@ namespace XRTK.Services.CameraSystem
                 {
                     UnityEngine.Object.DestroyImmediate(component);
                 }
+            }
+        }
+        
+        /// <summary>
+        /// Depending on whether there is an XR device connected,
+        /// moves the camera to the setting from the camera profile.
+        /// </summary>
+        private void ApplySettingsForDefaultHeadHeight()
+        {
+            if (!IsStereoscopic)
+            {
+                // If not device attached we'll just use the default head height setting.
+                CameraRig.CameraTransform.Translate(0f, DefaultHeadHeight, 0f);
+            }
+            else
+            {
+                // If we have a stereoscopic device attached we'll leave
+                // height control to the device itself and reset everything to origin.
+                ResetRigTransforms();
             }
         }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Implemented a simple approach to move the camera to the default head height position configured in the profile, when not XR device is attached.

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

Brief list of the targeted features that are being changed.

- Fixes: #487 