### PR TITLE
Fix canvas utility removed from prefabs unintentionally

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/CanvasEditorExtension.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/CanvasEditorExtension.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using XRTK.Extensions;

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/CanvasEditorExtension.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/CanvasEditorExtension.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using XRTK.Extensions;
@@ -119,7 +120,7 @@ namespace XRTK.Editor.Utilities
             var utility = canvas.GetComponent<CanvasUtility>();
 
             // Remove the helper if we don't need it.
-            if (removeUtility || !IsUtilityValid)
+            if (removeUtility)
             {
                 if (utility != null)
                 {


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Fixes the issue of a `CanvasUtility` being removed from a GameObject/Prefab without the user's consent. The utility will only get removed from a game object if

- The user answers No in the dialog prompt
- The user answers Never in the dialog prompt

This "fix" may lead to a `CanvasUtility` staying on a canvas that was set to Screen Space or modified in a way that it doesn't need a utility anymore. Or XRTK got removed from the scene or something. But that's better than having the user wonder why something stopped working because for some reason the utility got removed from his canvas.