### PR TITLE
updated the XRTKs Service locator script execution order to -50

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Services/MixedRealityToolkit.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences:
   - activeProfile: {instanceID: 0}
-  executionOrder: 25
+  executionOrder: -50
   icon: {fileID: 2800000, guid: 5e1c8765530949369db753b5770399e9, type: 3}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

On some platforms the services were not setup before some scripts wanted to request services. 

While these scripts should be more resilient to lazy service initialization, we probably do want the locator to run before most everything else in the scene. 

![image](https://user-images.githubusercontent.com/13334553/80120616-4554f280-8559-11ea-8a57-f313f732b6a0.png)
