### PR TITLE
Update EditorBuildTarget enum for better understanding

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/PlatformEntryPropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/PlatformEntryPropertyDrawer.cs
@@ -26,7 +26,7 @@ namespace XRTK.Inspectors.PropertyDrawers
         private static readonly GUIContent EverythingContent = new GUIContent(Everything);
         private static readonly GUIContent EditorOnlyContent = new GUIContent("Editor Only");
         private static readonly GUIContent RuntimePlatformContent = new GUIContent("Runtime Platforms");
-        private static readonly GUIContent EditorBuildTargetContent = new GUIContent("Editor Build Target");
+        private static readonly GUIContent EditorBuildTargetContent = new GUIContent("Editor + Build Target");
 
         private static readonly int ControlHint = typeof(PlatformEntryPropertyDrawer).GetHashCode();
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Updated the label for the EditorBuildTarget platform to say `Editor + Build Target`. It's a small change but IMO better indicates that this means runs in editor when the build target matches.