### PR TITLE
Updated handedness to properly work with the enum flags attribute

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Utilities/Handedness.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/Utilities/Handedness.cs
@@ -11,12 +11,12 @@ namespace XRTK.Definitions.Utilities
     /// "Other" defines potential controllers that will offer a "third" hand, e.g. a full body tracking suit.
     /// </summary>
     [Flags]
-    public enum Handedness : byte
+    public enum Handedness
     {
         /// <summary>
         /// No hand specified by the SDK for the controller
         /// </summary>
-        None = 0 << 0,
+        None = 0,
         /// <summary>
         /// The controller is identified as being provided in a Left hand
         /// </summary>


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

<!-- Please provide a clear and concise description of the pull request. -->

This enum wasn't working with the `EnumFlagsAttribute` properly because of the `byte` type didn't provide enough data to properly mask the bits with `-1`. Updated the type size to be whatever the default is.