### PR TITLE
Remove obsolete SetupDefaultInteractions

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/BaseController.cs
@@ -133,12 +133,6 @@ namespace XRTK.Providers.Controllers
         public virtual void UpdateController() { }
 
         /// <summary>
-        /// Assign the default interactions based on controller handedness if necessary.
-        /// </summary>
-        /// <param name="controllerHandedness">The handedness of the controller.</param>
-        public abstract void SetupDefaultInteractions(Handedness controllerHandedness);
-
-        /// <summary>
         /// Load the Interaction mappings for this controller from the configured Controller Mapping profile
         /// </summary>
         protected void AssignControllerMappings(MixedRealityInteractionMapping[] mappings) => Interactions = mappings;

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/Hands/BaseHandController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/Hands/BaseHandController.cs
@@ -7,7 +7,6 @@ using XRTK.Definitions.Controllers;
 using XRTK.Definitions.Controllers.Hands;
 using XRTK.Definitions.Devices;
 using XRTK.Definitions.Utilities;
-using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.Providers.Controllers;
 using XRTK.Interfaces.Providers.Controllers.Hands;
 using XRTK.Services;
@@ -391,9 +390,6 @@ namespace XRTK.Providers.Controllers.Hands
             newBounds = null;
             return false;
         }
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness) { }
 
         /// <inheritdoc />
         public virtual bool TryGetJointPose(TrackedHandJoint joint, out MixedRealityPose pose) => jointPoses.TryGetValue(joint, out pose);

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/GenericOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/GenericOpenVRController.cs
@@ -159,12 +159,6 @@ namespace XRTK.Providers.Controllers.OpenVR
         }
 
         /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
-        }
-
-        /// <inheritdoc />
         public override void UpdateController()
         {
             if (!Enabled) { return; }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/OculusGoOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/OculusGoOpenVRController.cs
@@ -31,11 +31,5 @@ namespace XRTK.Providers.Controllers.OpenVR
             new MixedRealityInteractionMapping("PrimaryTouchpad Click", AxisType.Digital, DeviceInputType.TouchpadPress, KeyCode.JoystickButton9),
             new MixedRealityInteractionMapping("PrimaryTouchpad Axis", AxisType.DualAxis, DeviceInputType.DirectionalPad, ControllerMappingLibrary.AXIS_4, ControllerMappingLibrary.AXIS_5)
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/OculusRemoteOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/OculusRemoteOpenVRController.cs
@@ -26,11 +26,5 @@ namespace XRTK.Providers.Controllers.OpenVR
             new MixedRealityInteractionMapping("Button.One", AxisType.Digital, DeviceInputType.ButtonPress, KeyCode.JoystickButton0),
             new MixedRealityInteractionMapping("Button.Two", AxisType.Digital, DeviceInputType.ButtonPress, KeyCode.JoystickButton1),
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/OculusTouchOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/OculusTouchOpenVRController.cs
@@ -63,11 +63,5 @@ namespace XRTK.Providers.Controllers.OpenVR
             new MixedRealityInteractionMapping("Touch.SecondaryThumbRest Touch", AxisType.Digital, DeviceInputType.ThumbTouch, KeyCode.JoystickButton19),
             new MixedRealityInteractionMapping("Touch.SecondaryThumbRest Near Touch", AxisType.Digital, DeviceInputType.ThumbNearTouch, ControllerMappingLibrary.AXIS_18)
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
-        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/ViveKnucklesOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/ViveKnucklesOpenVRController.cs
@@ -57,11 +57,5 @@ namespace XRTK.Providers.Controllers.OpenVR
             new MixedRealityInteractionMapping("Ring Finger Cap Sensor", AxisType.SingleAxis, DeviceInputType.RingFinger, ControllerMappingLibrary.AXIS_25),
             new MixedRealityInteractionMapping("Pinky Finger Cap Sensor", AxisType.SingleAxis, DeviceInputType.PinkyFinger, ControllerMappingLibrary.AXIS_27),
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
-        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/ViveWandOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/ViveWandOpenVRController.cs
@@ -46,11 +46,5 @@ namespace XRTK.Providers.Controllers.OpenVR
             new MixedRealityInteractionMapping("Trackpad Press", AxisType.Digital, DeviceInputType.TouchpadPress,  KeyCode.JoystickButton9),
             new MixedRealityInteractionMapping("Menu Button", AxisType.Digital, DeviceInputType.ButtonPress,  KeyCode.JoystickButton0),
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
-        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -73,11 +73,5 @@ namespace XRTK.Providers.Controllers.OpenVR
                 };
             }
         }
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
-        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/Simulation/Hands/SimulatedHandController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/Simulation/Hands/SimulatedHandController.cs
@@ -159,12 +159,6 @@ namespace XRTK.Providers.Controllers.Simulation.Hands
         /// </summary>
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
         /// <summary>
         /// Gets the hands position in screen space.
         /// </summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/GenericJoystickController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/GenericJoystickController.cs
@@ -35,12 +35,6 @@ namespace XRTK.Providers.Controllers.UnityInput
         protected MixedRealityPose LastControllerPose = MixedRealityPose.ZeroIdentity;
         protected MixedRealityPose CurrentControllerPose = MixedRealityPose.ZeroIdentity;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            // Generic unity controller's will not have default interactions
-        }
-
         /// <summary>
         /// Update the controller data from Unity's Input Manager
         /// </summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/MouseController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/MouseController.cs
@@ -50,12 +50,6 @@ namespace XRTK.Providers.Controllers.UnityInput
             }
         }
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
         private MixedRealityPose controllerPose = MixedRealityPose.ZeroIdentity;
         private Vector2 mouseDelta;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/UnityTouchController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/UnityTouchController.cs
@@ -63,31 +63,6 @@ namespace XRTK.Providers.Controllers.UnityInput
         private bool isManipulating;
         private MixedRealityPose lastPose = MixedRealityPose.ZeroIdentity;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-
-            if (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.GesturesProfile != null)
-            {
-                for (int i = 0; i < MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.GesturesProfile.Gestures.Length; i++)
-                {
-                    var gesture = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.GesturesProfile.Gestures[i];
-
-                    switch (gesture.GestureType)
-                    {
-                        case GestureInputType.Hold:
-                            holdingAction = gesture.Action;
-                            break;
-                        case GestureInputType.Manipulation:
-                            manipulationAction = gesture.Action;
-                            break;
-                    }
-                }
-            }
-        }
-
         /// <summary>
         /// Start the touch.
         /// </summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/XboxController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/UnityInput/XboxController.cs
@@ -51,11 +51,5 @@ namespace XRTK.Providers.Controllers.UnityInput
                 };
             }
         }
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
     }
 }


### PR DESCRIPTION
## Overview

Removes the obsolete `SetupDefaultInteractions` in `BaseController` since it's not run anywhere anymore.