### PR TITLE
updated boundary system to utilize enable and disable properly

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -54,9 +54,23 @@ namespace XRTK.Services.BoundarySystem
         {
             base.Initialize();
 
-            if (!Application.isPlaying) { return; }
+            if (!Application.isPlaying)
+            {
+                return;
+            }
 
             boundaryEventData = new BoundaryEventData(EventSystem.current);
+        }
+
+        /// <inheritdoc/>
+        public override void Enable()
+        {
+            base.Enable();
+
+            if (!Application.isPlaying)
+            {
+                return;
+            }
 
             CalculateBoundaryBounds();
             Boundary.visible = true;
@@ -90,13 +104,30 @@ namespace XRTK.Services.BoundarySystem
         }
 
         /// <inheritdoc/>
+        public override void Disable()
+        {
+            base.Disable();
+
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            showFloor = false;
+            showPlayArea = false;
+            showTrackedArea = false;
+            showBoundaryWalls = false;
+            showCeiling = false;
+            Boundary.visible = false;
+        }
+
+        /// <inheritdoc/>
         public override void Destroy()
         {
             // First, detach the child objects (we are tracking them separately)
             // and clean up the parent.
             if (boundaryVisualizationParent != null)
             {
-
                 if (Application.isEditor)
                 {
                     Object.DestroyImmediate(boundaryVisualizationParent);
@@ -180,12 +211,6 @@ namespace XRTK.Services.BoundarySystem
 
                 currentCeilingObject = null;
             }
-
-            showFloor = false;
-            showPlayArea = false;
-            showTrackedArea = false;
-            showBoundaryWalls = false;
-            showCeiling = false;
 
             RaiseBoundaryVisualizationChanged();
         }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Pulled out some more changes related to #517 

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)

## Changes:

Brief list of the targeted features that are being changed.

- Race condition in #517 where the boundary visualizations were trying to use the camera rig before the system had finished setting up. Moved the boundary visualization from Initialize to Enable, which makes sense anyway cause if we disable or enable this system we'd expect the visualizations to also toggle on/off. 
