### PR TITLE
Create default hand interaction for spatial pointer pose

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/Hands/BaseHandController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Providers/Controllers/Hands/BaseHandController.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using XRTK.Definitions.Controllers.Hands;
 using XRTK.Definitions.Devices;
+using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.Utilities;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.Providers.Controllers;
@@ -36,6 +37,18 @@ namespace XRTK.Providers.Controllers.Hands
 
         private Vector3 lastPalmNormal;
         private Vector3 lastPalmPosition;
+
+        /// <inheritdoc />
+        public override MixedRealityInteractionMapping[] DefaultInteractions { get; } =
+        {
+            new MixedRealityInteractionMapping(0, "Spatial Pointer Pose", AxisType.SixDof, DeviceInputType.SpatialPointer, MixedRealityInputAction.None)
+        };
+
+        /// <inheritdoc />
+        public override MixedRealityInteractionMapping[] DefaultLeftHandedInteractions => DefaultInteractions;
+
+        /// <inheritdoc />
+        public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
         /// <summary>
         /// Gets the current palm normal of the hand controller.


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Adds a default interaction mapping for hand controllers.