### PR TITLE
Update OpenVR for Oculus Quest controller name change

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OpenVRControllerDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/OpenVR/OpenVRControllerDataProvider.cs
@@ -84,7 +84,8 @@ namespace XRTK.Providers.Controllers.OpenVR
         protected override Type GetCurrentControllerType(string joystickName)
         {
             if (joystickName.Contains("Oculus Rift CV1") ||
-                joystickName.Contains("Oculus Touch"))
+                joystickName.Contains("Oculus Touch") ||
+                joystickName.Contains("Oculus Quest"))
             {
                 return typeof(OculusTouchOpenVRController);
             }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Change Request

## Overview

Fix to add additional resolution of Oculus Controllers following the V16 firmware Oculus update (controllers renamed for Quest)

## Target of the change:

Is this enhancement for:

- Core (core framework, interfaces and definitions)
- Platform (new or updated platform)

## Changes:

Adds an additional name lookup for Oculus based OpenVR controllers
