### PR TITLE
Fixed a bug where profile field assignment was not working

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/MixedRealityProfilePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/MixedRealityProfilePropertyDrawer.cs
@@ -80,6 +80,7 @@ namespace XRTK.Editor.PropertyDrawers
             if (EditorGUI.EndChangeCheck())
             {
                 property.objectReferenceValue = selectedProfile;
+                property.serializedObject.ApplyModifiedProperties();
 
                 if (!(selectedProfile is null) &&
                     !(selectedProfile is MixedRealityToolkitRootProfile))


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Assigning any profile by dragging and dropping the object from the project window into the object slot was not working, as well as using the object picker, or cloning.