### PR TITLE
Implement FoldoutWithBoldLabel inspector utility and update inspectors

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityToolkitRootProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Definitions/MixedRealityToolkitRootProfile.cs
@@ -45,7 +45,6 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Camera System Class to instantiate at runtime.")]
         [Implements(typeof(IMixedRealityCameraSystem), TypeGrouping.ByNamespaceFlat)]
         private SystemType cameraSystemType;
 
@@ -104,7 +103,6 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Input System Class to instantiate at runtime.")]
         [Implements(typeof(IMixedRealityInputSystem), TypeGrouping.ByNamespaceFlat)]
         private SystemType inputSystemType;
 
@@ -122,7 +120,7 @@ namespace XRTK.Definitions
         #region Boundary System Properties
 
         [SerializeField]
-        [Tooltip("Enable the Boundary on Startup")]
+        [Tooltip("Enable the Boundary on Startup.")]
         private bool enableBoundarySystem = false;
 
         /// <summary>
@@ -135,7 +133,6 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Boundary System Class to instantiate at runtime.")]
         [Implements(typeof(IMixedRealityBoundarySystem), TypeGrouping.ByNamespaceFlat)]
         private SystemType boundarySystemType;
 
@@ -166,7 +163,7 @@ namespace XRTK.Definitions
         #region Teleportation System Properties
 
         [SerializeField]
-        [Tooltip("Enable the Teleport System on Startup")]
+        [Tooltip("Enable the Teleport System on Startup.")]
         private bool enableTeleportSystem = false;
 
         /// <summary>
@@ -179,7 +176,6 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Boundary System Class to instantiate at runtime.")]
         [Implements(typeof(IMixedRealityTeleportSystem), TypeGrouping.ByNamespaceFlat)]
         private SystemType teleportSystemType;
 
@@ -197,7 +193,7 @@ namespace XRTK.Definitions
         #region Spatial Awareness System Properties
 
         [SerializeField]
-        [Tooltip("Enable the Spatial Awareness system on Startup")]
+        [Tooltip("Enable the Spatial Awareness system on Startup.")]
         private bool enableSpatialAwarenessSystem = false;
 
         /// <summary>
@@ -210,7 +206,6 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Spatial Awareness System Class to instantiate at runtime.")]
         [Implements(typeof(IMixedRealitySpatialAwarenessSystem), TypeGrouping.ByNamespaceFlat)]
         private SystemType spatialAwarenessSystemType;
 
@@ -254,7 +249,7 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Enable networking system")]
+        [Tooltip("Enable Networking System on Startup.")]
         private bool enableNetworkingSystem = false;
 
         /// <summary>
@@ -267,7 +262,6 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Networking System Class to instantiate at runtime.")]
         [Implements(typeof(IMixedRealityNetworkingSystem), TypeGrouping.ByNamespaceFlat)]
         private SystemType networkingSystemType;
 
@@ -298,7 +292,7 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Enable diagnostic system")]
+        [Tooltip("Enable Diagnostic System on Startup.")]
         private bool enableDiagnosticsSystem = false;
 
         /// <summary>
@@ -311,7 +305,6 @@ namespace XRTK.Definitions
         }
 
         [SerializeField]
-        [Tooltip("Diagnostics System Class to instantiate at runtime.")]
         [Implements(typeof(IMixedRealityDiagnosticsSystem), TypeGrouping.ByNamespaceFlat)]
         private SystemType diagnosticsSystemType;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/EditorGUILayoutExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/EditorGUILayoutExtensions.cs
@@ -18,7 +18,7 @@ namespace XRTK.Inspectors.Extensions
         /// <param name="content">Foldout label content.</param>
         /// <param name="toggleOnLabelClick">Should the foldout toggle on label click?</param>
         /// <returns>Returns true, if foldout unfolded.</returns>
-        public static bool FoldoutWithBoldLabel(bool foldout, GUIContent content, bool toggleOnLabelClick)
+        public static bool FoldoutWithBoldLabel(bool foldout, GUIContent content, bool toggleOnLabelClick = true)
         {
             GUIStyle defaultStyle = EditorStyles.foldout;
             FontStyle previousStyle = defaultStyle.fontStyle;

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/EditorGUILayoutExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/EditorGUILayoutExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace XRTK.Inspectors.Extensions
+{
+    /// <summary>
+    /// Extensions for <see cref="EditorGUILayout"/> usage.
+    /// </summary>
+    public static class EditorGUILayoutExtensions
+    {
+        /// <summary>
+        /// Draws a foldout but with bold label text.
+        /// </summary>
+        /// <param name="foldout">Foldout state.</param>
+        /// <param name="content">Foldout label content.</param>
+        /// <param name="toggleOnLabelClick">Should the foldout toggle on label click?</param>
+        /// <returns>Returns true, if foldout unfolded.</returns>
+        public static bool FoldoutWithBoldLabel(bool foldout, GUIContent content, bool toggleOnLabelClick)
+        {
+            GUIStyle defaultStyle = EditorStyles.foldout;
+            FontStyle previousStyle = defaultStyle.fontStyle;
+            defaultStyle.fontStyle = FontStyle.Bold;
+            foldout = EditorGUILayout.Foldout(foldout, content, toggleOnLabelClick);
+            defaultStyle.fontStyle = previousStyle;
+
+            return foldout;
+        }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/EditorGUILayoutExtensions.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/EditorGUILayoutExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47093934dde4fa7458039b452d7b9d37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/SerializedPropertyExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/SerializedPropertyExtensions.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace XRTK.Inspectors.Extensions
+{
+    /// <summary>
+    /// Extensions for <see cref="SerializedProperty"/> usage.
+    /// </summary>
+    public static class SerializedPropertyExtensions
+    {
+
+        /// <summary>
+        /// Draws a foldout but with bold label text.
+        /// </summary>
+        /// <param name="property"><see cref="SerializedProperty"/> to check if expanded.</param>
+        /// <param name="foldoutContent">Foldout label content.</param>
+        /// <param name="showPropertyChildren">Should the property field render its children?</param>
+        /// <param name="layoutOptions">Optional <see cref="GUILayoutOption"/> options.</param>
+        /// <param name="propertyContent"><see cref="SerializedProperty"/> label content.</param>
+        /// <returns>Returns true, if foldout unfolded.</returns>
+        public static bool FoldoutWithBoldLabelPropertyField(this SerializedProperty property, GUIContent foldoutContent, GUIContent propertyContent, bool showPropertyChildren = true, params GUILayoutOption[] layoutOptions)
+        {
+            return property.FoldoutWithBoldLabelPropertyField(foldoutContent, true, propertyContent, showPropertyChildren, layoutOptions);
+        }
+
+        /// <summary>
+        /// Draws a foldout but with bold label text.
+        /// </summary>
+        /// <param name="property"><see cref="SerializedProperty"/> to check if expanded.</param>
+        /// <param name="foldoutContent">Foldout label content.</param>
+        /// <param name="toggleOnLabelClick">Should the foldout toggle on label click?</param>
+        /// <param name="showPropertyChildren">Should the property field render its children?</param>
+        /// <param name="layoutOptions">Optional <see cref="GUILayoutOption"/> options.</param>
+        /// <param name="propertyContent"><see cref="SerializedProperty"/> label content.</param>
+        /// <returns>Returns true, if foldout unfolded.</returns>
+        public static bool FoldoutWithBoldLabelPropertyField(this SerializedProperty property, GUIContent foldoutContent, bool toggleOnLabelClick = true, GUIContent propertyContent = null, bool showPropertyChildren = true, params GUILayoutOption[] layoutOptions)
+        {
+            var defaultStyle = EditorStyles.foldout;
+            var previousStyle = defaultStyle.fontStyle;
+            defaultStyle.fontStyle = FontStyle.Bold;
+            property.isExpanded = EditorGUILayout.Foldout(property.isExpanded, foldoutContent, toggleOnLabelClick);
+            defaultStyle.fontStyle = previousStyle;
+
+            if (property.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(property, propertyContent, showPropertyChildren, layoutOptions);
+                EditorGUI.indentLevel--;
+            }
+
+            return property.isExpanded;
+        }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/SerializedPropertyExtensions.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Extensions/SerializedPropertyExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 60715e6930ac4f89993057348cb6d06d
+timeCreated: 1587746120

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityToolkitInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityToolkitInspector.cs
@@ -23,6 +23,14 @@ namespace XRTK.Inspectors
         private int currentPickerWindow = -1;
         private bool checkChange;
 
+        private void Awake()
+        {
+            if (target.name != nameof(MixedRealityToolkit))
+            {
+                target.name = nameof(MixedRealityToolkit);
+            }
+        }
+
         private void OnEnable()
         {
             activeProfile = serializedObject.FindProperty(nameof(activeProfile));
@@ -36,7 +44,8 @@ namespace XRTK.Inspectors
 
             serializedObject.Update();
             EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(activeProfile);
+            EditorGUILayout.LabelField(new GUIContent("Mixed Reality Toolkit Root Profile", "This profile is the main root configuration for the entire XRTK."));
+            EditorGUILayout.PropertyField(activeProfile, GUIContent.none);
             var changed = EditorGUI.EndChangeCheck();
             var commandName = Event.current.commandName;
             var profiles = ScriptableObjectExtensions.GetAllInstances<MixedRealityToolkitRootProfile>();
@@ -131,6 +140,24 @@ namespace XRTK.Inspectors
                             Selection.activeObject = activeProfile.objectReferenceValue;
                         };
                         break;
+                }
+            }
+
+            if (activeProfile.objectReferenceValue != null)
+            {
+                var rootProfile = activeProfile.objectReferenceValue as MixedRealityToolkitRootProfile;
+                var profileInspector = CreateEditor(rootProfile);
+
+                if (profileInspector is MixedRealityToolkitRootProfileInspector rootProfileInspector)
+                {
+                    EditorGUILayout.Space();
+                    EditorGUILayout.Space();
+                    EditorGUILayout.Space();
+                    Rect rect = new Rect(GUILayoutUtility.GetLastRect()) { height = 0.5f };
+                    EditorGUI.DrawRect(rect, Color.gray);
+                    EditorGUILayout.Space();
+
+                    rootProfileInspector.RenderSystemFields();
                 }
             }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityToolkitInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/MixedRealityToolkitInspector.cs
@@ -153,7 +153,7 @@ namespace XRTK.Inspectors
                     EditorGUILayout.Space();
                     EditorGUILayout.Space();
                     EditorGUILayout.Space();
-                    Rect rect = new Rect(GUILayoutUtility.GetLastRect()) { height = 0.5f };
+                    Rect rect = new Rect(GUILayoutUtility.GetLastRect()) { height = 0.75f };
                     EditorGUI.DrawRect(rect, Color.gray);
                     EditorGUILayout.Space();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
@@ -4,6 +4,7 @@
 using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions.CameraSystem;
+using XRTK.Inspectors.Extensions;
 using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles.CameraSystem
@@ -30,18 +31,25 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
 
         private readonly GUIContent nearClipTitle = new GUIContent("Near Clip");
         private readonly GUIContent clearFlagsTitle = new GUIContent("Clear Flags");
+        private readonly GUIContent platformSettingsFoldoutHeader = new GUIContent("Platform Specific Settings");
+        private readonly GUIContent opaqueSettingsFoldoutHeader = new GUIContent("Opaque Display Settings");
+        private readonly GUIContent transparentSettingsFoldoutHeader = new GUIContent("Transparent Display Settings");
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
             isCameraPersistent = serializedObject.FindProperty(nameof(isCameraPersistent));
+            isCameraPersistent.isExpanded = true;
+
             nearClipPlaneOpaqueDisplay = serializedObject.FindProperty(nameof(nearClipPlaneOpaqueDisplay));
+            nearClipPlaneOpaqueDisplay.isExpanded = true;
             cameraClearFlagsOpaqueDisplay = serializedObject.FindProperty(nameof(cameraClearFlagsOpaqueDisplay));
             backgroundColorOpaqueDisplay = serializedObject.FindProperty(nameof(backgroundColorOpaqueDisplay));
             opaqueQualityLevel = serializedObject.FindProperty(nameof(opaqueQualityLevel));
 
             nearClipPlaneTransparentDisplay = serializedObject.FindProperty(nameof(nearClipPlaneTransparentDisplay));
+            nearClipPlaneTransparentDisplay.isExpanded = true;
             cameraClearFlagsTransparentDisplay = serializedObject.FindProperty(nameof(cameraClearFlagsTransparentDisplay));
             backgroundColorTransparentDisplay = serializedObject.FindProperty(nameof(backgroundColorTransparentDisplay));
             transparentQualityLevel = serializedObject.FindProperty(nameof(transparentQualityLevel));
@@ -60,37 +68,55 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
 
             EditorGUI.BeginChangeCheck();
 
-            EditorGUILayout.LabelField("Platform Specific Settings:", EditorStyles.boldLabel);
-
-            EditorGUILayout.PropertyField(isCameraPersistent);
-            EditorGUILayout.PropertyField(cameraRigType);
-            EditorGUILayout.PropertyField(defaultHeadHeight);
-            EditorGUILayout.PropertyField(bodyAdjustmentAngle);
-            EditorGUILayout.PropertyField(bodyAdjustmentSpeed);
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Opaque Display Settings:", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(nearClipPlaneOpaqueDisplay, nearClipTitle);
-            EditorGUILayout.PropertyField(cameraClearFlagsOpaqueDisplay, clearFlagsTitle);
-
-            if ((CameraClearFlags)cameraClearFlagsOpaqueDisplay.intValue == CameraClearFlags.Color)
+            isCameraPersistent.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(isCameraPersistent.isExpanded, platformSettingsFoldoutHeader, true);
+            if (isCameraPersistent.isExpanded)
             {
-                backgroundColorOpaqueDisplay.colorValue = EditorGUILayout.ColorField("Background Color", backgroundColorOpaqueDisplay.colorValue);
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(isCameraPersistent);
+                EditorGUILayout.PropertyField(cameraRigType);
+                EditorGUILayout.PropertyField(defaultHeadHeight);
+                EditorGUILayout.PropertyField(bodyAdjustmentAngle);
+                EditorGUILayout.PropertyField(bodyAdjustmentSpeed);
+                EditorGUI.indentLevel--;
             }
 
-            opaqueQualityLevel.intValue = EditorGUILayout.Popup("Quality Setting", opaqueQualityLevel.intValue, QualitySettings.names);
-
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Transparent Display Settings:", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(nearClipPlaneTransparentDisplay, nearClipTitle);
-            EditorGUILayout.PropertyField(cameraClearFlagsTransparentDisplay, clearFlagsTitle);
 
-            if ((CameraClearFlags)cameraClearFlagsTransparentDisplay.intValue == CameraClearFlags.Color)
+            nearClipPlaneOpaqueDisplay.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(nearClipPlaneOpaqueDisplay.isExpanded, opaqueSettingsFoldoutHeader, true);
+            if (nearClipPlaneOpaqueDisplay.isExpanded)
             {
-                backgroundColorTransparentDisplay.colorValue = EditorGUILayout.ColorField("Background Color", backgroundColorTransparentDisplay.colorValue);
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(nearClipPlaneOpaqueDisplay, nearClipTitle);
+                EditorGUILayout.PropertyField(cameraClearFlagsOpaqueDisplay, clearFlagsTitle);
+
+                if ((CameraClearFlags)cameraClearFlagsOpaqueDisplay.intValue == CameraClearFlags.Color)
+                {
+                    backgroundColorOpaqueDisplay.colorValue = EditorGUILayout.ColorField("Background Color", backgroundColorOpaqueDisplay.colorValue);
+                }
+
+                opaqueQualityLevel.intValue = EditorGUILayout.Popup("Quality Setting", opaqueQualityLevel.intValue, QualitySettings.names);
+                EditorGUI.indentLevel--;
             }
 
-            transparentQualityLevel.intValue = EditorGUILayout.Popup("Quality Setting", transparentQualityLevel.intValue, QualitySettings.names);
+            EditorGUILayout.Space();
+
+            nearClipPlaneTransparentDisplay.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(nearClipPlaneTransparentDisplay.isExpanded, transparentSettingsFoldoutHeader, true);
+            if (nearClipPlaneTransparentDisplay.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(nearClipPlaneTransparentDisplay, nearClipTitle);
+                EditorGUILayout.PropertyField(cameraClearFlagsTransparentDisplay, clearFlagsTitle);
+
+                if ((CameraClearFlags)cameraClearFlagsTransparentDisplay.intValue == CameraClearFlags.Color)
+                {
+                    backgroundColorTransparentDisplay.colorValue = EditorGUILayout.ColorField("Background Color", backgroundColorTransparentDisplay.colorValue);
+                }
+
+                transparentQualityLevel.intValue = EditorGUILayout.Popup("Quality Setting", transparentQualityLevel.intValue, QualitySettings.names);
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.Space();
 
             serializedObject.ApplyModifiedProperties();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
@@ -40,16 +40,13 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
             base.OnEnable();
 
             isCameraPersistent = serializedObject.FindProperty(nameof(isCameraPersistent));
-            isCameraPersistent.isExpanded = true;
 
             nearClipPlaneOpaqueDisplay = serializedObject.FindProperty(nameof(nearClipPlaneOpaqueDisplay));
-            nearClipPlaneOpaqueDisplay.isExpanded = true;
             cameraClearFlagsOpaqueDisplay = serializedObject.FindProperty(nameof(cameraClearFlagsOpaqueDisplay));
             backgroundColorOpaqueDisplay = serializedObject.FindProperty(nameof(backgroundColorOpaqueDisplay));
             opaqueQualityLevel = serializedObject.FindProperty(nameof(opaqueQualityLevel));
 
             nearClipPlaneTransparentDisplay = serializedObject.FindProperty(nameof(nearClipPlaneTransparentDisplay));
-            nearClipPlaneTransparentDisplay.isExpanded = true;
             cameraClearFlagsTransparentDisplay = serializedObject.FindProperty(nameof(cameraClearFlagsTransparentDisplay));
             backgroundColorTransparentDisplay = serializedObject.FindProperty(nameof(backgroundColorTransparentDisplay));
             transparentQualityLevel = serializedObject.FindProperty(nameof(transparentQualityLevel));
@@ -68,11 +65,9 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
 
             EditorGUI.BeginChangeCheck();
 
-            isCameraPersistent.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(isCameraPersistent.isExpanded, platformSettingsFoldoutHeader, true);
-            if (isCameraPersistent.isExpanded)
+            if (isCameraPersistent.FoldoutWithBoldLabelPropertyField(platformSettingsFoldoutHeader))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(isCameraPersistent);
                 EditorGUILayout.PropertyField(cameraRigType);
                 EditorGUILayout.PropertyField(defaultHeadHeight);
                 EditorGUILayout.PropertyField(bodyAdjustmentAngle);
@@ -82,11 +77,9 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
 
             EditorGUILayout.Space();
 
-            nearClipPlaneOpaqueDisplay.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(nearClipPlaneOpaqueDisplay.isExpanded, opaqueSettingsFoldoutHeader, true);
-            if (nearClipPlaneOpaqueDisplay.isExpanded)
+            if (nearClipPlaneOpaqueDisplay.FoldoutWithBoldLabelPropertyField(opaqueSettingsFoldoutHeader, nearClipTitle))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(nearClipPlaneOpaqueDisplay, nearClipTitle);
                 EditorGUILayout.PropertyField(cameraClearFlagsOpaqueDisplay, clearFlagsTitle);
 
                 if ((CameraClearFlags)cameraClearFlagsOpaqueDisplay.intValue == CameraClearFlags.Color)
@@ -100,11 +93,9 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
 
             EditorGUILayout.Space();
 
-            nearClipPlaneTransparentDisplay.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(nearClipPlaneTransparentDisplay.isExpanded, transparentSettingsFoldoutHeader, true);
-            if (nearClipPlaneTransparentDisplay.isExpanded)
+            if (nearClipPlaneTransparentDisplay.FoldoutWithBoldLabelPropertyField(transparentSettingsFoldoutHeader, nearClipTitle))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(nearClipPlaneTransparentDisplay, nearClipTitle);
                 EditorGUILayout.PropertyField(cameraClearFlagsTransparentDisplay, clearFlagsTitle);
 
                 if ((CameraClearFlags)cameraClearFlagsTransparentDisplay.intValue == CameraClearFlags.Color)

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/DiagnosticsSystem/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/DiagnosticsSystem/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using UnityEditor;
+using UnityEngine;
 using XRTK.Definitions.DiagnosticsSystem;
+using XRTK.Inspectors.Extensions;
 
 namespace XRTK.Inspectors.Profiles.DiagnosticsSystem
 {
@@ -12,11 +14,14 @@ namespace XRTK.Inspectors.Profiles.DiagnosticsSystem
         private SerializedProperty diagnosticsWindowPrefab;
         private SerializedProperty showDiagnosticsWindowOnStart;
 
+        private readonly GUIContent generalSettingsFoldoutHeader = new GUIContent("General Settings");
+
         protected override void OnEnable()
         {
             base.OnEnable();
 
             diagnosticsWindowPrefab = serializedObject.FindProperty(nameof(diagnosticsWindowPrefab));
+            diagnosticsWindowPrefab.isExpanded = true;
             showDiagnosticsWindowOnStart = serializedObject.FindProperty(nameof(showDiagnosticsWindowOnStart));
         }
 
@@ -25,8 +30,18 @@ namespace XRTK.Inspectors.Profiles.DiagnosticsSystem
             RenderHeader("Diagnostics monitors system resources and performance inside an application during development.");
 
             serializedObject.Update();
-            EditorGUILayout.PropertyField(diagnosticsWindowPrefab);
-            EditorGUILayout.PropertyField(showDiagnosticsWindowOnStart);
+
+            diagnosticsWindowPrefab.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(diagnosticsWindowPrefab.isExpanded, generalSettingsFoldoutHeader, true);
+            if (diagnosticsWindowPrefab.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(diagnosticsWindowPrefab);
+                EditorGUILayout.PropertyField(showDiagnosticsWindowOnStart);
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.Space();
+
             serializedObject.ApplyModifiedProperties();
 
             base.OnInspectorGUI();

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/DiagnosticsSystem/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/DiagnosticsSystem/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -21,7 +21,6 @@ namespace XRTK.Inspectors.Profiles.DiagnosticsSystem
             base.OnEnable();
 
             diagnosticsWindowPrefab = serializedObject.FindProperty(nameof(diagnosticsWindowPrefab));
-            diagnosticsWindowPrefab.isExpanded = true;
             showDiagnosticsWindowOnStart = serializedObject.FindProperty(nameof(showDiagnosticsWindowOnStart));
         }
 
@@ -31,11 +30,9 @@ namespace XRTK.Inspectors.Profiles.DiagnosticsSystem
 
             serializedObject.Update();
 
-            diagnosticsWindowPrefab.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(diagnosticsWindowPrefab.isExpanded, generalSettingsFoldoutHeader, true);
-            if (diagnosticsWindowPrefab.isExpanded)
+            if (diagnosticsWindowPrefab.FoldoutWithBoldLabelPropertyField(generalSettingsFoldoutHeader))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(diagnosticsWindowPrefab);
                 EditorGUILayout.PropertyField(showDiagnosticsWindowOnStart);
                 EditorGUI.indentLevel--;
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
@@ -4,6 +4,7 @@
 using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions.BoundarySystem;
+using XRTK.Inspectors.Extensions;
 
 namespace XRTK.Inspectors.Profiles
 {
@@ -35,31 +36,43 @@ namespace XRTK.Inspectors.Profiles
         private readonly GUIContent showContent = new GUIContent("Show");
         private readonly GUIContent scaleContent = new GUIContent("Scale");
         private readonly GUIContent materialContent = new GUIContent("Material");
+        private readonly GUIContent generalSettingsFoldoutHeader = new GUIContent("General Settings");
+        private readonly GUIContent floorSettingsFoldoutHeader = new GUIContent("Floor Settings");
+        private readonly GUIContent playAreaSettingsFoldoutHeader = new GUIContent("Play Area Settings");
+        private readonly GUIContent trackedAreaSettingsFoldoutHeader = new GUIContent("Tracked Area Settings");
+        private readonly GUIContent boundaryWallSettingsFoldoutHeader = new GUIContent("Boundary Wall Settings");
+        private readonly GUIContent boundaryCeilingSettingsFoldoutHeader = new GUIContent("Boundary Ceiling Settings");
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
             boundaryHeight = serializedObject.FindProperty(nameof(boundaryHeight));
+            boundaryHeight.isExpanded = true;
 
             showFloor = serializedObject.FindProperty(nameof(showFloor));
+            showFloor.isExpanded = true;
             floorMaterial = serializedObject.FindProperty(nameof(floorMaterial));
             floorScale = serializedObject.FindProperty(nameof(floorScale));
             floorPhysicsLayer = serializedObject.FindProperty(nameof(floorPhysicsLayer));
 
             showPlayArea = serializedObject.FindProperty(nameof(showPlayArea));
+            showPlayArea.isExpanded = true;
             playAreaMaterial = serializedObject.FindProperty(nameof(playAreaMaterial));
             playAreaPhysicsLayer = serializedObject.FindProperty(nameof(playAreaPhysicsLayer));
 
             showTrackedArea = serializedObject.FindProperty(nameof(showTrackedArea));
+            showTrackedArea.isExpanded = true;
             trackedAreaMaterial = serializedObject.FindProperty(nameof(trackedAreaMaterial));
             trackedAreaPhysicsLayer = serializedObject.FindProperty(nameof(trackedAreaPhysicsLayer));
 
             showBoundaryWalls = serializedObject.FindProperty(nameof(showBoundaryWalls));
+            showBoundaryWalls.isExpanded = true;
             boundaryWallMaterial = serializedObject.FindProperty(nameof(boundaryWallMaterial));
             boundaryWallsPhysicsLayer = serializedObject.FindProperty(nameof(boundaryWallsPhysicsLayer));
 
             showBoundaryCeiling = serializedObject.FindProperty(nameof(showBoundaryCeiling));
+            showBoundaryCeiling.isExpanded = true;
             boundaryCeilingMaterial = serializedObject.FindProperty(nameof(boundaryCeilingMaterial));
             ceilingPhysicsLayer = serializedObject.FindProperty(nameof(ceilingPhysicsLayer));
         }
@@ -70,40 +83,79 @@ namespace XRTK.Inspectors.Profiles
 
             serializedObject.Update();
 
-            EditorGUILayout.PropertyField(boundaryHeight);
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Floor Settings:", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(showFloor, showContent);
-            EditorGUILayout.PropertyField(floorMaterial, materialContent);
-            var prevWideMode = EditorGUIUtility.wideMode;
-            EditorGUIUtility.wideMode = true;
-            EditorGUILayout.PropertyField(floorScale, scaleContent, GUILayout.ExpandWidth(true));
-            EditorGUIUtility.wideMode = prevWideMode;
-            EditorGUILayout.PropertyField(floorPhysicsLayer);
+            boundaryHeight.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(boundaryHeight.isExpanded, generalSettingsFoldoutHeader, true);
+            if (boundaryHeight.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(boundaryHeight);
+                EditorGUI.indentLevel--;
+            }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Play Area Settings:", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(showPlayArea, showContent);
-            EditorGUILayout.PropertyField(playAreaMaterial, materialContent);
-            EditorGUILayout.PropertyField(playAreaPhysicsLayer);
+
+            showFloor.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showFloor.isExpanded, floorSettingsFoldoutHeader, true);
+            if (showFloor.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(showFloor, showContent);
+                EditorGUILayout.PropertyField(floorMaterial, materialContent);
+                var prevWideMode = EditorGUIUtility.wideMode;
+                EditorGUIUtility.wideMode = true;
+                EditorGUILayout.PropertyField(floorScale, scaleContent, GUILayout.ExpandWidth(true));
+                EditorGUIUtility.wideMode = prevWideMode;
+                EditorGUILayout.PropertyField(floorPhysicsLayer);
+                EditorGUI.indentLevel--;
+            }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Tracked Area Settings:", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(showTrackedArea, showContent);
-            EditorGUILayout.PropertyField(trackedAreaMaterial, materialContent);
-            EditorGUILayout.PropertyField(trackedAreaPhysicsLayer);
+
+            showPlayArea.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showPlayArea.isExpanded, playAreaSettingsFoldoutHeader, true);
+            if (showPlayArea.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(showPlayArea, showContent);
+                EditorGUILayout.PropertyField(playAreaMaterial, materialContent);
+                EditorGUILayout.PropertyField(playAreaPhysicsLayer);
+                EditorGUI.indentLevel--;
+            }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Boundary Wall Settings:", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(showBoundaryWalls, showContent);
-            EditorGUILayout.PropertyField(boundaryWallMaterial, materialContent);
-            EditorGUILayout.PropertyField(boundaryWallsPhysicsLayer);
+
+            showTrackedArea.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showTrackedArea.isExpanded, trackedAreaSettingsFoldoutHeader, true);
+            if (showTrackedArea.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(showTrackedArea, showContent);
+                EditorGUILayout.PropertyField(trackedAreaMaterial, materialContent);
+                EditorGUILayout.PropertyField(trackedAreaPhysicsLayer);
+                EditorGUI.indentLevel--;
+            }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Boundary Ceiling Settings:", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(showBoundaryCeiling, showContent);
-            EditorGUILayout.PropertyField(boundaryCeilingMaterial, materialContent);
-            EditorGUILayout.PropertyField(ceilingPhysicsLayer);
+
+            showBoundaryWalls.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showBoundaryWalls.isExpanded, boundaryWallSettingsFoldoutHeader, true);
+            if (showBoundaryWalls.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(showBoundaryWalls, showContent);
+                EditorGUILayout.PropertyField(boundaryWallMaterial, materialContent);
+                EditorGUILayout.PropertyField(boundaryWallsPhysicsLayer);
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.Space();
+
+            showBoundaryCeiling.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showBoundaryCeiling.isExpanded, boundaryCeilingSettingsFoldoutHeader, true);
+            if (showBoundaryCeiling.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(showBoundaryCeiling, showContent);
+                EditorGUILayout.PropertyField(boundaryCeilingMaterial, materialContent);
+                EditorGUILayout.PropertyField(ceilingPhysicsLayer);
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.Space();
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
@@ -48,31 +48,25 @@ namespace XRTK.Inspectors.Profiles
             base.OnEnable();
 
             boundaryHeight = serializedObject.FindProperty(nameof(boundaryHeight));
-            boundaryHeight.isExpanded = true;
 
             showFloor = serializedObject.FindProperty(nameof(showFloor));
-            showFloor.isExpanded = true;
             floorMaterial = serializedObject.FindProperty(nameof(floorMaterial));
             floorScale = serializedObject.FindProperty(nameof(floorScale));
             floorPhysicsLayer = serializedObject.FindProperty(nameof(floorPhysicsLayer));
 
             showPlayArea = serializedObject.FindProperty(nameof(showPlayArea));
-            showPlayArea.isExpanded = true;
             playAreaMaterial = serializedObject.FindProperty(nameof(playAreaMaterial));
             playAreaPhysicsLayer = serializedObject.FindProperty(nameof(playAreaPhysicsLayer));
 
             showTrackedArea = serializedObject.FindProperty(nameof(showTrackedArea));
-            showTrackedArea.isExpanded = true;
             trackedAreaMaterial = serializedObject.FindProperty(nameof(trackedAreaMaterial));
             trackedAreaPhysicsLayer = serializedObject.FindProperty(nameof(trackedAreaPhysicsLayer));
 
             showBoundaryWalls = serializedObject.FindProperty(nameof(showBoundaryWalls));
-            showBoundaryWalls.isExpanded = true;
             boundaryWallMaterial = serializedObject.FindProperty(nameof(boundaryWallMaterial));
             boundaryWallsPhysicsLayer = serializedObject.FindProperty(nameof(boundaryWallsPhysicsLayer));
 
             showBoundaryCeiling = serializedObject.FindProperty(nameof(showBoundaryCeiling));
-            showBoundaryCeiling.isExpanded = true;
             boundaryCeilingMaterial = serializedObject.FindProperty(nameof(boundaryCeilingMaterial));
             ceilingPhysicsLayer = serializedObject.FindProperty(nameof(ceilingPhysicsLayer));
         }
@@ -83,21 +77,13 @@ namespace XRTK.Inspectors.Profiles
 
             serializedObject.Update();
 
-            boundaryHeight.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(boundaryHeight.isExpanded, generalSettingsFoldoutHeader, true);
-            if (boundaryHeight.isExpanded)
-            {
-                EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(boundaryHeight);
-                EditorGUI.indentLevel--;
-            }
+            boundaryHeight.FoldoutWithBoldLabelPropertyField(generalSettingsFoldoutHeader);
 
             EditorGUILayout.Space();
 
-            showFloor.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showFloor.isExpanded, floorSettingsFoldoutHeader, true);
-            if (showFloor.isExpanded)
+            if (showFloor.FoldoutWithBoldLabelPropertyField(floorSettingsFoldoutHeader, showContent))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(showFloor, showContent);
                 EditorGUILayout.PropertyField(floorMaterial, materialContent);
                 var prevWideMode = EditorGUIUtility.wideMode;
                 EditorGUIUtility.wideMode = true;
@@ -109,11 +95,9 @@ namespace XRTK.Inspectors.Profiles
 
             EditorGUILayout.Space();
 
-            showPlayArea.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showPlayArea.isExpanded, playAreaSettingsFoldoutHeader, true);
-            if (showPlayArea.isExpanded)
+            if (showPlayArea.FoldoutWithBoldLabelPropertyField(playAreaSettingsFoldoutHeader, showContent))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(showPlayArea, showContent);
                 EditorGUILayout.PropertyField(playAreaMaterial, materialContent);
                 EditorGUILayout.PropertyField(playAreaPhysicsLayer);
                 EditorGUI.indentLevel--;
@@ -121,11 +105,9 @@ namespace XRTK.Inspectors.Profiles
 
             EditorGUILayout.Space();
 
-            showTrackedArea.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showTrackedArea.isExpanded, trackedAreaSettingsFoldoutHeader, true);
-            if (showTrackedArea.isExpanded)
+            if (showTrackedArea.FoldoutWithBoldLabelPropertyField(trackedAreaSettingsFoldoutHeader, showContent))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(showTrackedArea, showContent);
                 EditorGUILayout.PropertyField(trackedAreaMaterial, materialContent);
                 EditorGUILayout.PropertyField(trackedAreaPhysicsLayer);
                 EditorGUI.indentLevel--;
@@ -133,11 +115,9 @@ namespace XRTK.Inspectors.Profiles
 
             EditorGUILayout.Space();
 
-            showBoundaryWalls.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showBoundaryWalls.isExpanded, boundaryWallSettingsFoldoutHeader, true);
-            if (showBoundaryWalls.isExpanded)
+            if (showBoundaryWalls.FoldoutWithBoldLabelPropertyField(boundaryWallSettingsFoldoutHeader, showContent))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(showBoundaryWalls, showContent);
                 EditorGUILayout.PropertyField(boundaryWallMaterial, materialContent);
                 EditorGUILayout.PropertyField(boundaryWallsPhysicsLayer);
                 EditorGUI.indentLevel--;
@@ -145,11 +125,9 @@ namespace XRTK.Inspectors.Profiles
 
             EditorGUILayout.Space();
 
-            showBoundaryCeiling.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showBoundaryCeiling.isExpanded, boundaryCeilingSettingsFoldoutHeader, true);
-            if (showBoundaryCeiling.isExpanded)
+            if (showBoundaryCeiling.FoldoutWithBoldLabelPropertyField(boundaryCeilingSettingsFoldoutHeader, showContent))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(showBoundaryCeiling, showContent);
                 EditorGUILayout.PropertyField(boundaryCeilingMaterial, materialContent);
                 EditorGUILayout.PropertyField(ceilingPhysicsLayer);
                 EditorGUI.indentLevel--;

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraSystemProfileInspector.cs
@@ -21,7 +21,6 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
             base.OnEnable();
 
             globalCameraProfile = serializedObject.FindProperty(nameof(globalCameraProfile));
-            globalCameraProfile.isExpanded = true;
         }
 
         public override void OnInspectorGUI()
@@ -32,8 +31,7 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
 
             EditorGUI.BeginChangeCheck();
 
-            globalCameraProfile.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(globalCameraProfile.isExpanded, generalSettingsFoldoutHeader, true);
-            if (globalCameraProfile.isExpanded)
+            if (globalCameraProfile.FoldoutWithBoldLabelPropertyField(generalSettingsFoldoutHeader))
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(globalCameraProfile);

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraSystemProfileInspector.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information. 
 
 using UnityEditor;
+using UnityEngine;
 using XRTK.Definitions.CameraSystem;
+using XRTK.Inspectors.Extensions;
 using XRTK.Services;
 
 namespace XRTK.Inspectors.Profiles.CameraSystem
@@ -12,11 +14,14 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
     {
         private SerializedProperty globalCameraProfile;
 
+        private readonly GUIContent generalSettingsFoldoutHeader = new GUIContent("General Settings");
+
         protected override void OnEnable()
         {
             base.OnEnable();
 
             globalCameraProfile = serializedObject.FindProperty(nameof(globalCameraProfile));
+            globalCameraProfile.isExpanded = true;
         }
 
         public override void OnInspectorGUI()
@@ -27,7 +32,15 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
 
             EditorGUI.BeginChangeCheck();
 
-            EditorGUILayout.PropertyField(globalCameraProfile);
+            globalCameraProfile.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(globalCameraProfile.isExpanded, generalSettingsFoldoutHeader, true);
+            if (globalCameraProfile.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(globalCameraProfile);
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.Space();
 
             base.OnInspectorGUI();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityServiceProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityServiceProviderProfileInspector.cs
@@ -24,8 +24,6 @@ namespace XRTK.Inspectors.Profiles
 
         private SerializedProperty configurations;
 
-        private bool showConfigurationFoldout = true;
-
         /// <summary>
         /// Gets the service constraint used to filter options listed in the
         /// <see cref="configurations"/> instance type dropdown. Set after
@@ -59,9 +57,9 @@ namespace XRTK.Inspectors.Profiles
         public override void OnInspectorGUI()
         {
             EditorGUILayout.Space();
-            showConfigurationFoldout = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showConfigurationFoldout, new GUIContent($"{ServiceConstraint.Name} Configuration Options"), true);
+            configurations.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(configurations.isExpanded, new GUIContent($"{ServiceConstraint.Name} Configuration Options"));
 
-            if (showConfigurationFoldout)
+            if (configurations.isExpanded)
             {
                 serializedObject.Update();
                 EditorGUILayout.Space();

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityServiceProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityServiceProviderProfileInspector.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using XRTK.Definitions;
 using XRTK.Definitions.Utilities;
 using XRTK.Extensions;
+using XRTK.Inspectors.Extensions;
 using XRTK.Inspectors.PropertyDrawers;
 using XRTK.Services;
 
@@ -58,7 +59,7 @@ namespace XRTK.Inspectors.Profiles
         public override void OnInspectorGUI()
         {
             EditorGUILayout.Space();
-            showConfigurationFoldout = EditorGUILayout.Foldout(showConfigurationFoldout, new GUIContent($"{ServiceConstraint.Name} Configuration Options"), true);
+            showConfigurationFoldout = EditorGUILayoutExtensions.FoldoutWithBoldLabel(showConfigurationFoldout, new GUIContent($"{ServiceConstraint.Name} Configuration Options"), true);
 
             if (showConfigurationFoldout)
             {

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityToolkitRootProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityToolkitRootProfileInspector.cs
@@ -52,6 +52,10 @@ namespace XRTK.Inspectors.Profiles
 
         private MixedRealityToolkitRootProfile rootProfile;
 
+        private readonly GUIContent enabledLabel = new GUIContent("Enabled");
+        private readonly GUIContent typeLabel = new GUIContent("Type");
+        private readonly GUIContent profileLabel = new GUIContent("Profile");
+
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -134,79 +138,76 @@ namespace XRTK.Inspectors.Profiles
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
             serializedObject.Update();
 
-            var previousLabelWidth = EditorGUIUtility.labelWidth;
-            EditorGUIUtility.labelWidth = 160f;
             EditorGUI.BeginChangeCheck();
 
             // Camera System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Camera System Settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(enableCameraSystem);
-            EditorGUILayout.PropertyField(cameraSystemType);
-            EditorGUILayout.PropertyField(cameraSystemProfile);
+            enableCameraSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableCameraSystem.boolValue);
+            EditorGUILayout.PropertyField(cameraSystemType, typeLabel);
+            EditorGUILayout.PropertyField(cameraSystemProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Input System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Input System Settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(enableInputSystem);
-            EditorGUILayout.PropertyField(inputSystemType);
-            EditorGUILayout.PropertyField(inputSystemProfile);
+            enableInputSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableInputSystem.boolValue);
+            EditorGUILayout.PropertyField(inputSystemType, typeLabel);
+            EditorGUILayout.PropertyField(inputSystemProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Boundary System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Boundary System Settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(enableBoundarySystem);
-            EditorGUILayout.PropertyField(boundarySystemType);
-            EditorGUILayout.PropertyField(boundaryVisualizationProfile);
+            enableBoundarySystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableBoundarySystem.boolValue);
+            EditorGUILayout.PropertyField(boundarySystemType, typeLabel);
+            EditorGUILayout.PropertyField(boundaryVisualizationProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Teleport System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Teleport System Settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(enableTeleportSystem);
-            EditorGUILayout.PropertyField(teleportSystemType);
+            enableTeleportSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableTeleportSystem.boolValue);
+            EditorGUILayout.PropertyField(teleportSystemType, typeLabel);
             EditorGUI.indentLevel--;
 
             // Spatial Awareness System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Spatial Awareness System Settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(enableSpatialAwarenessSystem);
-            EditorGUILayout.PropertyField(spatialAwarenessSystemType);
-            EditorGUILayout.PropertyField(spatialAwarenessProfile);
+            enableSpatialAwarenessSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableSpatialAwarenessSystem.boolValue);
+            EditorGUILayout.PropertyField(spatialAwarenessSystemType, typeLabel);
+            EditorGUILayout.PropertyField(spatialAwarenessProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Networking System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Networking System Settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(enableNetworkingSystem);
-            EditorGUILayout.PropertyField(networkingSystemType);
-            EditorGUILayout.PropertyField(networkingSystemProfile);
+            enableNetworkingSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableNetworkingSystem.boolValue);
+            EditorGUILayout.PropertyField(networkingSystemType, typeLabel);
+            EditorGUILayout.PropertyField(networkingSystemProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Diagnostics System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Diagnostics System Settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(enableDiagnosticsSystem);
-            EditorGUILayout.PropertyField(diagnosticsSystemType);
-            EditorGUILayout.PropertyField(diagnosticsSystemProfile);
+            enableDiagnosticsSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableDiagnosticsSystem.boolValue);
+            EditorGUILayout.PropertyField(diagnosticsSystemType, typeLabel);
+            EditorGUILayout.PropertyField(diagnosticsSystemProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Additional Service Providers", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(registeredServiceProvidersProfile);
+            EditorGUILayout.PropertyField(registeredServiceProvidersProfile, profileLabel);
             EditorGUI.indentLevel--;
 
-            EditorGUIUtility.labelWidth = previousLabelWidth;
             serializedObject.ApplyModifiedProperties();
 
             if (EditorGUI.EndChangeCheck() &&

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityToolkitRootProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityToolkitRootProfileInspector.cs
@@ -52,14 +52,37 @@ namespace XRTK.Inspectors.Profiles
 
         private MixedRealityToolkitRootProfile rootProfile;
 
-        private readonly GUIContent enabledLabel = new GUIContent("Enabled");
-        private readonly GUIContent typeLabel = new GUIContent("Type");
+        private readonly GUIContent typeLabel = new GUIContent("Instanced Type", "The class type to instantiate at runtime for this system.");
         private readonly GUIContent profileLabel = new GUIContent("Profile");
+        private GUIStyle headerStyle;
+
+        private GUIStyle HeaderStyle
+        {
+            get
+            {
+                if (headerStyle == null)
+                {
+                    var editorStyle = EditorGUIUtility.isProSkin ? EditorStyles.whiteLargeLabel : EditorStyles.largeLabel;
+
+                    if (editorStyle != null)
+                    {
+                        headerStyle = new GUIStyle(editorStyle)
+                        {
+                            alignment = TextAnchor.MiddleCenter,
+                            fontSize = 18,
+                            padding = new RectOffset(0, 0, -8, -8)
+                        };
+                    }
+                }
+
+                return headerStyle;
+            }
+        }
 
         protected override void OnEnable()
         {
             base.OnEnable();
-
+            headerStyle = null;
             rootProfile = target as MixedRealityToolkitRootProfile;
 
             var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
@@ -67,8 +90,6 @@ namespace XRTK.Inspectors.Profiles
             // Create The MR Manager if none exists.
             if (!MixedRealityToolkit.IsInitialized && prefabStage == null)
             {
-                // TODO Check base scene for service locator existence?
-
                 // Search for all instances, in case we've just hot reloaded the assembly.
                 var managerSearch = FindObjectsOfType<MixedRealityToolkit>();
 
@@ -136,75 +157,89 @@ namespace XRTK.Inspectors.Profiles
         public override void OnInspectorGUI()
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
+            EditorGUILayout.LabelField("The Mixed Reality Toolkit", HeaderStyle);
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+            RenderSystemFields();
+        }
+
+        internal void RenderSystemFields()
+        {
             serializedObject.Update();
 
             EditorGUI.BeginChangeCheck();
 
             // Camera System configuration
-            GUILayout.Space(12f);
-            EditorGUILayout.LabelField("Camera System Settings", EditorStyles.boldLabel);
+            enableCameraSystem.boolValue = EditorGUILayout.ToggleLeft("Camera System", enableCameraSystem.boolValue, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            enableCameraSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableCameraSystem.boolValue);
+            typeLabel.tooltip = cameraSystemType.tooltip;
             EditorGUILayout.PropertyField(cameraSystemType, typeLabel);
+            profileLabel.tooltip = cameraSystemProfile.tooltip;
             EditorGUILayout.PropertyField(cameraSystemProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Input System configuration
-            GUILayout.Space(12f);
-            EditorGUILayout.LabelField("Input System Settings", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+            enableInputSystem.boolValue = EditorGUILayout.ToggleLeft("Input System", enableInputSystem.boolValue, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            enableInputSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableInputSystem.boolValue);
+            typeLabel.tooltip = inputSystemType.tooltip;
             EditorGUILayout.PropertyField(inputSystemType, typeLabel);
+            profileLabel.tooltip = inputSystemProfile.tooltip;
             EditorGUILayout.PropertyField(inputSystemProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Boundary System configuration
-            GUILayout.Space(12f);
-            EditorGUILayout.LabelField("Boundary System Settings", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+            enableBoundarySystem.boolValue = EditorGUILayout.ToggleLeft("Boundary System", enableBoundarySystem.boolValue, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            enableBoundarySystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableBoundarySystem.boolValue);
+            typeLabel.tooltip = boundarySystemType.tooltip;
             EditorGUILayout.PropertyField(boundarySystemType, typeLabel);
+            profileLabel.tooltip = boundaryVisualizationProfile.tooltip;
             EditorGUILayout.PropertyField(boundaryVisualizationProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Teleport System configuration
-            GUILayout.Space(12f);
-            EditorGUILayout.LabelField("Teleport System Settings", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+            enableTeleportSystem.boolValue = EditorGUILayout.ToggleLeft("Teleport System", enableTeleportSystem.boolValue, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            enableTeleportSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableTeleportSystem.boolValue);
+            typeLabel.tooltip = teleportSystemType.tooltip;
             EditorGUILayout.PropertyField(teleportSystemType, typeLabel);
             EditorGUI.indentLevel--;
 
             // Spatial Awareness System configuration
-            GUILayout.Space(12f);
-            EditorGUILayout.LabelField("Spatial Awareness System Settings", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+            enableSpatialAwarenessSystem.boolValue = EditorGUILayout.ToggleLeft("Spatial Awareness System", enableSpatialAwarenessSystem.boolValue, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            enableSpatialAwarenessSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableSpatialAwarenessSystem.boolValue);
+            typeLabel.tooltip = spatialAwarenessSystemType.tooltip;
             EditorGUILayout.PropertyField(spatialAwarenessSystemType, typeLabel);
+            profileLabel.tooltip = spatialAwarenessProfile.tooltip;
             EditorGUILayout.PropertyField(spatialAwarenessProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Networking System configuration
-            GUILayout.Space(12f);
-            EditorGUILayout.LabelField("Networking System Settings", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+            enableNetworkingSystem.boolValue = EditorGUILayout.ToggleLeft("Networking System", enableNetworkingSystem.boolValue, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            enableNetworkingSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableNetworkingSystem.boolValue);
+            typeLabel.tooltip = networkingSystemType.tooltip;
             EditorGUILayout.PropertyField(networkingSystemType, typeLabel);
+            profileLabel.tooltip = networkingSystemProfile.tooltip;
             EditorGUILayout.PropertyField(networkingSystemProfile, profileLabel);
             EditorGUI.indentLevel--;
 
             // Diagnostics System configuration
-            GUILayout.Space(12f);
-            EditorGUILayout.LabelField("Diagnostics System Settings", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+            enableDiagnosticsSystem.boolValue = EditorGUILayout.ToggleLeft("Diagnostics System", enableDiagnosticsSystem.boolValue, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            enableDiagnosticsSystem.boolValue = EditorGUILayout.ToggleLeft(enabledLabel, enableDiagnosticsSystem.boolValue);
+            typeLabel.tooltip = diagnosticsSystemType.tooltip;
             EditorGUILayout.PropertyField(diagnosticsSystemType, typeLabel);
+            profileLabel.tooltip = diagnosticsSystemProfile.tooltip;
             EditorGUILayout.PropertyField(diagnosticsSystemProfile, profileLabel);
             EditorGUI.indentLevel--;
 
-            GUILayout.Space(12f);
+            EditorGUILayout.Space();
             EditorGUILayout.LabelField("Additional Service Providers", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
+            profileLabel.tooltip = registeredServiceProvidersProfile.tooltip;
             EditorGUILayout.PropertyField(registeredServiceProvidersProfile, profileLabel);
             EditorGUI.indentLevel--;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityToolkitRootProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityToolkitRootProfileInspector.cs
@@ -141,54 +141,70 @@ namespace XRTK.Inspectors.Profiles
             // Camera System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Camera System Settings", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(enableCameraSystem);
             EditorGUILayout.PropertyField(cameraSystemType);
             EditorGUILayout.PropertyField(cameraSystemProfile);
+            EditorGUI.indentLevel--;
 
             // Input System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Input System Settings", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(enableInputSystem);
             EditorGUILayout.PropertyField(inputSystemType);
             EditorGUILayout.PropertyField(inputSystemProfile);
+            EditorGUI.indentLevel--;
 
             // Boundary System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Boundary System Settings", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(enableBoundarySystem);
             EditorGUILayout.PropertyField(boundarySystemType);
             EditorGUILayout.PropertyField(boundaryVisualizationProfile);
+            EditorGUI.indentLevel--;
 
             // Teleport System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Teleport System Settings", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(enableTeleportSystem);
             EditorGUILayout.PropertyField(teleportSystemType);
+            EditorGUI.indentLevel--;
 
             // Spatial Awareness System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Spatial Awareness System Settings", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(enableSpatialAwarenessSystem);
             EditorGUILayout.PropertyField(spatialAwarenessSystemType);
             EditorGUILayout.PropertyField(spatialAwarenessProfile);
+            EditorGUI.indentLevel--;
 
             // Networking System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Networking System Settings", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(enableNetworkingSystem);
             EditorGUILayout.PropertyField(networkingSystemType);
             EditorGUILayout.PropertyField(networkingSystemProfile);
+            EditorGUI.indentLevel--;
 
             // Diagnostics System configuration
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Diagnostics System Settings", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(enableDiagnosticsSystem);
             EditorGUILayout.PropertyField(diagnosticsSystemType);
             EditorGUILayout.PropertyField(diagnosticsSystemProfile);
+            EditorGUI.indentLevel--;
 
             GUILayout.Space(12f);
             EditorGUILayout.LabelField("Additional Service Providers", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(registeredServiceProvidersProfile);
+            EditorGUI.indentLevel--;
 
             EditorGUIUtility.labelWidth = previousLabelWidth;
             serializedObject.ApplyModifiedProperties();

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySpatialMeshObserverProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySpatialMeshObserverProfileInspector.cs
@@ -4,6 +4,7 @@
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+using XRTK.Inspectors.Extensions;
 using XRTK.Inspectors.PropertyDrawers;
 using XRTK.Providers.SpatialObservers;
 
@@ -20,9 +21,10 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         private SerializedProperty additionalComponents;
         private SerializedProperty meshObjectPrefab;
 
-        private static bool foldout = true;
         private ReorderableList additionalComponentsList;
         private int currentlySelectedConfigurationOption;
+
+        private readonly GUIContent spatialMeshSettingsFoldoutHeader = new GUIContent("Spatial Mesh Settings");
 
         /// <inheritdoc />
         protected override void OnEnable()
@@ -30,6 +32,7 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
             base.OnEnable();
 
             meshLevelOfDetail = serializedObject.FindProperty(nameof(meshLevelOfDetail));
+            meshLevelOfDetail.isExpanded = true;
             meshTrianglesPerCubicMeter = serializedObject.FindProperty(nameof(meshTrianglesPerCubicMeter));
             meshRecalculateNormals = serializedObject.FindProperty(nameof(meshRecalculateNormals));
             meshVisibleMaterial = serializedObject.FindProperty(nameof(meshVisibleMaterial));
@@ -86,9 +89,8 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
 
             serializedObject.Update();
 
-            foldout = EditorGUILayout.Foldout(foldout, "Spatial Mesh Settings", true);
-
-            if (foldout)
+            meshLevelOfDetail.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(meshLevelOfDetail.isExpanded, spatialMeshSettingsFoldoutHeader, true);
+            if (meshLevelOfDetail.isExpanded)
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(meshLevelOfDetail);
@@ -102,6 +104,8 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
                 EditorGUILayout.HelpBox("The mesh object is procedurally generated, but you can also use an empty prefab object as well with predefined components and data.", MessageType.Info);
                 EditorGUI.indentLevel--;
             }
+
+            EditorGUILayout.Space();
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySpatialMeshObserverProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySpatialMeshObserverProfileInspector.cs
@@ -32,7 +32,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
             base.OnEnable();
 
             meshLevelOfDetail = serializedObject.FindProperty(nameof(meshLevelOfDetail));
-            meshLevelOfDetail.isExpanded = true;
             meshTrianglesPerCubicMeter = serializedObject.FindProperty(nameof(meshTrianglesPerCubicMeter));
             meshRecalculateNormals = serializedObject.FindProperty(nameof(meshRecalculateNormals));
             meshVisibleMaterial = serializedObject.FindProperty(nameof(meshVisibleMaterial));
@@ -89,11 +88,9 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
 
             serializedObject.Update();
 
-            meshLevelOfDetail.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(meshLevelOfDetail.isExpanded, spatialMeshSettingsFoldoutHeader, true);
-            if (meshLevelOfDetail.isExpanded)
+            if (meshLevelOfDetail.FoldoutWithBoldLabelPropertyField(spatialMeshSettingsFoldoutHeader))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(meshLevelOfDetail);
                 EditorGUILayout.PropertyField(meshTrianglesPerCubicMeter);
                 EditorGUILayout.PropertyField(meshRecalculateNormals);
                 EditorGUILayout.PropertyField(meshVisibleMaterial);

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySpatialObserverProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySpatialObserverProfileInspector.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEditor;
+using UnityEngine;
+using XRTK.Inspectors.Extensions;
 using XRTK.Providers.SpatialObservers;
 
 namespace XRTK.Inspectors.Profiles.SpatialAwareness
@@ -15,7 +17,7 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         private SerializedProperty updateInterval;
         private SerializedProperty physicsLayer;
 
-        private static bool foldout = true;
+        private readonly GUIContent generalSettingsFoldoutHeader = new GUIContent("General Settings");
 
         /// <inheritdoc />
         protected override void OnEnable()
@@ -23,6 +25,7 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
             base.OnEnable();
 
             startupBehavior = serializedObject.FindProperty(nameof(startupBehavior));
+            startupBehavior.isExpanded = true;
             observationExtents = serializedObject.FindProperty(nameof(observationExtents));
             isStationaryObserver = serializedObject.FindProperty(nameof(isStationaryObserver));
             updateInterval = serializedObject.FindProperty(nameof(updateInterval));
@@ -36,9 +39,8 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
 
             serializedObject.Update();
 
-            foldout = EditorGUILayout.Foldout(foldout, "General Settings", true);
-
-            if (foldout)
+            startupBehavior.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(startupBehavior.isExpanded, generalSettingsFoldoutHeader, true);
+            if (startupBehavior.isExpanded)
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(startupBehavior);
@@ -48,6 +50,8 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
                 EditorGUILayout.PropertyField(physicsLayer);
                 EditorGUI.indentLevel--;
             }
+
+            EditorGUILayout.Space();
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySpatialObserverProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySpatialObserverProfileInspector.cs
@@ -25,7 +25,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
             base.OnEnable();
 
             startupBehavior = serializedObject.FindProperty(nameof(startupBehavior));
-            startupBehavior.isExpanded = true;
             observationExtents = serializedObject.FindProperty(nameof(observationExtents));
             isStationaryObserver = serializedObject.FindProperty(nameof(isStationaryObserver));
             updateInterval = serializedObject.FindProperty(nameof(updateInterval));
@@ -39,11 +38,9 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
 
             serializedObject.Update();
 
-            startupBehavior.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(startupBehavior.isExpanded, generalSettingsFoldoutHeader, true);
-            if (startupBehavior.isExpanded)
+            if (startupBehavior.FoldoutWithBoldLabelPropertyField(generalSettingsFoldoutHeader))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(startupBehavior);
                 EditorGUILayout.PropertyField(observationExtents);
                 EditorGUILayout.PropertyField(isStationaryObserver);
                 EditorGUILayout.PropertyField(updateInterval);

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySurfaceObserverProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/BaseMixedRealitySurfaceObserverProfileInspector.cs
@@ -3,6 +3,7 @@
 
 using UnityEditor;
 using UnityEngine;
+using XRTK.Inspectors.Extensions;
 using XRTK.Providers.SpatialObservers;
 
 namespace XRTK.Inspectors.Profiles.SpatialAwareness
@@ -10,7 +11,8 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
     [CustomEditor(typeof(BaseMixedRealitySurfaceObserverProfile), true, isFallback = true)]
     public class BaseMixedRealitySurfaceObserverProfileInspector : BaseMixedRealitySpatialObserverProfileInspector
     {
-        private SerializedProperty surfacePhysicsLayerOverride;
+        private readonly GUIContent surfaceFoldoutContent = new GUIContent("Surface Finding Settings");
+
         private SerializedProperty surfaceFindingMinimumArea;
         private SerializedProperty displayFloorSurfaces;
         private SerializedProperty floorSurfaceMaterial;
@@ -27,14 +29,11 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         private readonly GUIContent wallMaterialContent = new GUIContent("Wall Material");
         private readonly GUIContent minimumAreaContent = new GUIContent("Minimum Area");
 
-        private bool foldout = true;
-
         /// <inheritdoc />
         protected override void OnEnable()
         {
             base.OnEnable();
 
-            surfacePhysicsLayerOverride = serializedObject.FindProperty(nameof(surfacePhysicsLayerOverride));
             surfaceFindingMinimumArea = serializedObject.FindProperty(nameof(surfaceFindingMinimumArea));
             displayFloorSurfaces = serializedObject.FindProperty(nameof(displayFloorSurfaces));
             floorSurfaceMaterial = serializedObject.FindProperty(nameof(floorSurfaceMaterial));
@@ -53,13 +52,9 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
 
             serializedObject.Update();
 
-            foldout = EditorGUILayout.Foldout(foldout, "Surface Finding Settings", true);
-
-            if (foldout)
+            if (surfaceFindingMinimumArea.FoldoutWithBoldLabelPropertyField(surfaceFoldoutContent, minimumAreaContent))
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(surfacePhysicsLayerOverride);
-                EditorGUILayout.PropertyField(surfaceFindingMinimumArea, minimumAreaContent);
                 EditorGUILayout.PropertyField(displayFloorSurfaces);
                 EditorGUILayout.PropertyField(floorSurfaceMaterial, floorMaterialContent);
                 EditorGUILayout.PropertyField(displayCeilingSurfaces);

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystemProfileInspector.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using UnityEditor;
+using UnityEngine;
 using XRTK.Definitions.SpatialAwarenessSystem;
+using XRTK.Inspectors.Extensions;
 
 namespace XRTK.Inspectors.Profiles.SpatialAwareness
 {
@@ -13,12 +15,15 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
         private SerializedProperty globalMeshObserverProfile;
         private SerializedProperty globalSurfaceObserverProfile;
 
+        private readonly GUIContent generalSettingsFoldoutHeader = new GUIContent("General Settings");
+
         /// <inheritdoc />
         protected override void OnEnable()
         {
             base.OnEnable();
 
             meshDisplayOption = serializedObject.FindProperty(nameof(meshDisplayOption));
+            meshDisplayOption.isExpanded = true;
             globalMeshObserverProfile = serializedObject.FindProperty(nameof(globalMeshObserverProfile));
             globalSurfaceObserverProfile = serializedObject.FindProperty(nameof(globalSurfaceObserverProfile));
         }
@@ -29,10 +34,18 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
             RenderHeader("Spatial Awareness can enhance your experience by enabling objects to interact with the real world.\n\nBelow is a list of registered Spatial Observers that can gather data about your environment.");
 
             serializedObject.Update();
-            EditorGUILayout.PropertyField(meshDisplayOption);
-            EditorGUILayout.Space();
-            EditorGUILayout.PropertyField(globalMeshObserverProfile);
-            EditorGUILayout.PropertyField(globalSurfaceObserverProfile);
+
+            meshDisplayOption.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(meshDisplayOption.isExpanded, generalSettingsFoldoutHeader, true);
+            if (meshDisplayOption.isExpanded)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(meshDisplayOption);
+                EditorGUILayout.Space();
+                EditorGUILayout.PropertyField(globalMeshObserverProfile);
+                EditorGUILayout.PropertyField(globalSurfaceObserverProfile);
+                EditorGUI.indentLevel--;
+            }
+
             serializedObject.ApplyModifiedProperties();
 
             base.OnInspectorGUI();

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystemProfileInspector.cs
@@ -23,7 +23,6 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
             base.OnEnable();
 
             meshDisplayOption = serializedObject.FindProperty(nameof(meshDisplayOption));
-            meshDisplayOption.isExpanded = true;
             globalMeshObserverProfile = serializedObject.FindProperty(nameof(globalMeshObserverProfile));
             globalSurfaceObserverProfile = serializedObject.FindProperty(nameof(globalSurfaceObserverProfile));
         }
@@ -35,12 +34,10 @@ namespace XRTK.Inspectors.Profiles.SpatialAwareness
 
             serializedObject.Update();
 
-            meshDisplayOption.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(meshDisplayOption.isExpanded, generalSettingsFoldoutHeader, true);
-            if (meshDisplayOption.isExpanded)
+            if (meshDisplayOption.FoldoutWithBoldLabelPropertyField(generalSettingsFoldoutHeader))
             {
-                EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(meshDisplayOption);
                 EditorGUILayout.Space();
+                EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(globalMeshObserverProfile);
                 EditorGUILayout.PropertyField(globalSurfaceObserverProfile);
                 EditorGUI.indentLevel--;

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/MixedRealityProfilePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/PropertyDrawers/MixedRealityProfilePropertyDrawer.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions;
 using XRTK.Inspectors.Utilities;
+using XRTK.Services;
 
 namespace XRTK.Inspectors.PropertyDrawers
 {
@@ -35,7 +36,14 @@ namespace XRTK.Inspectors.PropertyDrawers
 
                 if (parent == null)
                 {
-                    parent = Selection.activeObject as BaseMixedRealityProfile;
+                    if (Selection.activeObject.name.Equals(nameof(MixedRealityToolkit)))
+                    {
+                        parent = MixedRealityToolkit.Instance.ActiveProfile;
+                    }
+                    else
+                    {
+                        parent = Selection.activeObject as BaseMixedRealityProfile;
+                    }
                 }
 
                 ParentProfileOverride = null;

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProviderInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProviderInspector.cs
@@ -4,6 +4,7 @@
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+using XRTK.Inspectors.Extensions;
 using XRTK.Utilities.Lines.DataProviders;
 using XRTK.Utilities.Lines.Renderers;
 using XRTK.Utilities.Physics.Distorters;
@@ -14,14 +15,11 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
     public class BaseMixedRealityLineDataProviderInspector : Editor
     {
         private const string DrawLinePointsKey = "XRTK_Line_Inspector_DrawLinePoints";
-        private const string BasicSettingsFoldoutKey = "XRTK_Line_Inspector_BasicSettings";
         private const string DrawLineRotationsKey = "XRTK_Line_Inspector_DrawLineRotations";
         private const string EditorSettingsFoldoutKey = "XRTK_Line_Inspector_EditorSettings";
         private const string RotationArrowLengthKey = "XRTK_Line_Inspector_RotationArrowLength";
-        private const string RotationSettingsFoldoutKey = "XRTK_Line_Inspector_RotationSettings";
         private const string ManualUpVectorLengthKey = "XRTK_Line_Inspector_ManualUpVectorLength";
         private const string LinePreviewResolutionKey = "XRTK_Line_Inspector_LinePreviewResolution";
-        private const string DistortionSettingsFoldoutKey = "XRTK_Line_Inspector_DistortionSettings";
         private const string DrawLineManualUpVectorsKey = "XRTK_Line_Inspector_DrawLineManualUpVectors";
 
         private const float ManualUpVectorHandleSizeModifier = 0.1f;
@@ -32,11 +30,7 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
         private static readonly GUIContent RotationSettingsContent = new GUIContent("Rotation Settings");
         private static readonly GUIContent DistortionSettingsContent = new GUIContent("Distortion Settings");
 
-        private static bool basicSettingsFoldout = true;
         private static bool editorSettingsFoldout = false;
-        private static bool rotationSettingsFoldout = true;
-        private static bool distortionSettingsFoldout = true;
-
         protected static int LinePreviewResolution = 16;
 
         protected static bool DrawLinePoints = false;
@@ -51,7 +45,7 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
         private SerializedProperty lineStartClamp;
         private SerializedProperty lineEndClamp;
         private SerializedProperty loops;
-        private SerializedProperty rotationType;
+        private SerializedProperty rotationMode;
         private SerializedProperty flipUpVector;
         private SerializedProperty originOffset;
         private SerializedProperty manualUpVectorBlend;
@@ -69,11 +63,7 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
 
         protected virtual void OnEnable()
         {
-            basicSettingsFoldout = SessionState.GetBool(BasicSettingsFoldoutKey, basicSettingsFoldout);
             editorSettingsFoldout = SessionState.GetBool(EditorSettingsFoldoutKey, editorSettingsFoldout);
-            rotationSettingsFoldout = SessionState.GetBool(RotationSettingsFoldoutKey, rotationSettingsFoldout);
-            distortionSettingsFoldout = SessionState.GetBool(DistortionSettingsFoldoutKey, distortionSettingsFoldout);
-
             LinePreviewResolution = SessionState.GetInt(LinePreviewResolutionKey, LinePreviewResolution);
             DrawLinePoints = SessionState.GetBool(DrawLinePointsKey, DrawLinePoints);
             DrawLineRotations = SessionState.GetBool(DrawLineRotationsKey, DrawLineRotations);
@@ -82,21 +72,21 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
             ManualUpVectorLength = SessionState.GetFloat(ManualUpVectorLengthKey, ManualUpVectorLength);
 
             LineData = (BaseMixedRealityLineDataProvider)target;
-            transformMode = serializedObject.FindProperty("transformMode");
-            customLineTransform = serializedObject.FindProperty("customLineTransform");
-            lineStartClamp = serializedObject.FindProperty("lineStartClamp");
-            lineEndClamp = serializedObject.FindProperty("lineEndClamp");
-            loops = serializedObject.FindProperty("loops");
-            rotationType = serializedObject.FindProperty("rotationMode");
-            flipUpVector = serializedObject.FindProperty("flipUpVector");
-            originOffset = serializedObject.FindProperty("originOffset");
-            manualUpVectorBlend = serializedObject.FindProperty("manualUpVectorBlend");
-            manualUpVectors = serializedObject.FindProperty("manualUpVectors");
-            velocitySearchRange = serializedObject.FindProperty("velocitySearchRange");
-            distorters = serializedObject.FindProperty("distorters");
-            distortionMode = serializedObject.FindProperty("distortionMode");
-            distortionStrength = serializedObject.FindProperty("distortionStrength");
-            uniformDistortionStrength = serializedObject.FindProperty("uniformDistortionStrength");
+            transformMode = serializedObject.FindProperty(nameof(transformMode));
+            customLineTransform = serializedObject.FindProperty(nameof(customLineTransform));
+            lineStartClamp = serializedObject.FindProperty(nameof(lineStartClamp));
+            lineEndClamp = serializedObject.FindProperty(nameof(lineEndClamp));
+            loops = serializedObject.FindProperty(nameof(loops));
+            rotationMode = serializedObject.FindProperty(nameof(rotationMode));
+            flipUpVector = serializedObject.FindProperty(nameof(flipUpVector));
+            originOffset = serializedObject.FindProperty(nameof(originOffset));
+            manualUpVectorBlend = serializedObject.FindProperty(nameof(manualUpVectorBlend));
+            manualUpVectors = serializedObject.FindProperty(nameof(manualUpVectors));
+            velocitySearchRange = serializedObject.FindProperty(nameof(velocitySearchRange));
+            distorters = serializedObject.FindProperty(nameof(distorters));
+            distortionMode = serializedObject.FindProperty(nameof(distortionMode));
+            distortionStrength = serializedObject.FindProperty(nameof(distortionStrength));
+            uniformDistortionStrength = serializedObject.FindProperty(nameof(uniformDistortionStrength));
 
             manualUpVectorList = new ReorderableList(serializedObject, manualUpVectors, false, true, true, true);
             manualUpVectorList.drawElementCallback += DrawManualUpVectorListElement;
@@ -120,7 +110,7 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
         {
             serializedObject.Update();
 
-            editorSettingsFoldout = EditorGUILayout.Foldout(editorSettingsFoldout, EditorSettingsContent, true);
+            editorSettingsFoldout = EditorGUILayoutExtensions.FoldoutWithBoldLabel(editorSettingsFoldout, EditorSettingsContent);
             SessionState.SetBool(EditorSettingsFoldoutKey, editorSettingsFoldout);
 
             if (editorSettingsFoldout)
@@ -192,14 +182,10 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
                 EditorGUI.indentLevel--;
             }
 
-            basicSettingsFoldout = EditorGUILayout.Foldout(basicSettingsFoldout, BasicSettingsContent, true);
-            SessionState.SetBool(BasicSettingsFoldoutKey, basicSettingsFoldout);
-
-            if (basicSettingsFoldout)
+            if (transformMode.FoldoutWithBoldLabelPropertyField(BasicSettingsContent))
             {
                 EditorGUI.indentLevel++;
 
-                EditorGUILayout.PropertyField(transformMode);
                 EditorGUILayout.PropertyField(customLineTransform);
                 EditorGUILayout.PropertyField(lineStartClamp);
                 EditorGUILayout.PropertyField(lineEndClamp);
@@ -208,14 +194,11 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
                 EditorGUI.indentLevel--;
             }
 
-            rotationSettingsFoldout = EditorGUILayout.Foldout(rotationSettingsFoldout, RotationSettingsContent, true);
-            SessionState.SetBool(RotationSettingsFoldoutKey, rotationSettingsFoldout);
-
-            if (rotationSettingsFoldout)
+            if (rotationMode.FoldoutWithBoldLabelPropertyField(RotationSettingsContent))
             {
                 EditorGUI.indentLevel++;
 
-                EditorGUILayout.PropertyField(rotationType);
+                EditorGUILayout.PropertyField(rotationMode);
                 EditorGUILayout.PropertyField(flipUpVector);
                 EditorGUILayout.PropertyField(originOffset);
                 EditorGUILayout.PropertyField(velocitySearchRange);
@@ -248,13 +231,8 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
                 EditorGUI.indentLevel--;
             }
 
-            distortionSettingsFoldout = EditorGUILayout.Foldout(distortionSettingsFoldout, DistortionSettingsContent, true);
-            SessionState.SetBool(DistortionSettingsFoldoutKey, distortionSettingsFoldout);
-
-            if (distortionSettingsFoldout)
+            if (distortionMode.FoldoutWithBoldLabelPropertyField(DistortionSettingsContent))
             {
-                EditorGUILayout.HelpBox("No distorters attached to this line.\nTry adding a distortion component.", MessageType.Info);
-
                 EditorGUI.indentLevel++;
 
                 EditorGUILayout.PropertyField(distortionMode);

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Lines/DataProviders/BezierDataProviderInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Lines/DataProviders/BezierDataProviderInspector.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEditor;
 using UnityEngine;
+using XRTK.Inspectors.Extensions;
 using XRTK.Utilities.Lines;
 
 namespace XRTK.Inspectors.Utilities.Lines.DataProviders
@@ -20,9 +21,9 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
         {
             base.OnEnable();
 
-            controlPoints = serializedObject.FindProperty("controlPoints");
-            inertia = serializedObject.FindProperty("inertia");
-            useLocalTangentPoints = serializedObject.FindProperty("useLocalTangentPoints");
+            controlPoints = serializedObject.FindProperty(nameof(controlPoints));
+            inertia = serializedObject.FindProperty(nameof(inertia));
+            useLocalTangentPoints = serializedObject.FindProperty(nameof(useLocalTangentPoints));
         }
 
         public override void OnInspectorGUI()
@@ -32,10 +33,13 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
 
             // We always draw line points for bezier.
             DrawLinePoints = true;
-
-            EditorGUILayout.PropertyField(controlPoints, true);
-            EditorGUILayout.PropertyField(inertia, true);
-            EditorGUILayout.PropertyField(useLocalTangentPoints);
+            if (useLocalTangentPoints.FoldoutWithBoldLabelPropertyField(new GUIContent("Bezier Settings")))
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(controlPoints, true);
+                EditorGUILayout.PropertyField(inertia, true);
+                EditorGUI.indentLevel--;
+            }
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Lines/DataProviders/SplineDataProviderInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Utilities/Lines/DataProviders/SplineDataProviderInspector.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
 using XRTK.Definitions.Utilities;
+using XRTK.Inspectors.Extensions;
 using XRTK.Utilities.Lines.DataProviders;
 
 namespace XRTK.Inspectors.Utilities.Lines.DataProviders
@@ -31,8 +32,6 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
         private static readonly GUIContent RemoveControlPointContent = new GUIContent("-", "Remove a control point");
         private static readonly GUIContent ControlPointHeaderContent = new GUIContent("Spline Control Points", "The current control points for the spline.");
 
-        private static bool controlPointFoldout = true;
-
         private SerializedProperty controlPoints;
         private SerializedProperty alignAllControlPoints;
 
@@ -46,8 +45,8 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
             base.OnEnable();
 
             splineData = (SplineDataProvider)target;
-            controlPoints = serializedObject.FindProperty("controlPoints");
-            alignAllControlPoints = serializedObject.FindProperty("alignAllControlPoints");
+            controlPoints = serializedObject.FindProperty(nameof(controlPoints));
+            alignAllControlPoints = serializedObject.FindProperty(nameof(alignAllControlPoints));
 
             controlPointList = new ReorderableList(serializedObject, controlPoints, false, false, false, false)
             {
@@ -87,9 +86,9 @@ namespace XRTK.Inspectors.Utilities.Lines.DataProviders
             GUI.enabled = true;
             GUILayout.EndHorizontal();
 
-            controlPointFoldout = EditorGUILayout.Foldout(controlPointFoldout, ControlPointHeaderContent, true);
+            controlPoints.isExpanded = EditorGUILayoutExtensions.FoldoutWithBoldLabel(controlPoints.isExpanded, ControlPointHeaderContent);
 
-            if (controlPointFoldout)
+            if (controlPoints.isExpanded)
             {
                 // If we found overlapping points, provide an option to auto-separate them
                 if (OverlappingPointIndexes.Count > 0)

--- a/XRTK-Core/Packages/com.xrtk.core/Utilities/Lines/DataProviders/BezierLineDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Utilities/Lines/DataProviders/BezierLineDataProvider.cs
@@ -92,8 +92,6 @@ namespace XRTK.Utilities.Lines
 
         public override int PointCount => 4;
 
-        [Header("Bezier Settings")]
-
         [SerializeField]
         private BezierInertia inertia;
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Just adds an inspector extension / utility to render a foldout with a bold label easily, like in many standard Unity inspectors. Also updates all the inspectors (except input system, since that one is currently under construction in other PRs).

![mesh_observer](https://user-images.githubusercontent.com/9565734/80231386-96491180-8653-11ea-90fb-ffa477738dc8.PNG)
![awareness_system](https://user-images.githubusercontent.com/9565734/80231388-96e1a800-8653-11ea-83f5-8f4d68c4cada.PNG)
![camera_system](https://user-images.githubusercontent.com/9565734/80231371-947f4e00-8653-11ea-9d4f-0b7398d71a0a.PNG)
![camera_data_provider](https://user-images.githubusercontent.com/9565734/80231380-95b07b00-8653-11ea-9795-8d2b3bc4288a.PNG)
![boundary_system](https://user-images.githubusercontent.com/9565734/80231381-95b07b00-8653-11ea-8882-1619d64e4056.PNG)
![diagnostics_system](https://user-images.githubusercontent.com/9565734/80231384-96491180-8653-11ea-863c-10db6bab661d.PNG)
![image](https://user-images.githubusercontent.com/13334553/80255004-21bda500-864a-11ea-9af8-6ae114c07942.png)
![image](https://user-images.githubusercontent.com/13334553/80255034-2f732a80-864a-11ea-84aa-8c36dd3abfa1.png)

