### PR TITLE
fixed duplicate global profile entry in the camera system profile inspector

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Inspectors/Profiles/MixedRealityCameraSystemProfileInspector.cs
@@ -31,12 +31,7 @@ namespace XRTK.Inspectors.Profiles.CameraSystem
 
             EditorGUI.BeginChangeCheck();
 
-            if (globalCameraProfile.FoldoutWithBoldLabelPropertyField(generalSettingsFoldoutHeader))
-            {
-                EditorGUI.indentLevel++;
-                EditorGUILayout.PropertyField(globalCameraProfile);
-                EditorGUI.indentLevel--;
-            }
+            globalCameraProfile.FoldoutWithBoldLabelPropertyField(generalSettingsFoldoutHeader);
 
             EditorGUILayout.Space();
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Global profile object field was being rendered twice. Updated to use property foldout extension method.