### PR TITLE
Added guid regeneration for installed package profiles to prevent asset collisions

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
@@ -84,11 +84,16 @@ namespace XRTK.Editor
                     foreach (var configuration in platformConfigurationProfile.Configurations)
                     {
                         var configurationType = configuration.InstancedType.Type;
-                        Debug.Log(configuration.InstancedType.Type.Name);
+
+                        if (configurationType == null)
+                        {
+                            Debug.LogError($"Failed to find a valid {nameof(configuration.InstancedType)} for {configuration.Name}!");
+                            continue;
+                        }
 
                         switch (configurationType)
                         {
-                            case Type cameraDataProvider when typeof(IMixedRealityCameraDataProvider).IsAssignableFrom(configurationType):
+                            case Type _ when typeof(IMixedRealityCameraDataProvider).IsAssignableFrom(configurationType):
                                 var cameraSystemProfile = rootProfile.CameraSystemProfile;
                                 var cameraDataProviderConfiguration = new MixedRealityServiceConfiguration<IMixedRealityCameraDataProvider>(configuration.InstancedType, configuration.Name, configuration.Priority, configuration.RuntimePlatforms, configuration.Profile);
 
@@ -99,7 +104,7 @@ namespace XRTK.Editor
                                 }
                                 break;
 
-                            case Type inputDataProvider when typeof(IMixedRealityInputDataProvider).IsAssignableFrom(configurationType):
+                            case Type _ when typeof(IMixedRealityInputDataProvider).IsAssignableFrom(configurationType):
                                 var inputSystemProfile = rootProfile.InputSystemProfile;
                                 var inputDataProviderConfiguration = new MixedRealityServiceConfiguration<IMixedRealityInputDataProvider>(configuration.InstancedType, configuration.Name, configuration.Priority, configuration.RuntimePlatforms, configuration.Profile);
 
@@ -110,7 +115,7 @@ namespace XRTK.Editor
                                 }
                                 break;
 
-                            case Type spatialDataProvider when typeof(IMixedRealitySpatialObserverDataProvider).IsAssignableFrom(configurationType):
+                            case Type _ when typeof(IMixedRealitySpatialObserverDataProvider).IsAssignableFrom(configurationType):
                                 var spatialAwarenessSystemProfile = rootProfile.SpatialAwarenessProfile;
                                 var spatialObserverConfiguration = new MixedRealityServiceConfiguration<IMixedRealitySpatialObserverDataProvider>(configuration.InstancedType, configuration.Name, configuration.Priority, configuration.RuntimePlatforms, configuration.Profile);
 

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
@@ -57,7 +57,7 @@ namespace XRTK.Editor
                 return false;
             }
 
-            GuidRegenerator.RegenerateGuids(destinationPath, false);
+            GuidRegenerator.RegenerateGuids(Path.GetFullPath(destinationPath), false);
             EditorApplication.delayCall += () => { AddConfigurations(profilePaths); };
             return true;
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/GuidRegenerator.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/GuidRegenerator.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+
+namespace XRTK.Editor.Utilities
+{
+    /// <summary>
+    /// <para>
+    /// Used to regenerate guids for profiles and prefabs copied from upm packages.
+    /// </para>
+    /// <para>
+    /// Based on https://gist.github.com/ZimM-LostPolygon/7e2f8a3e5a1be183ac19
+    /// </para>
+    /// </summary>
+    internal static class GuidRegenerator
+    {
+        private static readonly string[] DefaultFileExtensions = {
+            "*.meta",
+            "*.mat",
+            "*.anim",
+            "*.prefab",
+            "*.unity",
+            "*.asset",
+            "*.guiskin",
+            "*.fontsettings",
+            "*.controller",
+        };
+
+        /// <summary>
+        /// Regenerate the guids for assets located in the <see cref="assetsRootPath"/>.
+        /// </summary>
+        /// <param name="assetsRootPath">The root directory to search for assets to regenerate guids for.</param>
+        /// <param name="refreshAssetDatabase">Should <see cref="AssetDatabase.Refresh(ImportAssetOptions)"/> be called after finishing regeneration? (Default is true)</param>
+        public static void RegenerateGuids(string assetsRootPath, bool refreshAssetDatabase = true)
+        {
+            try
+            {
+                AssetDatabase.StartAssetEditing();
+                RegenerateGuidsInternal(assetsRootPath);
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+                EditorUtility.ClearProgressBar();
+
+                if (refreshAssetDatabase)
+                {
+                    EditorApplication.delayCall += AssetDatabase.Refresh;
+                }
+            }
+        }
+
+        private static void RegenerateGuidsInternal(string assetsRootPath)
+        {
+            // Get list of working files
+            var filesPaths = new List<string>();
+
+            foreach (var extension in DefaultFileExtensions)
+            {
+                filesPaths.AddRange(Directory.GetFiles(assetsRootPath, extension, SearchOption.AllDirectories));
+            }
+
+            // Create dictionary to hold old-to-new GUID map
+            var guidOldToNewMap = new Dictionary<string, string>();
+            var guidsInFileMap = new Dictionary<string, List<string>>();
+
+            // We must only replace GUIDs for Resources present in the path.
+            // Otherwise built-in resources (shader, meshes etc) get overwritten.
+            var ownGuids = new HashSet<string>();
+
+            // Traverse all files, remember which GUIDs are in which files and generate new GUIDs
+            var counter = 0;
+
+            foreach (var filePath in filesPaths)
+            {
+                EditorUtility.DisplayProgressBar($"Scanning {assetsRootPath} folder", MakeRelativePath(assetsRootPath, filePath), counter / (float)filesPaths.Count);
+
+                var isFirstGuid = true;
+                var guids = GetGuids(File.ReadAllText(filePath));
+
+                foreach (var oldGuid in guids)
+                {
+                    // First GUID in .meta file is always the GUID of the asset itself
+                    if (isFirstGuid && Path.GetExtension(filePath) == ".meta")
+                    {
+                        ownGuids.Add(oldGuid);
+                        isFirstGuid = false;
+                    }
+
+                    // Generate and save new GUID if we haven't added it before
+                    if (!guidOldToNewMap.ContainsKey(oldGuid))
+                    {
+                        var newGuid = Guid.NewGuid().ToString("N");
+                        guidOldToNewMap.Add(oldGuid, newGuid);
+                    }
+
+                    if (!guidsInFileMap.ContainsKey(filePath))
+                    {
+                        guidsInFileMap[filePath] = new List<string>();
+                    }
+
+                    if (!guidsInFileMap[filePath].Contains(oldGuid))
+                    {
+                        guidsInFileMap[filePath].Add(oldGuid);
+                    }
+                }
+
+                counter++;
+            }
+
+            // Traverse the files again and replace the old GUIDs
+            counter = -1;
+            var guidsInFileMapKeysCount = guidsInFileMap.Keys.Count;
+
+            foreach (var filePath in guidsInFileMap.Keys)
+            {
+                EditorUtility.DisplayProgressBar("Regenerating GUIDs...", MakeRelativePath(assetsRootPath, filePath), counter / (float)guidsInFileMapKeysCount);
+                counter++;
+
+                var contents = File.ReadAllText(filePath);
+
+                foreach (var oldGuid in guidsInFileMap[filePath])
+                {
+                    if (!ownGuids.Contains(oldGuid)) { continue; }
+
+                    var newGuid = guidOldToNewMap[oldGuid];
+
+                    if (string.IsNullOrEmpty(newGuid))
+                    {
+                        throw new NullReferenceException("newGuid == null");
+                    }
+
+                    contents = contents.Replace($"guid: {oldGuid}", $"guid: {newGuid}");
+                }
+
+                File.WriteAllText(filePath, contents);
+            }
+
+            EditorUtility.ClearProgressBar();
+        }
+
+        private static IEnumerable<string> GetGuids(string text)
+        {
+            const string guidStart = "guid: ";
+            const int guidLength = 32;
+            var textLength = text.Length;
+            var guidStartLength = guidStart.Length;
+            var guids = new List<string>();
+            var index = 0;
+
+            while (index + guidStartLength + guidLength < textLength)
+            {
+                index = text.IndexOf(guidStart, index, StringComparison.Ordinal);
+
+                if (index == -1)
+                {
+                    break;
+                }
+
+                index += guidStartLength;
+                var guid = text.Substring(index, guidLength);
+                index += guidLength;
+
+                if (IsGuid(guid))
+                {
+                    guids.Add(guid);
+                }
+            }
+
+            return guids;
+        }
+
+        private static bool IsGuid(string text) => text.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z'));
+
+        private static string MakeRelativePath(string fromPath, string toPath)
+        {
+            var toUri = new Uri(toPath);
+            var fromUri = new Uri(fromPath);
+
+            var relativeUri = fromUri.MakeRelativeUri(toUri);
+            var relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+
+            return relativePath;
+        }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/GuidRegenerator.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/GuidRegenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f632b7c40b241d4469f3068b6beed6bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

To prevent asset collisions and problems when copying prefabs and profiles, I thought it'd be best to regenerate any guid references in the copied assets.