### PR TITLE
Concrete Instanced Guid References

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/ControllerPopupWindow.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/ControllerPopupWindow.cs
@@ -65,7 +65,7 @@ namespace XRTK.Editor
                                            ControllerType == typeof(GenericJoystickController) ||
                                            ControllerType == typeof(IMixedRealityHandController);
 
-        private static string EditorWindowOptionsPath => $"{PathFinderUtility.XRTK_Core_RelativeFolderPath}/Inspectors/Data/EditorWindowOptions.json";
+        private static string EditorWindowOptionsPath => $"{PathFinderUtility.XRTK_Core_RelativeFolderPath.Replace("/Runtime", "/Editor")}/Data/EditorWindowOptions.json";
 
         private void OnFocus()
         {

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/Controllers/BaseMixedRealityControllerDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/Controllers/BaseMixedRealityControllerDataProviderProfileInspector.cs
@@ -256,9 +256,7 @@ namespace XRTK.Editor.Profiles.InputSystem.Controllers
 
         internal void RenderControllerMappingButton(MixedRealityControllerMappingProfile controllerMappingProfile)
         {
-            var controllerType = controllerMappingProfile.ControllerType?.Type;
-
-            if (controllerType == null) { return; }
+            var controllerType = controllerMappingProfile.ControllerType.Type;
 
             if (controllerButtonStyle == null)
             {
@@ -280,9 +278,9 @@ namespace XRTK.Editor.Profiles.InputSystem.Controllers
                 GUILayout.BeginHorizontal();
             }
 
-            var typeName = controllerType.Name.ToProperCase();
+            var typeName = controllerType?.Name.ToProperCase();
 
-            if (controllerType.Name == "WindowsMixedRealityMotionController" && controllerMappingProfile.Handedness == Handedness.None)
+            if (controllerType?.Name == "WindowsMixedRealityMotionController" && controllerMappingProfile.Handedness == Handedness.None)
             {
                 typeName = "HoloLens 1";
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/Controllers/BaseMixedRealityControllerDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/Controllers/BaseMixedRealityControllerDataProviderProfileInspector.cs
@@ -60,9 +60,9 @@ namespace XRTK.Editor.Profiles.InputSystem.Controllers
 
                 for (int i = 0; i < defaultControllerOptions.Length; i++)
                 {
-                    var defaultControllerMappingProfile = defaultControllerOptions[i];
+                    var defaultControllerOption = defaultControllerOptions[i];
 
-                    var controllerMappingAsset = CreateInstance(nameof(MixedRealityControllerMappingProfile)).CreateAsset($"{profileRootPath}/", $"{defaultControllerMappingProfile.Description}Profile", false) as MixedRealityControllerMappingProfile;
+                    var controllerMappingAsset = CreateInstance(nameof(MixedRealityControllerMappingProfile)).CreateAsset($"{profileRootPath}/", $"{defaultControllerOption.Description}Profile", false) as MixedRealityControllerMappingProfile;
 
                     Debug.Assert(controllerMappingAsset != null);
 
@@ -70,22 +70,21 @@ namespace XRTK.Editor.Profiles.InputSystem.Controllers
                     mappingProfileSerializedObject.Update();
 
                     var controllerTypeProperty = mappingProfileSerializedObject.FindProperty("controllerType").FindPropertyRelative("reference");
-                    TypeExtensions.TryResolveType(controllerTypeProperty.stringValue, out var controllerType);
                     var handednessProperty = mappingProfileSerializedObject.FindProperty("handedness");
                     var useCustomInteractionsProperty = mappingProfileSerializedObject.FindProperty("useCustomInteractions");
                     var interactionMappingProfilesProperty = mappingProfileSerializedObject.FindProperty("interactionMappingProfiles");
 
-                    if (defaultControllerMappingProfile.ControllerType?.Type?.GUID != Guid.Empty)
+                    if (defaultControllerOption.ControllerType.Type.GUID != Guid.Empty)
                     {
-                        controllerTypeProperty.stringValue = defaultControllerMappingProfile.ControllerType?.Type?.GUID.ToString();
+                        controllerTypeProperty.stringValue = defaultControllerOption.ControllerType.Type.GUID.ToString();
                     }
                     else
                     {
-                        Debug.LogError($"{defaultControllerMappingProfile.ControllerType} requires a {nameof(GuidAttribute)}");
+                        Debug.LogError($"{defaultControllerOption.ControllerType} requires a {nameof(GuidAttribute)}");
                     }
 
-                    handednessProperty.intValue = (int)defaultControllerMappingProfile.Handedness;
-                    useCustomInteractionsProperty.boolValue = defaultControllerMappingProfile.UseCustomInteractions;
+                    handednessProperty.intValue = (int)defaultControllerOption.Handedness;
+                    useCustomInteractionsProperty.boolValue = defaultControllerOption.UseCustomInteractions;
 
                     SetDefaultInteractionMapping();
                     mappingProfileSerializedObject.ApplyModifiedProperties();

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -10,7 +10,6 @@ using UnityEngine;
 using XRTK.Attributes;
 using XRTK.Definitions.Utilities;
 using XRTK.Extensions;
-using XRTK.Interfaces;
 using Assembly = System.Reflection.Assembly;
 
 namespace XRTK.Editor.PropertyDrawers

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -255,10 +255,9 @@ namespace XRTK.Editor.PropertyDrawers
             {
                 var referenceProperty = systemTypeProperty.FindPropertyRelative("reference");
                 EditorGUI.showMixedValue = referenceProperty.hasMultipleDifferentValues;
-                var guid = referenceProperty.stringValue;
                 var restoreShowMixedValue = EditorGUI.showMixedValue;
 
-                if (TypeExtensions.TryResolveType(guid, out var resolvedType))
+                if (TypeExtensions.TryResolveType(referenceProperty.stringValue, out var resolvedType))
                 {
                     if (resolvedType.GUID != Guid.Empty)
                     {

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -268,7 +268,7 @@ namespace XRTK.Editor.PropertyDrawers
                     {
                         var qualifiedNameComponents = resolvedType?.AssemblyQualifiedName?.Split(',');
                         Debug.Assert(qualifiedNameComponents?.Length >= 2);
-                        referenceProperty.stringValue = $"{qualifiedNameComponents[0]}, {qualifiedNameComponents[1].Trim()}"; ;
+                        referenceProperty.stringValue = $"{qualifiedNameComponents[0]}, {qualifiedNameComponents[1].Trim()}";
                     }
                 }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -218,7 +218,7 @@ namespace XRTK.Editor.PropertyDrawers
                     break;
 
                 case EventType.Repaint:
-                    TempContent.text = selectedType == null ? "(None)" : selectedType.Name;
+                    TempContent.text = selectedType == null ? None : selectedType.Name;
 
                     if (TempContent.text == string.Empty)
                     {

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -25,7 +25,6 @@ namespace XRTK.Editor.PropertyDrawers
         public const string TypeReferenceUpdated = "TypeReferenceUpdated";
 
         private const string None = "(None)";
-        private const string Missing = " {missing}";
 
         /// <summary>
         /// The currently selected <see cref="Type"/> in the dropdown menu.
@@ -35,9 +34,6 @@ namespace XRTK.Editor.PropertyDrawers
         private static int selectionControlId;
         private static readonly int ControlHint = typeof(TypeReferencePropertyDrawer).GetHashCode();
         private static readonly GUIContent TempContent = new GUIContent();
-        private static readonly GUIContent RepairContent = new GUIContent("Repair", "Try to repair the reference");
-        private static readonly Color EnabledColor = Color.white;
-        private static readonly Color DisabledColor = Color.Lerp(Color.white, Color.clear, 0.5f);
 
         #region Type Filtering
 
@@ -279,47 +275,6 @@ namespace XRTK.Editor.PropertyDrawers
                 FilterConstraintOverride = null;
                 ExcludedTypeCollectionGetter = null;
             }
-        }
-
-        private static readonly char[] CsvSplit = { ',' };
-
-        private static bool TypeSearch(SerializedProperty property, ref string typeName, SystemTypeAttribute filter, bool showPickerWindow)
-        {
-            if (typeName.Contains(Missing)) { return false; }
-            var typeNameWithoutAssembly = typeName.Split(CsvSplit, StringSplitOptions.None)[0];
-            var typeNameWithoutNamespace = System.Text.RegularExpressions.Regex.Replace(typeNameWithoutAssembly, @"[.\w]+\.(\w+)", "$1");
-            var repairedTypeOptions = FindTypesByName(typeNameWithoutNamespace, filter);
-
-            switch (repairedTypeOptions.Length)
-            {
-                case 0:
-                    if (showPickerWindow)
-                    {
-                        EditorApplication.delayCall += () =>
-                            EditorUtility.DisplayDialog(
-                                "No types found",
-                                $"No types with the name '{typeNameWithoutNamespace}' were found.",
-                                "OK");
-                    }
-
-                    return false;
-                case 1:
-                    typeName = repairedTypeOptions[0].GUID.ToString();
-                    return true;
-                default:
-                    if (showPickerWindow)
-                    {
-                        EditorApplication.delayCall += () =>
-                            SystemTypeRepairWindow.Display(repairedTypeOptions, property);
-                    }
-
-                    return false;
-            }
-        }
-
-        private static Type[] FindTypesByName(string typeName, SystemTypeAttribute filter)
-        {
-            return GetFilteredTypes(filter).Where(type => type.Name.Equals(typeName)).ToArray();
         }
 
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -265,7 +265,7 @@ namespace XRTK.Editor.PropertyDrawers
                     }
                     else
                     {
-                        var qualifiedNameComponents = resolvedType?.AssemblyQualifiedName?.Split(',');
+                        var qualifiedNameComponents = resolvedType.AssemblyQualifiedName?.Split(',');
                         Debug.Assert(qualifiedNameComponents?.Length >= 2);
                         referenceProperty.stringValue = $"{qualifiedNameComponents[0]}, {qualifiedNameComponents[1].Trim()}";
                     }

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/SystemTypeRepairWindow.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/SystemTypeRepairWindow.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using UnityEditor;
 using UnityEngine;
-using XRTK.Definitions.Utilities;
 
 namespace XRTK.Editor
 {
@@ -39,9 +41,10 @@ namespace XRTK.Editor
         {
             foreach (var type in repairedTypeOptions)
             {
-                if (GUILayout.Button(type.FullName, EditorStyles.miniButton))
+                if (type.GUID != Guid.Empty &&
+                    GUILayout.Button(type.FullName, EditorStyles.miniButton))
                 {
-                    property.stringValue = SystemType.GetReference(type);
+                    property.stringValue = type.GUID.ToString();
                     property.serializedObject.ApplyModifiedProperties();
                     Close();
                 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Controllers/UnityInput/TouchScreenControllerDataProviderProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Controllers/UnityInput/TouchScreenControllerDataProviderProfile.cs
@@ -6,6 +6,7 @@ using XRTK.Providers.Controllers.UnityInput;
 
 namespace XRTK.Definitions.Controllers.UnityInput.Profiles
 {
+    [System.Runtime.InteropServices.Guid("344B09FD-88CA-4C4D-BD90-0F406771CF3D")]
     public class TouchScreenControllerDataProviderProfile : BaseMixedRealityControllerDataProviderProfile
     {
         public override ControllerDefinition[] GetDefaultControllerOptions()

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/AllPlatforms.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/AllPlatforms.cs
@@ -6,6 +6,7 @@ namespace XRTK.Definitions.Platforms
     /// <summary>
     /// Used by the XRTK to signal that the feature is available on every platform.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("C6BF6315-2E9C-4602-827D-2D4871D29422")]
     public sealed class AllPlatforms : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/AndroidPlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/AndroidPlatform.cs
@@ -6,6 +6,7 @@ namespace XRTK.Definitions.Platforms
     /// <summary>
     /// Used by the XRTK to signal that the feature is available on the Android platform.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("DAC9EAD8-54F9-4935-A27F-9F82F465C972")]
     public class AndroidPlatform : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/CurrentBuildTargetPlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/CurrentBuildTargetPlatform.cs
@@ -10,6 +10,7 @@ namespace XRTK.Definitions.Platforms
     /// <summary>
     /// Used by the XRTK to signal that the feature is only available when the current built target matches the platform target.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("C838C4F5-A87E-48C7-8742-09A4D85FC3BC")]
     public sealed class CurrentBuildTargetPlatform : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/EditorPlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/EditorPlatform.cs
@@ -11,6 +11,7 @@ namespace XRTK.Definitions.Platforms
     /// <remarks>
     /// Defines any editor platform for Win, OSX, and Linux.
     /// </remarks>
+    [System.Runtime.InteropServices.Guid("3324B4A2-30F0-4145-BB06-CD65B8945487")]
     public sealed class EditorPlatform : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/IOSPlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/IOSPlatform.cs
@@ -6,6 +6,7 @@ namespace XRTK.Definitions.Platforms
     /// <summary>
     ///  Used by the XRTK to signal that the feature is available on the iOS platform.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("BCAC2CEF-E793-47B8-9DB7-116AF668CB66")]
     public class IOSPlatform : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/OSXPlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/OSXPlatform.cs
@@ -6,6 +6,7 @@ namespace XRTK.Definitions.Platforms
     /// <summary>
     /// Used by the XRTK to signal that the feature is available on the OSX platform.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("97344133-03B4-4314-9581-E42D1AAC91BA")]
     public class OSXPlatform : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/UniversalWindowsPlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/UniversalWindowsPlatform.cs
@@ -6,6 +6,7 @@ namespace XRTK.Definitions.Platforms
     /// <summary>
     /// Used by the XRTK to signal that the feature is available on the Windows Universal Platform.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("7DC72B4E-34F6-4B26-AFD7-CDE0C51F83A3")]
     public class UniversalWindowsPlatform : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/WebGlPlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/WebGlPlatform.cs
@@ -6,6 +6,7 @@ namespace XRTK.Definitions.Platforms
     /// <summary>
     /// Used by the XRTK to signal that the feature is available on the WebGL platform.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("A2FFB628-3CE7-4759-9C66-8F2BA8D16FC2")]
     public class WebGlPlatform : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/WindowsStandalonePlatform.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Platforms/WindowsStandalonePlatform.cs
@@ -6,6 +6,7 @@ namespace XRTK.Definitions.Platforms
     /// <summary>
     /// Used by the XRTK to signal that the feature is available on the Windows Standalone platform.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("58DE2D2A-DB5F-4090-A949-4028B8EA3AFD")]
     public class WindowsStandalonePlatform : BasePlatform
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Utilities/SystemType.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Utilities/SystemType.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using UnityEngine;
+using XRTK.Extensions;
 
 namespace XRTK.Definitions.Utilities
 {
@@ -12,42 +13,14 @@ namespace XRTK.Definitions.Utilities
     [Serializable]
     public sealed class SystemType : ISerializationCallbackReceiver
     {
-        [SerializeField]
-        private string reference = string.Empty;
-
-        private Type type;
-
-        public static string GetReference(Type type)
-        {
-            if (type == null || string.IsNullOrEmpty(type.AssemblyQualifiedName))
-            {
-                return string.Empty;
-            }
-
-            var qualifiedNameComponents = type.AssemblyQualifiedName.Split(',');
-            Debug.Assert(qualifiedNameComponents.Length >= 2);
-            return $"{qualifiedNameComponents[0]}, {qualifiedNameComponents[1].Trim()}";
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SystemType"/> class.
         /// </summary>
-        /// <param name="assemblyQualifiedClassName">Assembly qualified class name.</param>
-        public SystemType(string assemblyQualifiedClassName)
+        /// <param name="typeGuid"><see cref="System.Type.GUID"/> reference as <see cref="string"/>.</param>
+        public SystemType(string typeGuid)
         {
-            if (!string.IsNullOrEmpty(assemblyQualifiedClassName))
-            {
-                Type = Type.GetType(assemblyQualifiedClassName);
-
-                if (Type != null && Type.IsAbstract)
-                {
-                    Type = null;
-                }
-            }
-            else
-            {
-                Type = null;
-            }
+            TypeExtensions.TryResolveType(typeGuid, out var resolvedType);
+            Type = resolvedType;
         }
 
         /// <summary>
@@ -61,14 +34,25 @@ namespace XRTK.Definitions.Utilities
 
         #region ISerializationCallbackReceiver Members
 
+        [SerializeField]
+        private string reference = string.Empty;
+
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
-            type = !string.IsNullOrEmpty(reference) ? Type.GetType(reference) : null;
+            TypeExtensions.TryResolveType(reference, out type);
         }
 
-        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
+        void ISerializationCallbackReceiver.OnBeforeSerialize()
+        {
+            if (type != null && type.GUID != Guid.Empty)
+            {
+                reference = type.GUID.ToString();
+            }
+        }
 
         #endregion ISerializationCallbackReceiver Members
+
+        private Type type;
 
         /// <summary>
         /// Gets or sets type of class reference.
@@ -89,8 +73,13 @@ namespace XRTK.Definitions.Utilities
                 }
 
                 type = value;
-                reference = GetReference(value);
+                reference = type?.GUID.ToString();
             }
+        }
+
+        public static implicit operator Guid(SystemType type)
+        {
+            return type.type == null ? Guid.Empty : type.type.GUID;
         }
 
         public static implicit operator string(SystemType type)
@@ -108,6 +97,7 @@ namespace XRTK.Definitions.Utilities
             return new SystemType(type);
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Type?.FullName ?? (string.IsNullOrWhiteSpace(reference) ? "{None}" : reference);

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Utilities/SystemType.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Utilities/SystemType.cs
@@ -16,7 +16,16 @@ namespace XRTK.Definitions.Utilities
         /// <summary>
         /// Initializes a new instance of the <see cref="SystemType"/> class.
         /// </summary>
-        /// <param name="typeGuid"><see cref="System.Type.GUID"/> reference as <see cref="string"/>.</param>
+        /// <param name="type">Class type.</param>
+        public SystemType(Type type)
+        {
+            Type = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SystemType"/> class.
+        /// </summary>
+        /// <param name="typeGuid"><see cref="T:Type.GUID"/> reference as <see cref="string"/>.</param>
         public SystemType(string typeGuid)
         {
             TypeExtensions.TryResolveType(typeGuid, out var resolvedType);
@@ -26,10 +35,11 @@ namespace XRTK.Definitions.Utilities
         /// <summary>
         /// Initializes a new instance of the <see cref="SystemType"/> class.
         /// </summary>
-        /// <param name="type">Class type.</param>
-        public SystemType(Type type)
+        /// <param name="guid"><see cref="T:Type.GUID"/> reference of the type to instantiate.</param>
+        public SystemType(Guid guid)
         {
-            Type = type;
+            TypeExtensions.TryResolveType(guid, out var resolvedType);
+            Type = resolvedType;
         }
 
         #region ISerializationCallbackReceiver Members
@@ -96,6 +106,16 @@ namespace XRTK.Definitions.Utilities
         {
             return new SystemType(type);
         }
+
+        public static implicit operator SystemType(Guid guid)
+        {
+            return new SystemType(guid);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="T:System.Guid"/> associated with the <see cref="T:System.Type" />.
+        /// </summary>
+        public Guid Guid => type.GUID;
 
         /// <inheritdoc />
         public override string ToString()

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/TypeExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/TypeExtensions.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 using UnityEngine;
+using XRTK.Interfaces;
 
 namespace XRTK.Extensions
 {
@@ -12,22 +15,60 @@ namespace XRTK.Extensions
     /// </summary>
     public static class TypeExtensions
     {
-        private static readonly Dictionary<string, Type> TypeMap = new Dictionary<string, Type>();
+        private static readonly Dictionary<Guid, Type> TypeCache = new Dictionary<Guid, Type>();
+
+        private static IEnumerable<Type> allTypes = null;
+
+        private static IEnumerable<Type> AllTypes => allTypes ?? (allTypes = AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => type.IsClass && !type.IsAbstract));
 
         /// <summary>
-        /// Attempts to resolve the class reference by the <see cref="Type.AssemblyQualifiedName"/>.
+        /// Attempts to resolve the type using a the <see cref="System.Type.AssemblyQualifiedName"/> or <see cref="System.Type.GUID"/> as <see cref="string"/>.
         /// </summary>
-        /// <param name="classRef">The <see cref="Type.AssemblyQualifiedName"/> of the type to get.</param>
-        /// <returns>The <see cref="Type"/> from <see cref="classRef"/></returns>
-        public static Type ResolveType(string classRef)
+        /// <param name="typeRef">The <see cref="System.Type.GUID"/> or <see cref="System.Type.AssemblyQualifiedName"/> as <see cref="string"/>.</param>
+        /// <param name="resolvedType"></param>
+        /// <returns>The resolved <see cref="Type"/></returns>
+        public static bool TryResolveType(string typeRef, out Type resolvedType)
         {
-            if (!TypeMap.TryGetValue(classRef, out var type))
+            resolvedType = null;
+
+            if (string.IsNullOrEmpty(typeRef)) { return false; }
+
+            if (Guid.TryParse(typeRef, out var guid))
             {
-                type = !string.IsNullOrEmpty(classRef) ? Type.GetType(classRef) : null;
-                TypeMap[classRef] = type;
+                if (!TypeCache.TryGetValue(guid, out resolvedType))
+                {
+                    resolvedType = AllTypes.FirstOrDefault(type => type.GUID == guid);
+                }
+            }
+            else
+            {
+                resolvedType = Type.GetType(typeRef);
+
+                if (resolvedType != null &&
+                    resolvedType.GUID != Guid.Empty)
+                {
+                    guid = resolvedType.GUID;
+                }
             }
 
-            return type;
+            if (resolvedType != null && !resolvedType.IsAbstract)
+            {
+                if (!TypeCache.ContainsKey(guid))
+                {
+                    if (resolvedType.GUID == Guid.Empty)
+                    {
+                        Debug.LogWarning($"{resolvedType.Name} is missing a {nameof(GuidAttribute)}. This extension has been upgraded to use System.Type.GUID instead of System.Type.AssemblyQualifiedName");
+                    }
+
+                    TypeCache.Add(guid, resolvedType);
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -14,6 +14,7 @@ namespace XRTK.Providers.CameraSystem
     /// <summary>
     /// Base class for all <see cref="IMixedRealityCameraDataProvider"/>s can inherit from.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("EA4C0C19-E533-4AE8-91A2-6998CB8905BB")]
     public class BaseCameraDataProvider : BaseDataProvider, IMixedRealityCameraDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/BaseController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/BaseController.cs
@@ -25,7 +25,10 @@ namespace XRTK.Providers.Controllers
     /// </summary>
     public abstract class BaseController : IMixedRealityController
     {
-        public BaseController() { }
+        /// <summary>
+        /// Creates a new instance of a controller.
+        /// </summary>
+        protected BaseController() { }
 
         /// <summary>
         /// Creates a new instance of a controller.

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Hands/BaseHandController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Hands/BaseHandController.cs
@@ -18,7 +18,8 @@ namespace XRTK.Providers.Controllers.Hands
     /// </summary>
     public abstract class BaseHandController : BaseController, IMixedRealityHandController
     {
-        protected BaseHandController() : base() { }
+        /// <inheritdoc />
+        protected BaseHandController() { }
 
         /// <inheritdoc />
         protected BaseHandController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Hands/MixedRealityHandController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Hands/MixedRealityHandController.cs
@@ -11,9 +11,10 @@ namespace XRTK.Providers.Controllers.Hands
     /// <summary>
     /// Platform agnostic hand controller type.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("B18A9A6C-E5FD-40AE-89E9-9822415EC62B")]
     public class MixedRealityHandController : BaseHandController
     {
-        public MixedRealityHandController() : base() { }
+        public MixedRealityHandController() { }
 
         /// <inheritdoc />
         public MixedRealityHandController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/GenericOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/GenericOpenVRController.cs
@@ -13,9 +13,11 @@ using XRTK.Services;
 
 namespace XRTK.Providers.Controllers.OpenVR
 {
+    [System.Runtime.InteropServices.Guid("8DE3A393-71F8-47A4-89FE-7927B034DEAB")]
     public class GenericOpenVRController : GenericJoystickController
     {
-        public GenericOpenVRController() : base() { }
+        /// <inheritdoc />
+        public GenericOpenVRController() { }
 
         /// <inheritdoc />
         public GenericOpenVRController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OculusGoOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OculusGoOpenVRController.cs
@@ -9,9 +9,11 @@ using XRTK.Interfaces.Providers.Controllers;
 
 namespace XRTK.Providers.Controllers.OpenVR
 {
+    [System.Runtime.InteropServices.Guid("F57DF6F5-167E-45E8-B3F2-195D2C57A3F4")]
     public class OculusGoOpenVRController : GenericOpenVRController
     {
-        public OculusGoOpenVRController() : base() { }
+        /// <inheritdoc />
+        public OculusGoOpenVRController() { }
 
         /// <inheritdoc />
         public OculusGoOpenVRController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OculusRemoteOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OculusRemoteOpenVRController.cs
@@ -9,9 +9,11 @@ using XRTK.Interfaces.Providers.Controllers;
 
 namespace XRTK.Providers.Controllers.OpenVR
 {
+    [System.Runtime.InteropServices.Guid("24A7E9CA-43F0-487A-9E2B-609CCEDF2756")]
     public class OculusRemoteOpenVRController : GenericOpenVRController
     {
-        public OculusRemoteOpenVRController() : base() { }
+        /// <inheritdoc />
+        public OculusRemoteOpenVRController() { }
 
         /// <inheritdoc />
         public OculusRemoteOpenVRController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OculusTouchOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OculusTouchOpenVRController.cs
@@ -9,9 +9,11 @@ using XRTK.Interfaces.Providers.Controllers;
 
 namespace XRTK.Providers.Controllers.OpenVR
 {
+    [System.Runtime.InteropServices.Guid("F5779130-4990-44F7-A61A-196B34FA3AEF")]
     public class OculusTouchOpenVRController : GenericOpenVRController
     {
-        public OculusTouchOpenVRController() : base() { }
+        /// <inheritdoc />
+        public OculusTouchOpenVRController() { }
 
         /// <inheritdoc />
         public OculusTouchOpenVRController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OpenVRControllerDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OpenVRControllerDataProvider.cs
@@ -14,6 +14,7 @@ namespace XRTK.Providers.Controllers.OpenVR
     /// <summary>
     /// Manages Open VR Devices using unity's input system.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("9B116969-7F4B-4CF9-9D5A-4FBA7793F50E")]
     public class OpenVRControllerDataProvider : UnityJoystickDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/ViveKnucklesOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/ViveKnucklesOpenVRController.cs
@@ -9,9 +9,11 @@ using XRTK.Interfaces.Providers.Controllers;
 
 namespace XRTK.Providers.Controllers.OpenVR
 {
+    [System.Runtime.InteropServices.Guid("9550BBBB-799E-48AB-B421-3E64CCB7A2E7")]
     public class ViveKnucklesOpenVRController : GenericOpenVRController
     {
-        public ViveKnucklesOpenVRController() : base() { }
+        /// <inheritdoc />
+        public ViveKnucklesOpenVRController() { }
 
         /// <inheritdoc />
         public ViveKnucklesOpenVRController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/ViveWandOpenVRController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/ViveWandOpenVRController.cs
@@ -9,9 +9,11 @@ using XRTK.Interfaces.Providers.Controllers;
 
 namespace XRTK.Providers.Controllers.OpenVR
 {
+    [System.Runtime.InteropServices.Guid("506F192F-B93F-43B3-A34F-B15DFD855631")]
     public class ViveWandOpenVRController : GenericOpenVRController
     {
-        public ViveWandOpenVRController() : base() { }
+        /// <inheritdoc />
+        public ViveWandOpenVRController() { }
 
         /// <inheritdoc />
         public ViveWandOpenVRController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -13,9 +13,11 @@ namespace XRTK.Providers.Controllers.OpenVR
     /// <summary>
     /// Open VR Implementation of the Windows Mixed Reality Motion Controllers.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("193F55D4-44E0-4D3B-82FD-0CB417B3668B")]
     public class WindowsMixedRealityOpenVRMotionController : GenericOpenVRController
     {
-        public WindowsMixedRealityOpenVRMotionController() : base() { }
+        /// <inheritdoc />
+        public WindowsMixedRealityOpenVRMotionController() { }
 
         /// <inheritdoc />
         public WindowsMixedRealityOpenVRMotionController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Simulation/Hands/SimulatedHandControllerDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Simulation/Hands/SimulatedHandControllerDataProvider.cs
@@ -18,6 +18,7 @@ namespace XRTK.Providers.Controllers.Simulation.Hands
     /// <summary>
     /// Hand controller type for simulated hand controllers.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("07512FFC-5128-434C-B7BF-5CD7CA8EF853")]
     public class SimulatedHandControllerDataProvider : BaseSimulatedControllerDataProvider, ISimulatedHandControllerDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Simulation/Hands/SimulatedMixedRealityHandController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Simulation/Hands/SimulatedMixedRealityHandController.cs
@@ -20,9 +20,11 @@ namespace XRTK.Providers.Controllers.Simulation.Hands
     /// <summary>
     /// Hand controller type for simulated hand controllers.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("435C4F16-8E23-4228-B2B0-5FCE09A97043")]
     public class SimulatedMixedRealityHandController : BaseHandController, IMixedRealitySimulatedController
     {
-        public SimulatedMixedRealityHandController() : base() { }
+        /// <inheritdoc />
+        public SimulatedMixedRealityHandController() { }
 
         /// <inheritdoc />
         public SimulatedMixedRealityHandController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/GenericJoystickController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/GenericJoystickController.cs
@@ -13,9 +13,11 @@ namespace XRTK.Providers.Controllers.UnityInput
     /// <summary>
     /// The <see cref="GenericJoystickController"/> attempts to be a catch-all for joysticks and controllers defined in Unity's legacy input system.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("0E3781D2-72AE-4C85-A083-703CC21E8693")]
     public class GenericJoystickController : BaseController
     {
-        public GenericJoystickController() : base() { }
+        /// <inheritdoc />
+        public GenericJoystickController() { }
 
         /// <inheritdoc />
         public GenericJoystickController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/MouseController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/MouseController.cs
@@ -14,9 +14,11 @@ namespace XRTK.Providers.Controllers.UnityInput
     /// <summary>
     /// Manages the mouse using unity input system.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("A80E17F6-8221-49C3-BC4B-CAB495C91D6C")]
     public class MouseController : BaseController
     {
-        public MouseController() : base() { }
+        /// <inheritdoc />
+        public MouseController() { }
 
         /// <inheritdoc />
         public MouseController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/UnityJoystickDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/UnityJoystickDataProvider.cs
@@ -15,6 +15,7 @@ namespace XRTK.Providers.Controllers.UnityInput
     /// <summary>
     /// Manages joysticks using unity input system.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("A4D8D13B-253C-469A-A3A2-ECFE16DD969F")]
     public class UnityJoystickDataProvider : BaseControllerDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/UnityTouchController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/UnityTouchController.cs
@@ -10,9 +10,11 @@ using XRTK.Services;
 
 namespace XRTK.Providers.Controllers.UnityInput
 {
+    [System.Runtime.InteropServices.Guid("98F97EDA-4418-4B4B-88E9-E4F1F0734E4E")]
     public class UnityTouchController : BaseController
     {
-        public UnityTouchController() : base() { }
+        /// <inheritdoc />
+        public UnityTouchController() { }
 
         /// <inheritdoc />
         public UnityTouchController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/UnityTouchDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/UnityTouchDataProvider.cs
@@ -16,6 +16,7 @@ namespace XRTK.Providers.Controllers.UnityInput
     /// <summary>
     /// Manages Touch devices using unity input system.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("4D4D36E3-6ACB-45E5-8316-0B15A098EA2F")]
     public class UnityTouchDataProvider : BaseControllerDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/XboxController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/UnityInput/XboxController.cs
@@ -13,9 +13,11 @@ namespace XRTK.Providers.Controllers.UnityInput
     /// <summary>
     /// Xbox Controller using Unity Input System
     /// </summary>
+    [System.Runtime.InteropServices.Guid("71E70C1B-9F77-4B69-BFC7-974905BB7702")]
     public class XboxController : GenericJoystickController
     {
-        public XboxController() : base() { }
+        /// <inheritdoc />
+        public XboxController() { }
 
         /// <inheritdoc />
         public XboxController(IMixedRealityControllerDataProvider controllerDataProvider, TrackingState trackingState, Handedness controllerHandedness, MixedRealityControllerMappingProfile controllerMappingProfile)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Speech/WindowsDictationDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Speech/WindowsDictationDataProvider.cs
@@ -18,6 +18,7 @@ namespace XRTK.Providers.Speech
     /// <summary>
     /// Dictation data provider for Windows 10 based platforms.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("9D96D660-CB10-48B8-B2A7-3262ADB2AB14")]
     public class WindowsDictationDataProvider : BaseDictationDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Speech/WindowsSpeechDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Speech/WindowsSpeechDataProvider.cs
@@ -18,6 +18,7 @@ namespace XRTK.Providers.Speech
     /// <summary>
     /// Speech data provider for windows 10 based platforms.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("12E24F3D-7689-4863-A403-DD7A80DA3C25")]
     public class WindowsSpeechDataProvider : BaseSpeechDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -17,6 +17,7 @@ namespace XRTK.Services.BoundarySystem
     /// <summary>
     /// The Boundary system controls the presentation and display of the users boundary in a scene.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("FE458876-CC0F-4B6F-9459-544DDF6A9263")]
     public class MixedRealityBoundarySystem : BaseEventSystem, IMixedRealityBoundarySystem
     {
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
@@ -14,6 +14,7 @@ namespace XRTK.Services.CameraSystem
     /// The default <see cref="IMixedRealityCameraRig"/> for the XRTK.
     /// </summary>
     [ExecuteAlways]
+    [System.Runtime.InteropServices.Guid("8E0EE4FC-C8A5-4B10-9FCA-EE55B6D421FF")]
     public class DefaultCameraRig : MonoBehaviour, IMixedRealityCameraRig
     {
         #region IMixedRealityCameraRig Implementation

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -12,6 +12,7 @@ namespace XRTK.Services.CameraSystem
     /// <summary>
     /// The Mixed Reality Toolkit's default implementation of the <see cref="IMixedRealityCameraSystem"/>.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("5C656EE3-FE7C-4FB3-B3EE-DF3FC0D0973D")]
     public class MixedRealityCameraSystem : BaseSystem, IMixedRealityCameraSystem
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityConsoleDiagnosticsDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityConsoleDiagnosticsDataProvider.cs
@@ -11,6 +11,7 @@ namespace XRTK.Services.DiagnosticsSystem
     /// Console diagnostics data providers mirrors the Unity console and digests logs so the
     /// diagnostics system can work with it.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("06916F29-4640-475E-8BF6-313C6B831FCF")]
     public class MixedRealityConsoleDiagnosticsDataProvider : BaseMixedRealityDiagnosticsDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -16,6 +16,7 @@ namespace XRTK.Services.DiagnosticsSystem
     /// <summary>
     /// The default implementation of the <see cref="IMixedRealityDiagnosticsSystem"/>
     /// </summary>
+    [System.Runtime.InteropServices.Guid("2044B5AE-8F50-4B66-B508-D8087356C140")]
     public class MixedRealityDiagnosticsSystem : BaseEventSystem, IMixedRealityDiagnosticsSystem
     {
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityFrameDiagnosticsDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityFrameDiagnosticsDataProvider.cs
@@ -12,6 +12,7 @@ namespace XRTK.Services.DiagnosticsSystem
     /// Diagnostics data provider for frame diagnostics. It provides frame rate information and missed frames
     /// information to identify performance issues.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("1B5E5A67-864C-4A3D-A099-5A46EAD399A8")]
     public class MixedRealityFrameDiagnosticsDataProvider : BaseMixedRealityDiagnosticsDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityMemoryDiagnosticsDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityMemoryDiagnosticsDataProvider.cs
@@ -11,6 +11,7 @@ namespace XRTK.Services.DiagnosticsSystem
     /// <summary>
     /// Diagnostics data provider for memory diagnostics. E.g. provides information about used application memory.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("9F9C6912-DD68-4010-8B4A-B7B01B6AD77B")]
     public class MixedRealityMemoryDiagnosticsDataProvider : BaseMixedRealityDiagnosticsDataProvider
     {
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/FocusProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/FocusProvider.cs
@@ -19,6 +19,7 @@ namespace XRTK.Services.InputSystem
     /// The focus provider handles the focused objects per input source.
     /// </summary>
     /// <remarks>There are convenience properties for getting only Gaze Pointer if needed.</remarks>
+    [System.Runtime.InteropServices.Guid("249D4D78-CADD-45BA-9438-DB9FC2509213")]
     public class FocusProvider : BaseService, IMixedRealityFocusProvider
     {
         private readonly HashSet<PointerData> pointers = new HashSet<PointerData>();

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/MixedRealityInputSystem.cs
@@ -22,6 +22,7 @@ namespace XRTK.Services.InputSystem
     /// <summary>
     /// The Mixed Reality Toolkit's specific implementation of the <see cref="IMixedRealityInputSystem"/>
     /// </summary>
+    [System.Runtime.InteropServices.Guid("18C9CAF0-8D36-4ADD-BB49-CDF7561CF793")]
     public class MixedRealityInputSystem : BaseEventSystem, IMixedRealityInputSystem
     {
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/NetworkingSystem/MixedRealityNetworkingSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/NetworkingSystem/MixedRealityNetworkingSystem.cs
@@ -10,6 +10,7 @@ namespace XRTK.Services.NetworkingSystem
     /// <summary>
     /// The Mixed Reality Toolkit's default implementation of the <see cref="IMixedRealityNetworkingSystem"/>
     /// </summary>
+    [System.Runtime.InteropServices.Guid("6CB7110B-058B-4AA6-B81D-792FE443191A")]
     public class MixedRealityNetworkingSystem : BaseEventSystem, IMixedRealityNetworkingSystem
     {
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -17,6 +17,7 @@ namespace XRTK.Services.SpatialAwarenessSystem
     /// <summary>
     /// Class providing the default implementation of the <see cref="IMixedRealitySpatialAwarenessSystem"/> interface.
     /// </summary>
+    [System.Runtime.InteropServices.Guid("05EF9DDC-13C2-47D4-84C5-1C9CB6CC5C1C")]
     public class MixedRealitySpatialAwarenessSystem : BaseEventSystem, IMixedRealitySpatialAwarenessSystem
     {
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -14,6 +14,7 @@ namespace XRTK.Services.Teleportation
     /// <summary>
     /// The Mixed Reality Toolkit's specific implementation of the <see cref="IMixedRealityTeleportSystem"/>
     /// </summary>
+    [System.Runtime.InteropServices.Guid("2C18630A-9837-46FA-ADDF-6C8AF34D4143")]
     public class MixedRealityTeleportSystem : BaseEventSystem, IMixedRealityTeleportSystem
     {
         /// <summary>


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Previously whenever we refactored any class we were simply serializing the `AssemblyQualifiedName` as a string, which could lead to types being unable to be found after we either rename the class or change the namespace.

This change is backwards compatible to what we had previously.

The two classes to review:

- `SystemType`
- `TypeExtensions`

## Submodule Changes

- https://github.com/XRTK/SDK/pull/166
- https://github.com/XRTK/Lumin/pull/70
- https://github.com/XRTK/Oculus/pull/65
- https://github.com/XRTK/WindowsMixedReality/pull/74