### PR TITLE
Fix endless configure toolkit dialog issue

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityToolkitRootProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityToolkitRootProfileInspector.cs
@@ -51,6 +51,7 @@ namespace XRTK.Editor.Profiles
         private SerializedProperty registeredServiceProvidersProfile;
 
         private MixedRealityToolkitRootProfile rootProfile;
+        private bool didPromptToConfigure = false;
 
         private readonly GUIContent typeLabel = new GUIContent("Instanced Type", "The class type to instantiate at runtime for this system.");
         private readonly GUIContent profileLabel = new GUIContent("Profile");
@@ -88,7 +89,7 @@ namespace XRTK.Editor.Profiles
             var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
 
             // Create The MR Manager if none exists.
-            if (!MixedRealityToolkit.IsInitialized && prefabStage == null)
+            if (!MixedRealityToolkit.IsInitialized && prefabStage == null && !didPromptToConfigure)
             {
                 // Search for all instances, in case we've just hot reloaded the assembly.
                 var managerSearch = FindObjectsOfType<MixedRealityToolkit>();
@@ -112,7 +113,7 @@ namespace XRTK.Editor.Profiles
                     else
                     {
                         Debug.LogWarning("No Mixed Reality Toolkit in your scene.");
-                        Selection.activeObject = null;
+                        didPromptToConfigure = true;
                     }
                 }
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityToolkitRootProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityToolkitRootProfileInspector.cs
@@ -112,6 +112,7 @@ namespace XRTK.Editor.Profiles
                     else
                     {
                         Debug.LogWarning("No Mixed Reality Toolkit in your scene.");
+                        Selection.activeObject = null;
                     }
                 }
             }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Fixes an issue where the "There is no active Mixed Reality Toolkit in your scene! Would you like to create one now?" dialog endlessly blocks the editor when pressing "Later".

To observe the error in dev open a scene without the Toolkit in it, e.g. some scene you want to load in additively when running. While in that scene select the MixedRealityToolkitRootProfile asset. The dialog shows up. Press later, press later, press later, press later...

## Changes

Clear selection for one frame if the user answers "Later". That will make sure Unity does not trigger the `OnEnable` event right away again after selectin "Later".
