### PR TITLE
Disabled package installation button in xrtk.core project

### DIFF
--- a/XRTK-Core/Assets/XRTK.Seed/PackagePickerWindow.cs
+++ b/XRTK-Core/Assets/XRTK.Seed/PackagePickerWindow.cs
@@ -74,6 +74,12 @@ namespace XRTK.Seed
                 isNew = false;
             }
 
+            if (Packages.Count == 0)
+            {
+                Debug.LogWarning($"{nameof(PackagePickerWindow)}.{nameof(Packages)} is empty!");
+                Close();
+            }
+
             GUILayout.BeginVertical();
             GUILayout.Label(Logo, new GUIStyle
             {

--- a/XRTK-Core/Assets/XRTK.Seed/PackagePickerWindow.cs
+++ b/XRTK-Core/Assets/XRTK.Seed/PackagePickerWindow.cs
@@ -111,6 +111,8 @@ namespace XRTK.Seed
 
             GUILayout.FlexibleSpace();
 
+            GUI.enabled = !EditorPrefs.HasKey("XRTK"); // Don't enable in XRTK-Core project
+
             if (GUILayout.Button("Add selected packages", EditorStyles.miniButton, GUILayout.Height(16f)))
             {
                 var manifest = JsonConvert.DeserializeObject<PackageManifest>(File.ReadAllText(PackageManifest.ManifestFilePath));
@@ -119,7 +121,7 @@ namespace XRTK.Seed
                 {
                     var (package, enabled) = item;
 
-                    if (enabled)
+                    if (enabled && !manifest.Dependencies.ContainsKey(package.name))
                     {
                         manifest.Dependencies.Add(package.name, package.version);
                     }
@@ -131,6 +133,7 @@ namespace XRTK.Seed
                 Close();
             }
 
+            GUI.enabled = true;
             EditorGUILayout.Space();
             GUILayout.EndVertical();
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/Editor/MixedRealityEditorSettings.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/Editor/MixedRealityEditorSettings.cs
@@ -78,6 +78,8 @@ namespace XRTK.Utilities.Editor
         /// </summary>
         public static void CheckSettings()
         {
+            EditorPrefs.SetBool("XRTK", true);
+
             if (Application.isPlaying ||
                 EditorPrefs.GetBool(IgnoreKey, false) ||
                 !SessionState.GetBool(SessionKey, true))


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Because `Mixed Reality Toolkit/List Packages` menu is a part of the seed it's availible in the xrtk.core project, but we don't want people to install the packages as they're already referenced as submodules. 

To prevent this I added a simple XRTK key to check if the editor prefs has an XRTK key and disables the `Add selected packages` button to prevent its self destruction in the core project itself.