### PR TITLE
Added IMixedRealityServiceProfile<out TService>

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityServiceProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/BaseMixedRealityServiceProfile.cs
@@ -6,6 +6,14 @@ using XRTK.Interfaces;
 
 namespace XRTK.Definitions
 {
+    public interface IMixedRealityServiceProfile<out TService> where TService : IMixedRealityService
+    {
+        /// <summary>
+        /// The <see cref="IMixedRealityServiceConfiguration"/>s registered for this profile.
+        /// </summary>
+        IMixedRealityServiceConfiguration<TService>[] RegisteredServiceConfigurations { get; }
+    }
+
     /// <summary>
     /// The base profile type to derive all <see cref="IMixedRealityService"/>s from.
     /// </summary>
@@ -13,15 +21,15 @@ namespace XRTK.Definitions
     /// The <see cref="IMixedRealityService"/> type to constrain all of the valid <see cref="IMixedRealityServiceConfiguration.InstancedType"/>s to.
     /// Only types that implement the <see cref="TService"/> will show up in the inspector dropdown for the <see cref="IMixedRealityServiceConfiguration.InstancedType"/>
     /// </typeparam>
-    public abstract class BaseMixedRealityServiceProfile<TService> : BaseMixedRealityProfile where TService : IMixedRealityService
+    public abstract class BaseMixedRealityServiceProfile<TService> : BaseMixedRealityProfile, IMixedRealityServiceProfile<TService> where TService : IMixedRealityService
     {
         [SerializeField]
         private MixedRealityServiceConfiguration[] configurations = new MixedRealityServiceConfiguration[0];
 
-        /// <summary>
-        /// The <see cref="IMixedRealityServiceConfiguration"/>s registered for this profile.
-        /// </summary>
-        public MixedRealityServiceConfiguration<TService>[] RegisteredServiceConfigurations
+        private IMixedRealityServiceConfiguration<TService>[] registeredServiceConfigurations;
+
+        /// <inheritdoc />
+        public IMixedRealityServiceConfiguration<TService>[] RegisteredServiceConfigurations
         {
             get
             {
@@ -30,18 +38,22 @@ namespace XRTK.Definitions
                     configurations = new MixedRealityServiceConfiguration[0];
                 }
 
-                var serviceConfigurations = new MixedRealityServiceConfiguration<TService>[configurations.Length];
+                if (registeredServiceConfigurations == null ||
+                    registeredServiceConfigurations.Length != configurations.Length)
+                {
+                    registeredServiceConfigurations = new IMixedRealityServiceConfiguration<TService>[configurations.Length];
+                }
 
-                for (int i = 0; i < serviceConfigurations.Length; i++)
+                for (int i = 0; i < registeredServiceConfigurations.Length; i++)
                 {
                     var cachedConfig = configurations[i];
                     Debug.Assert(cachedConfig != null);
                     var serviceConfig = new MixedRealityServiceConfiguration<TService>(cachedConfig.InstancedType, cachedConfig.Name, cachedConfig.Priority, cachedConfig.RuntimePlatforms, cachedConfig.Profile);
                     Debug.Assert(serviceConfig != null);
-                    serviceConfigurations[i] = serviceConfig;
+                    registeredServiceConfigurations[i] = serviceConfig;
                 }
 
-                return serviceConfigurations;
+                return registeredServiceConfigurations;
             }
             internal set
             {

--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
@@ -773,16 +773,17 @@ namespace XRTK.Services
 
                 if (TryCreateAndRegisterService(configuration, out var serviceInstance))
                 {
-                    if (configuration.Profile is IMixedRealityServiceProfile<IMixedRealityDataProvider> profile)
+                    if (configuration.Profile is IMixedRealityServiceProfile<IMixedRealityDataProvider> profile &&
+                        !TryRegisterDataProviderConfigurations(profile.RegisteredServiceConfigurations, serviceInstance))
                     {
-                        TryRegisterDataProviderConfigurations(profile.RegisteredServiceConfigurations, serviceInstance);
+                        anyFailed = true;
                     }
-
-                    continue;
                 }
-
-                Debug.LogError($"Failed to start {configuration.Name}!");
-                anyFailed = true;
+                else
+                {
+                    Debug.LogError($"Failed to start {configuration.Name}!");
+                    anyFailed = true;
+                }
             }
 
             return !anyFailed;

--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
@@ -835,7 +835,7 @@ namespace XRTK.Services
         /// Creates a new instance of a service and registers it to the Mixed Reality Toolkit service registry for the specified platform.
         /// </summary>
         /// <typeparam name="T">The interface type for the <see cref="IMixedRealityService"/> to be registered.</typeparam>
-        /// <param name="configuration">The <see cref="MixedRealityServiceConfiguration"/> to use to create and register the service.</param>
+        /// <param name="configuration">The <see cref="IMixedRealityServiceConfiguration{T}"/> to use to create and register the service.</param>
         /// <param name="service">If successful, then the new <see cref="IMixedRealityService"/> instance will be passed back out.</param>
         /// <returns>True, if the service was successfully created and registered.</returns>
         public static bool TryCreateAndRegisterService<T>(IMixedRealityServiceConfiguration<T> configuration, out IMixedRealityService service) where T : IMixedRealityService
@@ -853,7 +853,7 @@ namespace XRTK.Services
         /// Creates a new instance of a data provider and registers it to the Mixed Reality Toolkit service registry for the specified platform.
         /// </summary>
         /// <typeparam name="T">The interface type for the <see cref="IMixedRealityService"/> to be registered.</typeparam>
-        /// <param name="configuration">The <see cref="MixedRealityServiceConfiguration"/> to use to create and register the service.</param>
+        /// <param name="configuration">The <see cref="IMixedRealityServiceConfiguration{T}"/> to use to create and register the data provider.</param>
         /// <param name="serviceParent">The <see cref="IMixedRealityService"/> that the <see cref="IMixedRealityDataProvider"/> will be assigned to.</param>
         /// <returns>True, if the service was successfully created and registered.</returns>
         public static bool TryCreateAndRegisterDataProvider<T>(IMixedRealityServiceConfiguration<T> configuration, IMixedRealityService serviceParent) where T : IMixedRealityDataProvider

--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
@@ -756,7 +756,7 @@ namespace XRTK.Services
         /// <typeparam name="T">The interface type for the <see cref="IMixedRealityService"/> to be registered.</typeparam>
         /// <param name="configurations">The list of <see cref="MixedRealityServiceConfiguration{T}"/>s.</param>
         /// <returns>True, if all configurations successfully created and registered their services.</returns>
-        public static bool TryRegisterServiceConfigurations<T>(MixedRealityServiceConfiguration<T>[] configurations) where T : IMixedRealityService
+        public static bool TryRegisterServiceConfigurations<T>(IMixedRealityServiceConfiguration<T>[] configurations) where T : IMixedRealityService
         {
             bool anyFailed = false;
 
@@ -773,7 +773,7 @@ namespace XRTK.Services
 
                 if (TryCreateAndRegisterService(configuration, out var serviceInstance))
                 {
-                    if (configuration.Profile is BaseMixedRealityServiceProfile<IMixedRealityDataProvider> profile)
+                    if (configuration.Profile is IMixedRealityServiceProfile<IMixedRealityDataProvider> profile)
                     {
                         TryRegisterDataProviderConfigurations(profile.RegisteredServiceConfigurations, serviceInstance);
                     }
@@ -795,7 +795,7 @@ namespace XRTK.Services
         /// <param name="configurations">The list of <see cref="MixedRealityServiceConfiguration{T}"/>s.</param>
         /// <param name="serviceParent">The <see cref="IMixedRealityService"/> that the <see cref="IMixedRealityDataProvider"/> will be assigned to.</param>
         /// <returns>True, if all configurations successfully created and registered their data providers.</returns>
-        public static bool TryRegisterDataProviderConfigurations<T>(MixedRealityServiceConfiguration<T>[] configurations, IMixedRealityService serviceParent) where T : IMixedRealityDataProvider
+        public static bool TryRegisterDataProviderConfigurations<T>(IMixedRealityServiceConfiguration<T>[] configurations, IMixedRealityService serviceParent) where T : IMixedRealityDataProvider
         {
             bool anyFailed = false;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs
@@ -754,7 +754,7 @@ namespace XRTK.Services
         /// Registers all the <see cref="IMixedRealityService"/>s defined in the provided configuration collection.
         /// </summary>
         /// <typeparam name="T">The interface type for the <see cref="IMixedRealityService"/> to be registered.</typeparam>
-        /// <param name="configurations">The list of <see cref="MixedRealityServiceConfiguration{T}"/>s.</param>
+        /// <param name="configurations">The list of <see cref="IMixedRealityServiceConfiguration{T}"/>s.</param>
         /// <returns>True, if all configurations successfully created and registered their services.</returns>
         public static bool TryRegisterServiceConfigurations<T>(IMixedRealityServiceConfiguration<T>[] configurations) where T : IMixedRealityService
         {
@@ -792,7 +792,7 @@ namespace XRTK.Services
         /// Registers all the <see cref="IMixedRealityDataProvider"/>s defined in the provided configuration collection.
         /// </summary>
         /// <typeparam name="T">The interface type for the <see cref="IMixedRealityDataProvider"/> to be registered.</typeparam>
-        /// <param name="configurations">The list of <see cref="MixedRealityServiceConfiguration{T}"/>s.</param>
+        /// <param name="configurations">The list of <see cref="IMixedRealityServiceConfiguration{T}"/>s.</param>
         /// <param name="serviceParent">The <see cref="IMixedRealityService"/> that the <see cref="IMixedRealityDataProvider"/> will be assigned to.</param>
         /// <returns>True, if all configurations successfully created and registered their data providers.</returns>
         public static bool TryRegisterDataProviderConfigurations<T>(IMixedRealityServiceConfiguration<T>[] configurations, IMixedRealityService serviceParent) where T : IMixedRealityDataProvider

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/ValidateConfiguration.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/ValidateConfiguration.cs
@@ -25,7 +25,7 @@ namespace XRTK.Utilities
         /// <param name="providerDefaultConfiguration">Array of Data Provider default configurations to add if missing</param>
         /// <param name="prompt">Unit Test helper, to control whether the UI prompt is offered or not</param>
         /// <returns></returns>
-        public static bool ValidateService<T>(this BaseMixedRealityServiceProfile<T> profile, Type[] providerTypesToValidate, MixedRealityServiceConfiguration<T>[] providerDefaultConfiguration, bool prompt = true) where T : IMixedRealityService
+        public static bool ValidateService<T>(this BaseMixedRealityServiceProfile<T> profile, Type[] providerTypesToValidate, IMixedRealityServiceConfiguration<T>[] providerDefaultConfiguration, bool prompt = true) where T : IMixedRealityService
         {
 #if UNITY_EDITOR
             if (Application.isPlaying || EditorPrefs.GetBool(IgnoreKey, false))


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

The configuration profiles were not properly registering their data providers because of a type casting bug where the  more derived interface types were getting passed on and this caused the check `is` to fail when attempting to cast the configuration profile to `BaseMixedRealityServiceProfile<IMixedRealityDataProvider>`

Adding the contravarent `IMixedRealityServiceProfile<out TService>` solves this problem.

We should probably have been using the interfaces in the service locator anyway instead of our concrete types for the profiles anyway.
