### PR TITLE
Updated ScriptableObject.CreateAsset method to handle full path names

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/ScriptableObjectExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/ScriptableObjectExtensions.cs
@@ -52,6 +52,8 @@ namespace XRTK.Inspectors.Extensions
                 path = MixedRealityPreferences.ProfileGenerationPath;
             }
 
+            path = path.Replace(".asset", string.Empty);
+
             if (!string.IsNullOrWhiteSpace(Path.GetExtension(path)))
             {
                 var subtractedPath = path.Substring(path.LastIndexOf("/", StringComparison.Ordinal));
@@ -63,7 +65,7 @@ namespace XRTK.Inspectors.Extensions
                 Directory.CreateDirectory(Path.GetFullPath(path));
             }
 
-            path = path.Replace(".asset", string.Empty);
+            path = path.Replace($"{Directory.GetParent(Application.dataPath).FullName}\\", string.Empty);
 
             string assetPathAndName = AssetDatabase.GenerateUniqueAssetPath($"{path}/{name}.asset");
 


### PR DESCRIPTION
- Changes path to be relative to the project if a full path is provided