### PR TITLE
IsNull and Destroy Unity Object Extensions

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/ControllerPopupWindow.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/ControllerPopupWindow.cs
@@ -101,7 +101,7 @@ namespace XRTK.Editor
 
         private void OnFocus()
         {
-            if (window == null)
+            if (window.IsNull())
             {
                 Close();
             }
@@ -141,7 +141,7 @@ namespace XRTK.Editor
 
             var asset = AssetDatabase.LoadAssetAtPath<TextAsset>(EditorWindowOptionsPath);
 
-            if (asset == null)
+            if (asset.IsNull())
             {
                 var empty = new ControllerInputActionOptions
                 {
@@ -322,7 +322,7 @@ namespace XRTK.Editor
                 var interactionProfileProperty = interactionProfilesList.GetArrayElementAtIndex(i);
                 var mappingProfile = interactionProfileProperty.objectReferenceValue as MixedRealityInteractionMappingProfile;
 
-                if (mappingProfile == null)
+                if (mappingProfile.IsNull())
                 {
                     EditorGUILayout.BeginHorizontal();
                     EditorGUILayout.PropertyField(interactionProfileProperty, GUIContent.none, GUILayout.Width(INPUT_ACTION_LABEL_WIDTH));
@@ -341,7 +341,7 @@ namespace XRTK.Editor
                 EditorGUILayout.BeginHorizontal();
 
                 if (useCustomInteractionMapping ||
-                    currentControllerTexture == null)
+                    currentControllerTexture.IsNull())
                 {
                     bool skip = false;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityPreferences.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityPreferences.cs
@@ -217,7 +217,7 @@ namespace XRTK.Editor
             {
                 EditorPreferences.Set("_AutoLoadSymbolicLinks", autoLoadSymbolicLinks = value);
 
-                if (autoLoadSymbolicLinks && SymbolicLinker.Settings == null)
+                if (autoLoadSymbolicLinks && SymbolicLinker.Settings.IsNull())
                 {
                     ScriptableObject.CreateInstance(nameof(SymbolicLinkSettings)).CreateAsset();
                 }
@@ -402,7 +402,7 @@ namespace XRTK.Editor
 
             if (EditorBuildSettings.scenes.Length < 1)
             {
-                if (asset == null)
+                if (asset.IsNull())
                 {
                     Debug.Log($"{sceneName} scene not found in build settings!");
                     return null;
@@ -435,7 +435,7 @@ namespace XRTK.Editor
                 asset = AssetDatabase.LoadAssetAtPath(editorScene.path, typeof(SceneAsset)) as SceneAsset;
             }
 
-            if (asset == null)
+            if (asset.IsNull())
             {
                 return null;
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityToolkitInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityToolkitInspector.cs
@@ -11,6 +11,7 @@ using XRTK.Definitions;
 using XRTK.Editor.Extensions;
 using XRTK.Editor.Profiles;
 using XRTK.Editor.Utilities;
+using XRTK.Extensions;
 using XRTK.Services;
 
 namespace XRTK.Editor
@@ -34,7 +35,7 @@ namespace XRTK.Editor
         {
             activeProfile = serializedObject.FindProperty(nameof(activeProfile));
             currentPickerWindow = -1;
-            checkChange = activeProfile.objectReferenceValue == null;
+            checkChange = activeProfile.objectReferenceValue.IsNull();
         }
 
         public override void OnInspectorGUI()
@@ -62,7 +63,7 @@ namespace XRTK.Editor
             var commandName = Event.current.commandName;
             var rootProfiles = ScriptableObjectExtensions.GetAllInstances<MixedRealityToolkitRootProfile>();
 
-            if (activeProfile.objectReferenceValue == null &&
+            if (activeProfile.objectReferenceValue.IsNull() &&
                 currentPickerWindow == -1 && checkChange)
             {
                 switch (rootProfiles.Length)

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
@@ -137,7 +137,7 @@ namespace XRTK.Editor
             {
                 var platformConfigurationProfile = AssetDatabase.LoadAssetAtPath<MixedRealityPlatformServiceConfigurationProfile>(profile);
 
-                if (platformConfigurationProfile == null) { continue; }
+                if (platformConfigurationProfile.IsNull()) { continue; }
 
                 var rootProfile = MixedRealityToolkit.IsInitialized
                     ? MixedRealityToolkit.Instance.ActiveProfile

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/BaseMixedRealityProfileInspector.cs
@@ -40,7 +40,7 @@ namespace XRTK.Editor.Profiles
         {
             targetProfile = serializedObject;
             currentlySelectedProfile = target as BaseMixedRealityProfile;
-            Debug.Assert(currentlySelectedProfile != null);
+            Debug.Assert(!currentlySelectedProfile.IsNull());
             ThisProfile = currentlySelectedProfile;
             AssetDatabase.TryGetGUIDAndLocalFileIdentifier(ThisProfile, out var guidHex, out long _);
             ThisProfileGuidString = guidHex;
@@ -54,7 +54,7 @@ namespace XRTK.Editor.Profiles
 
         protected void RenderHeader(string infoBoxText = "", Texture2D image = null)
         {
-            if (image != null ||
+            if (!image.IsNull() ||
                 !string.IsNullOrWhiteSpace(infoBoxText))
             {
                 isOverrideHeader = true;
@@ -64,7 +64,7 @@ namespace XRTK.Editor.Profiles
                 if (isOverrideHeader) { return; }
             }
 
-            if (image == null)
+            if (image.IsNull())
             {
                 MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
             }
@@ -73,7 +73,7 @@ namespace XRTK.Editor.Profiles
                 MixedRealityInspectorUtility.RenderInspectorHeader(image);
             }
 
-            if (ThisProfile.ParentProfile != null &&
+            if (!ThisProfile.ParentProfile.IsNull() &&
                 GUILayout.Button("Back to parent profile"))
             {
                 Selection.activeObject = ThisProfile.ParentProfile;
@@ -96,7 +96,7 @@ namespace XRTK.Editor.Profiles
             profileSource = currentlySelectedProfile;
             var newProfile = CreateInstance(currentlySelectedProfile.GetType().ToString());
             currentlySelectedProfile = newProfile.CreateAsset() as BaseMixedRealityProfile;
-            Debug.Assert(currentlySelectedProfile != null);
+            Debug.Assert(!currentlySelectedProfile.IsNull());
 
             await new WaitUntil(() => profileSource != currentlySelectedProfile);
 
@@ -115,9 +115,9 @@ namespace XRTK.Editor.Profiles
         [MenuItem("CONTEXT/BaseMixedRealityProfile/Paste Profile Values", true)]
         private static bool PasteProfileValuesValidation()
         {
-            return currentlySelectedProfile != null &&
+            return !currentlySelectedProfile.IsNull() &&
                    targetProfile != null &&
-                   profileSource != null &&
+                   !profileSource.IsNull() &&
                    currentlySelectedProfile.GetType() == profileSource.GetType();
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/MixedRealityGesturesProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/MixedRealityGesturesProfileInspector.cs
@@ -8,6 +8,7 @@ using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions.Devices;
 using XRTK.Definitions.InputSystem;
+using XRTK.Extensions;
 
 namespace XRTK.Editor.Profiles.InputSystem
 {
@@ -80,13 +81,13 @@ namespace XRTK.Editor.Profiles.InputSystem
         {
             RenderHeader("This gesture map is any and all movements of part the user's body, especially a hand or the head, that raise actions through the input system.\n\nNote: Defined controllers can look up the list of gestures and raise the events based on specific criteria.");
 
-            if (inputSystemProfile == null)
+            if (inputSystemProfile.IsNull())
             {
                 EditorGUILayout.HelpBox("No input system profile found, please specify a input system profile in the main configuration.", MessageType.Error);
                 return;
             }
 
-            if (inputSystemProfile.InputActionsProfile == null)
+            if (inputSystemProfile.InputActionsProfile.IsNull())
             {
                 EditorGUILayout.HelpBox("No input actions found, please specify a input action profile in the main configuration.", MessageType.Error);
                 return;

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/MixedRealityInputSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/MixedRealityInputSystemProfileInspector.cs
@@ -9,6 +9,7 @@ using XRTK.Definitions.Controllers;
 using XRTK.Definitions.InputSystem;
 using XRTK.Editor.Extensions;
 using XRTK.Editor.Profiles.InputSystem.Controllers;
+using XRTK.Extensions;
 using XRTK.Services;
 
 namespace XRTK.Editor.Profiles.InputSystem
@@ -78,7 +79,7 @@ namespace XRTK.Editor.Profiles.InputSystem
                 {
                     var controllerDataProviderProfile = (BaseMixedRealityControllerDataProviderProfile)configurationProfileProperty.objectReferenceValue;
 
-                    if (controllerDataProviderProfile == null ||
+                    if (controllerDataProviderProfile.IsNull() ||
                         controllerDataProviderProfile.ControllerMappingProfiles == null)
                     {
                         continue;
@@ -86,7 +87,7 @@ namespace XRTK.Editor.Profiles.InputSystem
 
                     foreach (var mappingProfile in controllerDataProviderProfile.ControllerMappingProfiles)
                     {
-                        if (mappingProfile == null) { continue; }
+                        if (mappingProfile.IsNull()) { continue; }
 
                         AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mappingProfile, out var guid, out long _);
 

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/MixedRealitySpeechCommandsProfileInspector.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions.InputSystem;
+using XRTK.Extensions;
 
 namespace XRTK.Editor.Profiles.InputSystem
 {
@@ -30,7 +31,7 @@ namespace XRTK.Editor.Profiles.InputSystem
 
             inputSystemProfile = ThisProfile.ParentProfile as MixedRealityInputSystemProfile;
 
-            if (inputSystemProfile == null ||
+            if (inputSystemProfile.IsNull() ||
                 inputSystemProfile.InputActionsProfile == null)
             {
                 return;
@@ -47,13 +48,13 @@ namespace XRTK.Editor.Profiles.InputSystem
         {
             RenderHeader("Speech Commands are any/all spoken keywords your users will be able say to raise an Input Action in your application.");
 
-            if (inputSystemProfile == null)
+            if (inputSystemProfile.IsNull())
             {
                 EditorGUILayout.HelpBox("No input system profile found, please specify an input system profile in the main configuration profile.", MessageType.Error);
                 return;
             }
 
-            if (inputSystemProfile.InputActionsProfile == null)
+            if (inputSystemProfile.InputActionsProfile.IsNull())
             {
                 EditorGUILayout.HelpBox("No input actions found, please specify a input action profile in the input system profile.", MessageType.Error);
                 return;

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityPlatformServiceConfigurationProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityPlatformServiceConfigurationProfileInspector.cs
@@ -268,7 +268,7 @@ namespace XRTK.Editor.Profiles
                 var renderedProfile = configurationProfileProperty.objectReferenceValue as BaseMixedRealityProfile;
                 Debug.Assert(renderedProfile != null);
 
-                if (renderedProfile.ParentProfile == null ||
+                if (renderedProfile.ParentProfile.IsNull() ||
                     renderedProfile.ParentProfile != ThisProfile)
                 {
                     renderedProfile.ParentProfile = ThisProfile;

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityServiceProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityServiceProviderProfileInspector.cs
@@ -218,7 +218,7 @@ namespace XRTK.Editor.Profiles
                     var renderedProfile = configurationProfileProperty.objectReferenceValue as BaseMixedRealityProfile;
                     Debug.Assert(renderedProfile != null);
 
-                    if (renderedProfile.ParentProfile == null ||
+                    if (renderedProfile.ParentProfile.IsNull() ||
                         renderedProfile.ParentProfile != ThisProfile)
                     {
                         renderedProfile.ParentProfile = ThisProfile;

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/MixedRealityProfilePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/MixedRealityProfilePropertyDrawer.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions;
 using XRTK.Editor.Utilities;
+using XRTK.Extensions;
 using XRTK.Services;
 
 namespace XRTK.Editor.PropertyDrawers
@@ -30,11 +31,11 @@ namespace XRTK.Editor.PropertyDrawers
         {
             BaseMixedRealityProfile profile = null;
 
-            if (parent == null)
+            if (parent.IsNull())
             {
                 parent = ParentProfileOverride;
 
-                if (parent == null)
+                if (parent.IsNull())
                 {
                     if (Selection.activeObject.name.Equals(nameof(MixedRealityToolkit)))
                     {
@@ -49,14 +50,15 @@ namespace XRTK.Editor.PropertyDrawers
                 ParentProfileOverride = null;
             }
 
-            if (property.objectReferenceValue != null)
+            if (!property.objectReferenceValue.IsNull())
             {
                 profile = property.objectReferenceValue as BaseMixedRealityProfile;
             }
 
-            if (profile != null)
+            if (!profile.IsNull())
             {
-                if (profile is MixedRealityToolkitRootProfile && parent != null)
+                if (profile is MixedRealityToolkitRootProfile &&
+                    !parent.IsNull())
                 {
                     profile.ParentProfile = null;
                 }
@@ -85,14 +87,14 @@ namespace XRTK.Editor.PropertyDrawers
                 if (!(selectedProfile is null) &&
                     !(selectedProfile is MixedRealityToolkitRootProfile))
                 {
-                    Debug.Assert(parent != null, $"Failed to find a valid parent profile for {selectedProfile.name}");
+                    Debug.Assert(!parent.IsNull(), $"Failed to find a valid parent profile for {selectedProfile.name}");
                     selectedProfile.ParentProfile = parent;
                 }
             }
 
             if (DrawCloneButtons)
             {
-                hasSelection = selectedProfile != null;
+                hasSelection = !selectedProfile.IsNull();
                 var buttonContent = hasSelection ? CloneProfileContent : NewProfileContent;
                 var buttonRect = new Rect(objectRect.xMax + BUTTON_PADDING, position.y, buttonWidth, position.height);
 
@@ -105,7 +107,7 @@ namespace XRTK.Editor.PropertyDrawers
             if (!(selectedProfile is null) &&
                 !(selectedProfile is MixedRealityToolkitRootProfile))
             {
-                if (selectedProfile.ParentProfile == null ||
+                if (selectedProfile.ParentProfile.IsNull() ||
                     selectedProfile.ParentProfile != parent)
                 {
                     if (parent != null &&
@@ -115,7 +117,7 @@ namespace XRTK.Editor.PropertyDrawers
                     }
                 }
 
-                Debug.Assert(selectedProfile.ParentProfile != null);
+                Debug.Assert(!selectedProfile.ParentProfile.IsNull());
                 Debug.Assert(selectedProfile.ParentProfile != selectedProfile);
             }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/AssemblyDefinitionEditorExtension.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/AssemblyDefinitionEditorExtension.cs
@@ -8,6 +8,7 @@ using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEditorInternal;
 using UnityEngine;
+using XRTK.Extensions;
 
 namespace XRTK.Editor.Utilities
 {
@@ -63,7 +64,7 @@ namespace XRTK.Editor.Utilities
         [MenuItem("CONTEXT/AssemblyDefinitionImporter/Replace Source with Assembly", true, 99)]
         public static bool ReplaceWithAssemblyValidation()
         {
-            if (Selection.activeObject == null) { return false; }
+            if (Selection.activeObject.IsNull()) { return false; }
             return !AssetDatabase.GetAssetPath(Selection.activeObject).GetAssetPathSiblings().Any(path => path.Contains(DLL));
         }
 
@@ -204,7 +205,7 @@ namespace XRTK.Editor.Utilities
         [MenuItem("CONTEXT/AssemblyDefinitionImporter/Replace Assembly with Source", true, 99)]
         public static bool ReplaceWithSourceValidation()
         {
-            if (Selection.activeObject == null) { return false; }
+            if (Selection.activeObject.IsNull()) { return false; }
 
             string assetPath = AssetDatabase.GetAssetPath(Selection.activeObject);
             return assetPath.GetAssetPathSiblings().Any(path => assetPath.Contains(DLL) && path.Contains(ASMDEF) || assetPath.Contains(ASMDEF) && path.Contains(DLL));

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/BaseMixedRealityProfileInspectorExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/BaseMixedRealityProfileInspectorExtensions.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions;
 using XRTK.Editor.Extensions;
+using XRTK.Extensions;
 
 namespace XRTK.Editor.Utilities
 {
@@ -40,14 +41,14 @@ namespace XRTK.Editor.Utilities
                 instance = ScriptableObject.CreateInstance(profileType);
             }
 
-            Debug.Assert(instance != null);
+            Debug.Assert(!instance.IsNull());
 
-            var assetPath = parentProfile != null ? AssetDatabase.GetAssetPath(parentProfile) : string.Empty;
+            var assetPath = !parentProfile.IsNull() ? AssetDatabase.GetAssetPath(parentProfile) : string.Empty;
             var newProfile = instance.CreateAsset(assetPath) as BaseMixedRealityProfile;
-            Debug.Assert(newProfile != null);
+            Debug.Assert(!newProfile.IsNull());
 
             if (clone &&
-                property.objectReferenceValue != null)
+                !property.objectReferenceValue.IsNull())
             {
                 var oldProfile = property.objectReferenceValue as BaseMixedRealityProfile;
                 newProfile.CopySerializedValues(oldProfile);
@@ -60,7 +61,7 @@ namespace XRTK.Editor.Utilities
 
         public static void CopySerializedValues(this BaseMixedRealityProfile target, BaseMixedRealityProfile source)
         {
-            Debug.Assert(target != null);
+            Debug.Assert(!target.IsNull());
             var serializedObject = new SerializedObject(target);
             Undo.RecordObject(target, "Paste Profile Values");
             var originalName = serializedObject.targetObject.name;

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/CanvasEditorExtension.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/CanvasEditorExtension.cs
@@ -124,7 +124,7 @@ namespace XRTK.Editor.Utilities
                 if (utility != null)
                 {
                     canvas.worldCamera = null;
-                    EditorApplication.delayCall += () => DestroyImmediate(utility);
+                    utility.Destroy();
                 }
 
                 hasUtility = false;

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/EventDatum/Diagnostics/BaseDiagnosticsEventData.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/EventDatum/Diagnostics/BaseDiagnosticsEventData.cs
@@ -1,5 +1,9 @@
-﻿using System;
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using UnityEngine.EventSystems;
+using XRTK.Extensions;
 
 namespace XRTK.EventDatum.DiagnosticsSystem
 {
@@ -22,7 +26,7 @@ namespace XRTK.EventDatum.DiagnosticsSystem
         /// <param name="eventSystem"></param>
         protected BaseDiagnosticsEventData(EventSystem eventSystem) : base(eventSystem)
         {
-            if (eventSystem == null)
+            if (eventSystem.IsNull())
             {
                 throw new Exception($"{nameof(EventSystem)} cannot be null!");
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/EventDatum/GenericBaseEventData.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/EventDatum/GenericBaseEventData.cs
@@ -3,6 +3,7 @@
 
 using System;
 using UnityEngine.EventSystems;
+using XRTK.Extensions;
 using XRTK.Interfaces.Events;
 
 namespace XRTK.EventDatum
@@ -31,7 +32,7 @@ namespace XRTK.EventDatum
         /// <param name="eventSystem">Usually <see cref="EventSystem.current"/></param>
         public GenericBaseEventData(EventSystem eventSystem) : base(eventSystem)
         {
-            if (eventSystem == null)
+            if (eventSystem.IsNull())
             {
                 throw new Exception("Event system cannot be null!");
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/EventDatum/Input/BaseInputEventData.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/EventDatum/Input/BaseInputEventData.cs
@@ -4,6 +4,7 @@
 using System;
 using UnityEngine.EventSystems;
 using XRTK.Definitions.InputSystem;
+using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 
 namespace XRTK.EventDatum.Input
@@ -42,7 +43,7 @@ namespace XRTK.EventDatum.Input
         /// <param name="eventSystem">Typically will be <see cref="EventSystem.current"/></param>
         protected BaseInputEventData(EventSystem eventSystem) : base(eventSystem)
         {
-            if (eventSystem == null)
+            if (eventSystem.IsNull())
             {
                 throw new Exception($"{nameof(EventSystem)} cannot be null!");
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/EventDatum/Input/GraphicInputEventData.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/EventDatum/Input/GraphicInputEventData.cs
@@ -4,6 +4,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using XRTK.Extensions;
 
 namespace XRTK.EventDatum.Input
 {
@@ -15,7 +16,7 @@ namespace XRTK.EventDatum.Input
         /// <inheritdoc />
         public GraphicInputEventData(EventSystem eventSystem) : base(eventSystem)
         {
-            if (eventSystem == null)
+            if (eventSystem.IsNull())
             {
                 throw new Exception("Event system cannot be null!");
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/CanvasExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/CanvasExtensions.cs
@@ -178,7 +178,7 @@ namespace XRTK.Extensions
             {
                 rectTransform = rectTransformParent.GetChild(i).GetComponent<RectTransform>();
                 Graphic graphic = rectTransform.GetComponent<Graphic>();
-                shouldRaycast = ((shouldReturnRaycastable && graphic != null && graphic.raycastTarget) || graphic == null || !shouldReturnRaycastable);
+                shouldRaycast = ((shouldReturnRaycastable && !graphic.IsNull() && graphic.raycastTarget) || graphic.IsNull() || !shouldReturnRaycastable);
 
                 if (((shouldReturnActive && rectTransform.gameObject.activeSelf) || !shouldReturnActive))
                 {

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/ComponentExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/ComponentExtensions.cs
@@ -49,7 +49,7 @@ namespace XRTK.Extensions
         public static T EnsureComponent<T>(this GameObject gameObject) where T : Component
         {
             T foundComponent = gameObject.GetComponent<T>();
-            return foundComponent == null ? gameObject.AddComponent<T>() : foundComponent;
+            return foundComponent.IsNull() ? gameObject.AddComponent<T>() : foundComponent;
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace XRTK.Extensions
         public static Component EnsureComponent(this GameObject gameObject, Type component)
         {
             var foundComponent = gameObject.GetComponent(component);
-            return foundComponent == null ? gameObject.AddComponent(component) : foundComponent;
+            return foundComponent.IsNull() ? gameObject.AddComponent(component) : foundComponent;
         }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/EventSystemExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/EventSystemExtensions.cs
@@ -10,7 +10,7 @@ using XRTK.Utilities.Physics;
 namespace XRTK.Extensions
 {
     /// <summary>
-    /// Extension methods for Unity's EventSystem 
+    /// Extension methods for Unity's EventSystem
     /// </summary>
     public static class EventSystemExtensions
     {
@@ -39,14 +39,14 @@ namespace XRTK.Extensions
 
             for (var i = 0; i < RaycastResults.Count; i++)
             {
-                if (RaycastResults[i].gameObject == null) { continue; }
+                if (RaycastResults[i].gameObject.IsNull()) { continue; }
 
                 var layerMaskIndex = RaycastResults[i].gameObject.layer.FindLayerListIndex(priority);
                 if (layerMaskIndex == -1) { continue; }
 
                 var result = new ComparableRaycastResult(RaycastResults[i], layerMaskIndex);
 
-                if (maxResult.RaycastResult.module == null || RaycastResultComparer.Compare(maxResult, result) < 0)
+                if (maxResult.RaycastResult.module.IsNull() || RaycastResultComparer.Compare(maxResult, result) < 0)
                 {
                     maxResult = result;
                 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/GameObjectExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/GameObjectExtensions.cs
@@ -33,11 +33,6 @@ namespace XRTK.Extensions
         /// <param name="layer">The layer to apply</param>
         public static void SetLayerRecursively(this GameObject root, int layer)
         {
-            if (root == null)
-            {
-                throw new ArgumentNullException(nameof(root), "Root transform can't be null.");
-            }
-
             foreach (var child in root.transform.EnumerateHierarchy())
             {
                 child.gameObject.layer = layer;
@@ -53,8 +48,6 @@ namespace XRTK.Extensions
         /// <exception cref="T:System.ArgumentNullException"><paramref name="root"/> is <see langword="null"/></exception>
         public static void SetLayerRecursively(this GameObject root, int layer, out Dictionary<GameObject, int> cache)
         {
-            if (root == null) { throw new ArgumentNullException(nameof(root)); }
-
             cache = new Dictionary<GameObject, int>();
 
             foreach (var child in root.transform.EnumerateHierarchy())
@@ -241,7 +234,7 @@ namespace XRTK.Extensions
         public static T GetOrAddComponent<T>(this GameObject gameObject) where T : Component
         {
             T component = gameObject.GetComponent<T>();
-            return component != null ? component : gameObject.AddComponent<T>();
+            return component.IsNull() ? gameObject.AddComponent<T>() : component;
         }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/UnityObjectExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/UnityObjectExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace XRTK.Extensions
@@ -13,13 +14,57 @@ namespace XRTK.Extensions
         /// <summary>
         /// Enable Unity objects to skip <see cref="Object.DontDestroyOnLoad"/> when editor isn't playing so test runner passes.
         /// </summary>
-        /// <param name="target"></param>
-        public static void DontDestroyOnLoad(this Object target)
+        /// <param name="object"></param>
+        public static void DontDestroyOnLoad(this Object @object)
         {
 #if UNITY_EDITOR
             if (UnityEditor.EditorApplication.isPlaying)
 #endif
-                Object.DontDestroyOnLoad(target);
+                Object.DontDestroyOnLoad(@object);
+        }
+
+        /// <summary>
+        /// Destroys a Unity  <see cref="Object"/> appropriately depending if running in in edit or play mode.
+        /// </summary>
+        /// <param name="object">Unity  <see cref="Object"/> to destroy</param>
+        /// <param name="t">Time in seconds at which to destroy the object, if applicable.</param>
+        public static void Destroy(this Object @object, float t = 0.0f)
+        {
+            if (@object.IsNull()) { return; }
+
+            if (Application.isPlaying)
+            {
+                Object.Destroy(@object, t);
+            }
+            else
+            {
+#if UNITY_EDITOR
+                // Must use DestroyImmediate in edit mode but it is not allowed when called from
+                // trigger/contact, animation event callbacks or OnValidate. Must use Destroy instead.
+                // Delay call to counter this issue in editor.
+                UnityEditor.EditorApplication.delayCall += () => Object.DestroyImmediate(@object);
+#else
+                Object.DestroyImmediate(@object);
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Checks if a Unity <see cref="Object"/> is null.
+        /// </summary>
+        /// <param name="object"></param>
+        /// <remarks>Checks both the managed object and the underling Unity-managed native object.</remarks>
+        /// <returns>True if null, otherwise false.</returns>
+        public static bool IsNull(this Object @object)
+        {
+            try
+            {
+                return @object == null;
+            }
+            catch
+            {
+                return true;
+            }
         }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -23,7 +23,7 @@ namespace XRTK.Providers.CameraSystem
         {
             cameraSystem = MixedRealityToolkit.CameraSystem;
 
-            if (profile == null)
+            if (profile.IsNull())
             {
                 profile = MixedRealityToolkit.Instance.ActiveProfile.CameraSystemProfile.GlobalCameraProfile;
             }
@@ -194,16 +194,16 @@ namespace XRTK.Providers.CameraSystem
         {
             base.Disable();
 
-            if (CameraRig == null ||
-                CameraRig.GameObject == null)
+            if (CameraRig.GameObject.IsNull() ||
+                CameraRig == null)
             {
                 return;
             }
 
             ResetRigTransforms();
 
-            if (CameraRig.PlayerCamera != null &&
-                CameraRig.PlayerCamera.transform != null)
+            if (!CameraRig.PlayerCamera.IsNull() &&
+                !CameraRig.PlayerCamera.transform.IsNull())
             {
                 var cameraTransform = CameraRig.PlayerCamera.transform;
                 cameraTransform.SetParent(null);
@@ -213,27 +213,13 @@ namespace XRTK.Providers.CameraSystem
 
             if (CameraRig.PlayspaceTransform != null)
             {
-                if (Application.isPlaying)
-                {
-                    UnityEngine.Object.Destroy(CameraRig.PlayspaceTransform.gameObject);
-                }
-                else
-                {
-                    UnityEngine.Object.DestroyImmediate(CameraRig.PlayspaceTransform.gameObject);
-                }
+                CameraRig.PlayspaceTransform.gameObject.Destroy();
             }
 
             if (CameraRig is Component component &&
                 component is IMixedRealityCameraRig)
             {
-                if (Application.isPlaying)
-                {
-                    UnityEngine.Object.Destroy(component);
-                }
-                else
-                {
-                    UnityEngine.Object.DestroyImmediate(component);
-                }
+                component.Destroy();
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/BaseController.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/BaseController.cs
@@ -9,6 +9,7 @@ using XRTK.Definitions.Controllers;
 using XRTK.Definitions.Devices;
 using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.Utilities;
+using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.InputSystem.Handlers;
 using XRTK.Interfaces.Providers.Controllers;
@@ -53,7 +54,7 @@ namespace XRTK.Providers.Controllers
 
             Name = $"{handednessPrefix}{GetType().Name}";
 
-            if (controllerMappingProfile == null)
+            if (controllerMappingProfile.IsNull())
             {
                 throw new Exception($"{nameof(controllerMappingProfile)} cannot be null for {Name}");
             }
@@ -195,7 +196,7 @@ namespace XRTK.Providers.Controllers
         /// <param name="useAlternatePoseAction">Should the visualizer be assigned the alternate pose actions?</param>
         public async Task TryRenderControllerModelAsync(byte[] glbData = null, bool useAlternatePoseAction = false)
         {
-            if (visualizationProfile == null)
+            if (visualizationProfile.IsNull())
             {
                 Debug.LogWarning($"Missing {nameof(visualizationProfile)} for {GetType().Name}");
                 return;
@@ -214,21 +215,21 @@ namespace XRTK.Providers.Controllers
 
             // If we didn't get an override model, and we didn't load the driver model,
             // then get the global controller model for each hand.
-            if (controllerModel == null)
+            if (controllerModel.IsNull())
             {
                 switch (ControllerHandedness)
                 {
-                    case Handedness.Left when visualizationProfile.LeftHandModel != null:
+                    case Handedness.Left when !visualizationProfile.LeftHandModel.IsNull():
                         controllerModel = visualizationProfile.LeftHandModel;
                         break;
-                    case Handedness.Right when visualizationProfile.LeftHandModel != null:
+                    case Handedness.Right when !visualizationProfile.LeftHandModel.IsNull():
                         controllerModel = visualizationProfile.LeftHandModel;
                         break;
                 }
             }
 
             // If we've got a controller model, then place it in the scene and get/attach the visualizer.
-            if (controllerModel != null)
+            if (!controllerModel.IsNull())
             {
                 var playspaceTransform = MixedRealityToolkit.CameraSystem != null
                     ? MixedRealityToolkit.CameraSystem.MainCameraRig.PlayspaceTransform

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/BaseControllerDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/BaseControllerDataProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using XRTK.Definitions.Controllers;
 using XRTK.Definitions.Utilities;
+using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.Providers.Controllers;
 using XRTK.Services;
@@ -21,7 +22,7 @@ namespace XRTK.Providers.Controllers
         protected BaseControllerDataProvider(string name, uint priority, BaseMixedRealityControllerDataProviderProfile profile, IMixedRealityInputSystem parentService)
             : base(name, priority, profile, parentService)
         {
-            if (profile == null)
+            if (profile.IsNull())
             {
                 throw new UnassignedReferenceException($"A {nameof(profile)} is required for {name}");
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Simulation/BaseSimulatedControllerDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Simulation/BaseSimulatedControllerDataProvider.cs
@@ -5,6 +5,7 @@ using System;
 using UnityEngine;
 using XRTK.Definitions.Controllers.Simulation;
 using XRTK.Definitions.Utilities;
+using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.Providers.Controllers;
 using XRTK.Services;
@@ -21,7 +22,7 @@ namespace XRTK.Providers.Controllers.Simulation
         protected BaseSimulatedControllerDataProvider(string name, uint priority, SimulatedControllerDataProviderProfile profile, IMixedRealityInputSystem parentService)
             : base(name, priority, profile, parentService)
         {
-            if (profile == null)
+            if (profile.IsNull())
             {
                 throw new NullReferenceException($"A {nameof(SimulatedControllerDataProviderProfile)} is required for {name}");
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/SpatialObservers/BaseMixedRealitySpatialMeshObserver.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/SpatialObservers/BaseMixedRealitySpatialMeshObserver.cs
@@ -23,12 +23,12 @@ namespace XRTK.Providers.SpatialObservers
         protected BaseMixedRealitySpatialMeshObserver(string name, uint priority, BaseMixedRealitySpatialMeshObserverProfile profile, IMixedRealitySpatialAwarenessSystem parentService)
             : base(name, priority, profile, parentService)
         {
-            if (profile == null)
+            if (profile.IsNull())
             {
                 profile = MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessProfile.GlobalMeshObserverProfile;
             }
 
-            if (profile == null)
+            if (profile.IsNull())
             {
                 throw new ArgumentNullException($"Missing a {profile.GetType().Name} profile for {name}");
             }
@@ -146,19 +146,10 @@ namespace XRTK.Providers.SpatialObservers
         {
             base.Destroy();
 
-            if (!Application.isPlaying) { return; }
-
             // Cleanup the spatial meshes that are being managed by this observer.
             foreach (var meshObject in spatialMeshObjects.Values)
             {
-                if (Application.isEditor)
-                {
-                    UnityEngine.Object.DestroyImmediate(meshObject.GameObject);
-                }
-                else
-                {
-                    UnityEngine.Object.Destroy(meshObject.GameObject);
-                }
+                meshObject.GameObject.Destroy();
             }
 
             spatialMeshObjects.Clear();
@@ -167,14 +158,7 @@ namespace XRTK.Providers.SpatialObservers
             {
                 foreach (var meshObject in spatialMeshObjectPool)
                 {
-                    if (Application.isEditor)
-                    {
-                        UnityEngine.Object.DestroyImmediate(meshObject.GameObject);
-                    }
-                    else
-                    {
-                        UnityEngine.Object.Destroy(meshObject.GameObject);
-                    }
+                    meshObject.GameObject.Destroy();
                 }
 
                 spatialMeshObjectPool.Clear();
@@ -349,7 +333,7 @@ namespace XRTK.Providers.SpatialObservers
         {
             GameObject newGameObject;
 
-            if (meshObjectPrefab == null)
+            if (meshObjectPrefab.IsNull())
             {
                 newGameObject = new GameObject("Blank Spatial Mesh GameObject", requiredMeshComponents)
                 {

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/SpatialObservers/BaseMixedRealitySpatialObserverDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/SpatialObservers/BaseMixedRealitySpatialObserverDataProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using UnityEngine;
 using XRTK.Definitions.Utilities;
+using XRTK.Extensions;
 using XRTK.Interfaces.Providers.SpatialObservers;
 using XRTK.Interfaces.SpatialAwarenessSystem;
 using XRTK.Services;
@@ -20,12 +21,12 @@ namespace XRTK.Providers.SpatialObservers
         protected BaseMixedRealitySpatialObserverDataProvider(string name, uint priority, BaseMixedRealitySpatialObserverProfile profile, IMixedRealitySpatialAwarenessSystem parentService)
             : base(name, priority, profile, parentService)
         {
-            if (profile == null)
+            if (profile.IsNull())
             {
                 profile = MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessProfile.GlobalMeshObserverProfile;
             }
 
-            if (profile == null)
+            if (profile.IsNull())
             {
                 throw new ArgumentNullException($"Missing a {profile.GetType().Name} profile for {name}");
             }
@@ -125,7 +126,7 @@ namespace XRTK.Providers.SpatialObservers
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) { return false; }
+            if (obj is null) { return false; }
             if (ReferenceEquals(this, obj)) { return true; }
             if (obj.GetType() != GetType()) { return false; }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/SpatialObservers/BaseMixedRealitySpatialSurfaceObserver.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/SpatialObservers/BaseMixedRealitySpatialSurfaceObserver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using XRTK.Extensions;
 using XRTK.Interfaces.Providers.SpatialObservers;
 using XRTK.Interfaces.SpatialAwarenessSystem;
 using XRTK.Services;
@@ -19,12 +20,12 @@ namespace XRTK.Providers.SpatialObservers
         protected BaseMixedRealitySpatialSurfaceObserver(string name, uint priority, BaseMixedRealitySurfaceObserverProfile profile, IMixedRealitySpatialAwarenessSystem parentService)
             : base(name, priority, profile, parentService)
         {
-            if (profile == null)
+            if (profile.IsNull())
             {
                 profile = MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessProfile.GlobalSurfaceObserverProfile;
             }
 
-            if (profile == null)
+            if (profile.IsNull())
             {
                 throw new ArgumentNullException($"Missing a {profile.GetType().Name} profile for {name}");
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/BaseSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/BaseSystem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using XRTK.Definitions;
+using XRTK.Extensions;
 using XRTK.Interfaces;
 
 namespace XRTK.Services
@@ -18,7 +19,7 @@ namespace XRTK.Services
         /// <param name="profile"></param>
         protected BaseSystem(BaseMixedRealityProfile profile)
         {
-            if (profile == null)
+            if (profile.IsNull())
             {
                 throw new ArgumentException($"Missing the profile for {base.Name} system!");
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -9,6 +9,7 @@ using UnityEngine.Experimental.XR;
 using UnityEngine.XR;
 using XRTK.Definitions.BoundarySystem;
 using XRTK.EventDatum.Boundary;
+using XRTK.Extensions;
 using XRTK.Interfaces.BoundarySystem;
 using XRTK.Utilities;
 
@@ -125,94 +126,9 @@ namespace XRTK.Services.BoundarySystem
         /// <inheritdoc/>
         public override void Destroy()
         {
-            // First, detach the child objects (we are tracking them separately)
-            // and clean up the parent.
-            if (boundaryVisualizationParent != null)
-            {
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(boundaryVisualizationParent);
-                }
-                else
-                {
-                    boundaryVisualizationParent.transform.DetachChildren();
-                    Object.Destroy(boundaryVisualizationParent);
-                }
-
-                boundaryVisualizationParent = null;
-            }
-
-            // Next, clean up the detached children.
-            if (currentFloorObject != null)
-            {
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(currentFloorObject);
-                }
-                else
-                {
-                    Object.Destroy(currentFloorObject);
-                }
-
-                currentFloorObject = null;
-            }
-
-            if (currentPlayAreaObject != null)
-            {
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(currentPlayAreaObject);
-                }
-                else
-                {
-                    Object.Destroy(currentPlayAreaObject);
-                }
-
-                currentPlayAreaObject = null;
-            }
-
-            if (currentTrackedAreaObject != null)
-            {
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(currentTrackedAreaObject);
-                }
-                else
-                {
-                    Object.Destroy(currentTrackedAreaObject);
-                }
-
-                currentTrackedAreaObject = null;
-            }
-
-            if (currentBoundaryWallObject != null)
-            {
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(currentBoundaryWallObject);
-                }
-                else
-                {
-                    Object.Destroy(currentBoundaryWallObject);
-                }
-
-                currentBoundaryWallObject = null;
-            }
-
-            if (currentCeilingObject != null)
-            {
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(currentCeilingObject);
-                }
-                else
-                {
-                    Object.Destroy(currentCeilingObject);
-                }
-
-                currentCeilingObject = null;
-            }
-
+            base.Destroy();
+            // Destroys the parent and all the child objects
+            boundaryVisualizationParent.Destroy();
             RaiseBoundaryVisualizationChanged();
         }
 
@@ -318,7 +234,7 @@ namespace XRTK.Services.BoundarySystem
         {
             get
             {
-                if (boundaryVisualizationParent != null)
+                if (!boundaryVisualizationParent.IsNull())
                 {
                     return boundaryVisualizationParent;
                 }
@@ -347,12 +263,12 @@ namespace XRTK.Services.BoundarySystem
 
                 showFloor = value;
 
-                if (value && (currentFloorObject == null))
+                if (value && (currentFloorObject.IsNull()))
                 {
                     GetFloorVisualization();
                 }
 
-                if (currentFloorObject != null)
+                if (!currentFloorObject.IsNull())
                 {
                     currentFloorObject.SetActive(value);
                 }
@@ -376,7 +292,7 @@ namespace XRTK.Services.BoundarySystem
         {
             get
             {
-                if (currentFloorObject != null)
+                if (!currentFloorObject.IsNull())
                 {
                     floorPhysicsLayer = currentFloorObject.layer;
                 }
@@ -386,7 +302,8 @@ namespace XRTK.Services.BoundarySystem
             set
             {
                 floorPhysicsLayer = value;
-                if (currentFloorObject != null)
+
+                if (!currentFloorObject.IsNull())
                 {
                     currentFloorObject.layer = floorPhysicsLayer;
                 }
@@ -403,12 +320,12 @@ namespace XRTK.Services.BoundarySystem
 
                 showPlayArea = value;
 
-                if (value && (currentPlayAreaObject == null))
+                if (value && currentPlayAreaObject.IsNull())
                 {
                     GetPlayAreaVisualization();
                 }
 
-                if (currentPlayAreaObject != null)
+                if (!currentPlayAreaObject.IsNull())
                 {
                     currentPlayAreaObject.SetActive(value);
                 }
@@ -424,7 +341,7 @@ namespace XRTK.Services.BoundarySystem
         {
             get
             {
-                if (currentPlayAreaObject != null)
+                if (!currentPlayAreaObject.IsNull())
                 {
                     playAreaPhysicsLayer = currentPlayAreaObject.layer;
                 }
@@ -435,7 +352,7 @@ namespace XRTK.Services.BoundarySystem
             {
                 playAreaPhysicsLayer = value;
 
-                if (currentPlayAreaObject != null)
+                if (!currentPlayAreaObject.IsNull())
                 {
                     currentPlayAreaObject.layer = playAreaPhysicsLayer;
                 }
@@ -456,12 +373,12 @@ namespace XRTK.Services.BoundarySystem
                 if (showTrackedArea == value) { return; }
                 showTrackedArea = value;
 
-                if (value && (currentTrackedAreaObject == null))
+                if (value && currentTrackedAreaObject.IsNull())
                 {
                     GetTrackedAreaVisualization();
                 }
 
-                if (currentTrackedAreaObject != null)
+                if (!currentTrackedAreaObject.IsNull())
                 {
                     currentTrackedAreaObject.SetActive(value);
                 }
@@ -479,7 +396,7 @@ namespace XRTK.Services.BoundarySystem
         {
             get
             {
-                if (currentTrackedAreaObject != null)
+                if (!currentTrackedAreaObject.IsNull())
                 {
                     trackedAreaPhysicsLayer = currentTrackedAreaObject.layer;
                 }
@@ -490,7 +407,7 @@ namespace XRTK.Services.BoundarySystem
             {
                 trackedAreaPhysicsLayer = value;
 
-                if (currentTrackedAreaObject != null)
+                if (!currentTrackedAreaObject.IsNull())
                 {
                     currentTrackedAreaObject.layer = trackedAreaPhysicsLayer;
                 }
@@ -510,12 +427,12 @@ namespace XRTK.Services.BoundarySystem
 
                 showBoundaryWalls = value;
 
-                if (value && (currentBoundaryWallObject == null))
+                if (value && currentBoundaryWallObject.IsNull())
                 {
                     GetBoundaryWallVisualization();
                 }
 
-                if (currentBoundaryWallObject != null)
+                if (!currentBoundaryWallObject.IsNull())
                 {
                     currentBoundaryWallObject.SetActive(value);
                 }
@@ -533,7 +450,7 @@ namespace XRTK.Services.BoundarySystem
         {
             get
             {
-                if (currentBoundaryWallObject != null)
+                if (!currentBoundaryWallObject.IsNull())
                 {
                     boundaryWallsPhysicsLayer = currentBoundaryWallObject.layer;
                 }
@@ -544,7 +461,7 @@ namespace XRTK.Services.BoundarySystem
             {
                 boundaryWallsPhysicsLayer = value;
 
-                if (currentBoundaryWallObject != null)
+                if (!currentBoundaryWallObject.IsNull())
                 {
                     currentBoundaryWallObject.layer = boundaryWallsPhysicsLayer;
                 }
@@ -564,12 +481,12 @@ namespace XRTK.Services.BoundarySystem
 
                 showCeiling = value;
 
-                if (value && (currentCeilingObject == null))
+                if (value && currentCeilingObject.IsNull())
                 {
                     GetBoundaryCeilingVisualization();
                 }
 
-                if (currentCeilingObject != null)
+                if (!currentCeilingObject.IsNull())
                 {
                     currentCeilingObject.SetActive(value);
                 }
@@ -585,7 +502,7 @@ namespace XRTK.Services.BoundarySystem
         {
             get
             {
-                if (currentCeilingObject != null)
+                if (!currentCeilingObject.IsNull())
                 {
                     ceilingPhysicsLayer = currentCeilingObject.layer;
                 }
@@ -596,7 +513,7 @@ namespace XRTK.Services.BoundarySystem
             {
                 ceilingPhysicsLayer = value;
 
-                if (currentCeilingObject != null)
+                if (!currentCeilingObject.IsNull())
                 {
                     currentFloorObject.layer = ceilingPhysicsLayer;
                 }
@@ -688,7 +605,7 @@ namespace XRTK.Services.BoundarySystem
         {
             if (!Application.isPlaying) { return null; }
 
-            if (currentFloorObject != null)
+            if (!currentFloorObject.IsNull())
             {
                 return currentFloorObject;
             }
@@ -725,7 +642,7 @@ namespace XRTK.Services.BoundarySystem
         {
             if (!Application.isPlaying) { return null; }
 
-            if (currentPlayAreaObject != null)
+            if (!currentPlayAreaObject.IsNull())
             {
                 return currentPlayAreaObject;
             }
@@ -763,7 +680,7 @@ namespace XRTK.Services.BoundarySystem
         {
             if (!Application.isPlaying) { return null; }
 
-            if (currentTrackedAreaObject != null)
+            if (!currentTrackedAreaObject.IsNull())
             {
                 return currentTrackedAreaObject;
             }
@@ -820,7 +737,7 @@ namespace XRTK.Services.BoundarySystem
         {
             if (!Application.isPlaying) { return null; }
 
-            if (currentBoundaryWallObject != null)
+            if (!currentBoundaryWallObject.IsNull())
             {
                 return currentBoundaryWallObject;
             }
@@ -872,7 +789,7 @@ namespace XRTK.Services.BoundarySystem
         {
             if (!Application.isPlaying) { return null; }
 
-            if (currentCeilingObject != null)
+            if (!currentCeilingObject.IsNull())
             {
                 return currentCeilingObject;
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
@@ -57,7 +57,7 @@ namespace XRTK.Services.CameraSystem
 
                 var playspaceTransformLookup = GameObject.Find(playspaceName);
 
-                playspaceTransform = playspaceTransformLookup == null
+                playspaceTransform = playspaceTransformLookup.IsNull()
                     ? new GameObject(playspaceName).transform
                     : playspaceTransformLookup.transform;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -6,6 +6,7 @@ using UnityEngine.EventSystems;
 using XRTK.Definitions.DiagnosticsSystem;
 using XRTK.Definitions.Utilities;
 using XRTK.EventDatum.DiagnosticsSystem;
+using XRTK.Extensions;
 using XRTK.Interfaces.DiagnosticsSystem;
 using XRTK.Interfaces.DiagnosticsSystem.Handlers;
 using XRTK.Utilities;
@@ -74,24 +75,13 @@ namespace XRTK.Services.DiagnosticsSystem
         {
             base.Disable();
 
-            if (!Application.isPlaying)
-            {
-                return;
-            }
+            if (!Application.isPlaying) { return; }
 
             if (diagnosticsWindow != null)
             {
                 Unregister(diagnosticsWindow);
-
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(diagnosticsWindow);
-                }
-                else
-                {
-                    Object.Destroy(diagnosticsWindow);
-                }
             }
+
         }
 
         /// <inheritdoc />
@@ -99,16 +89,12 @@ namespace XRTK.Services.DiagnosticsSystem
         {
             base.Destroy();
 
-            if (diagnosticsRoot != null)
+            diagnosticsWindow.Destroy();
+
+            if (!diagnosticsRoot.IsNull() &&
+                !diagnosticsRoot.gameObject.IsNull())
             {
-                if (Application.isEditor)
-                {
-                    Object.DestroyImmediate(diagnosticsRoot.gameObject);
-                }
-                else
-                {
-                    Object.Destroy(diagnosticsRoot.gameObject);
-                }
+                diagnosticsRoot.gameObject.Destroy();
             }
         }
 
@@ -123,7 +109,7 @@ namespace XRTK.Services.DiagnosticsSystem
         {
             get
             {
-                if (diagnosticsRoot == null)
+                if (diagnosticsRoot.IsNull())
                 {
                     diagnosticsRoot = new GameObject("Diagnostics").transform;
                     var playspaceTransform = MixedRealityToolkit.CameraSystem != null
@@ -143,7 +129,7 @@ namespace XRTK.Services.DiagnosticsSystem
         {
             get
             {
-                if (diagnosticsWindow == null)
+                if (diagnosticsWindow.IsNull())
                 {
                     diagnosticsWindow = Object.Instantiate(profile.DiagnosticsWindowPrefab, DiagnosticsRoot);
                     Register(diagnosticsWindow);

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/FocusProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/FocusProvider.cs
@@ -531,18 +531,7 @@ namespace XRTK.Services.InputSystem
         public override void Destroy()
         {
             base.Destroy();
-
-            if (uiRaycastCamera != null)
-            {
-                if (Application.isEditor)
-                {
-                    UnityEngine.Object.DestroyImmediate(uiRaycastCamera.gameObject);
-                }
-                else
-                {
-                    UnityEngine.Object.Destroy(uiRaycastCamera.gameObject);
-                }
-            }
+            uiRaycastCamera.Destroy();
         }
 
         #endregion IMixedRealityService Implementation

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/MixedRealityInputSystem.cs
@@ -194,14 +194,14 @@ namespace XRTK.Services.InputSystem
                 // ReSharper disable once SuspiciousTypeConversion.Global
                 var component = CameraCache.Main.GetComponent<IMixedRealityGazeProvider>() as Component;
 
-                if (component != null)
+                if (!component.IsNull())
                 {
                     UnityEngine.Object.DestroyImmediate(component);
                 }
 
                 var inputModule = CameraCache.Main.GetComponent<StandaloneInputModule>();
 
-                if (inputModule != null)
+                if (!inputModule.IsNull())
                 {
                     UnityEngine.Object.DestroyImmediate(inputModule);
                 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
@@ -72,7 +72,7 @@ namespace XRTK.Services
             {
 #if UNITY_EDITOR
                 if (!Application.isPlaying &&
-                    activeProfile == null &&
+                    activeProfile.IsNull() &&
                     UnityEditor.Selection.activeObject != Instance)
                 {
                     UnityEditor.Selection.activeObject = Instance;
@@ -106,7 +106,7 @@ namespace XRTK.Services
 
             isResetting = true;
 
-            if (activeProfile != null)
+            if (!activeProfile.IsNull())
             {
                 DisableAllServices();
                 DestroyAllServices();
@@ -114,7 +114,7 @@ namespace XRTK.Services
 
             activeProfile = profile;
 
-            if (profile != null)
+            if (!profile.IsNull())
             {
                 DisableAllServices();
                 DestroyAllServices();
@@ -659,7 +659,7 @@ namespace XRTK.Services
                     Destroy(gameObject);
                 }
 
-                Debug.LogWarning("Trying to instantiate a second instance of the Mixed Reality Toolkit. Additional Instance was destroyed");
+                Debug.LogWarning($"Trying to instantiate a second instance of the {nameof(MixedRealityToolkit)}. Additional Instance was destroyed");
             }
             else if (!IsInitialized)
             {
@@ -1905,8 +1905,8 @@ namespace XRTK.Services
             {
                 if (!IsInitialized ||
                     IsApplicationQuitting ||
-                    instance.activeProfile == null ||
-                    instance.activeProfile != null && !instance.activeProfile.IsCameraSystemEnabled)
+                    instance.activeProfile.IsNull() ||
+                   !instance.activeProfile.IsNull() && !instance.activeProfile.IsCameraSystemEnabled)
                 {
                     return null;
                 }
@@ -1961,8 +1961,8 @@ namespace XRTK.Services
             {
                 if (!IsInitialized ||
                     IsApplicationQuitting ||
-                    instance.activeProfile == null ||
-                    instance.activeProfile != null && !instance.activeProfile.IsInputSystemEnabled)
+                    instance.activeProfile.IsNull() ||
+                   !instance.activeProfile.IsNull() && !instance.activeProfile.IsInputSystemEnabled)
                 {
                     return null;
                 }
@@ -2017,8 +2017,8 @@ namespace XRTK.Services
             {
                 if (!IsInitialized ||
                     IsApplicationQuitting ||
-                    instance.activeProfile == null ||
-                    instance.activeProfile != null && !instance.activeProfile.IsBoundarySystemEnabled)
+                    instance.activeProfile.IsNull() ||
+                   !instance.activeProfile.IsNull() && !instance.activeProfile.IsBoundarySystemEnabled)
                 {
                     return null;
                 }
@@ -2073,8 +2073,8 @@ namespace XRTK.Services
             {
                 if (!IsInitialized ||
                     IsApplicationQuitting ||
-                    instance.activeProfile == null ||
-                    instance.activeProfile != null && !instance.activeProfile.IsSpatialAwarenessSystemEnabled)
+                    instance.activeProfile.IsNull() ||
+                   !instance.activeProfile.IsNull() && !instance.activeProfile.IsSpatialAwarenessSystemEnabled)
                 {
                     return null;
                 }
@@ -2129,8 +2129,8 @@ namespace XRTK.Services
             {
                 if (!IsInitialized ||
                     IsApplicationQuitting ||
-                    instance.activeProfile == null ||
-                    instance.activeProfile != null && !instance.activeProfile.IsTeleportSystemEnabled)
+                    instance.activeProfile.IsNull() ||
+                   !instance.activeProfile.IsNull() && !instance.activeProfile.IsTeleportSystemEnabled)
                 {
                     return null;
                 }
@@ -2185,8 +2185,8 @@ namespace XRTK.Services
             {
                 if (!IsInitialized ||
                     IsApplicationQuitting ||
-                    instance.activeProfile == null ||
-                    instance.activeProfile != null && !instance.activeProfile.IsNetworkingSystemEnabled)
+                    instance.activeProfile.IsNull() ||
+                   !instance.activeProfile.IsNull() && !instance.activeProfile.IsNetworkingSystemEnabled)
                 {
                     return null;
                 }
@@ -2241,8 +2241,8 @@ namespace XRTK.Services
             {
                 if (!IsInitialized ||
                     IsApplicationQuitting ||
-                    instance.activeProfile == null ||
-                    instance.activeProfile != null && !instance.activeProfile.IsDiagnosticsSystemEnabled)
+                    instance.activeProfile.IsNull() ||
+                   !instance.activeProfile.IsNull() && !instance.activeProfile.IsDiagnosticsSystemEnabled)
                 {
                     return null;
                 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using XRTK.Definitions.SpatialAwarenessSystem;
 using XRTK.EventDatum.SpatialAwarenessSystem;
+using XRTK.Extensions;
 using XRTK.Interfaces.Providers.SpatialObservers;
 using XRTK.Interfaces.SpatialAwarenessSystem;
 using XRTK.Interfaces.SpatialAwarenessSystem.Handlers;
@@ -196,60 +197,30 @@ namespace XRTK.Services.SpatialAwarenessSystem
         {
             base.Destroy();
 
-            // Cleanup game objects created during execution.
-            if (Application.isPlaying)
+            if (!Application.isPlaying) { return; }
+
+            if (spatialAwarenessParent != null)
             {
-                // Detach the child objects and clean up the parent.
-                if (spatialAwarenessParent != null)
-                {
-
-                    if (Application.isEditor)
-                    {
-                        Object.DestroyImmediate(spatialAwarenessParent);
-                    }
-                    else
-                    {
-                        spatialAwarenessParent.transform.DetachChildren();
-                        Object.Destroy(spatialAwarenessParent);
-                    }
-
-                    spatialAwarenessParent = null;
-                }
-
-                // Detach the mesh objects (they are to be cleaned up by the observer) and cleanup the parent
-                if (meshParent != null)
-                {
-
-                    if (Application.isEditor)
-                    {
-                        Object.DestroyImmediate(meshParent);
-                    }
-                    else
-                    {
-                        meshParent.transform.DetachChildren();
-                        Object.Destroy(meshParent);
-                    }
-
-                    meshParent = null;
-                }
-
-                // Detach the surface objects (they are to be cleaned up by the observer) and cleanup the parent
-                if (surfaceParent != null)
-                {
-
-                    if (Application.isEditor)
-                    {
-                        Object.DestroyImmediate(surfaceParent);
-                    }
-                    else
-                    {
-                        surfaceParent.transform.DetachChildren();
-                        Object.Destroy(surfaceParent);
-                    }
-
-                    surfaceParent = null;
-                }
+                spatialAwarenessParent.transform.DetachChildren();
             }
+
+            spatialAwarenessParent.Destroy();
+
+            // Detach the mesh objects (they are to be cleaned up by the observer) and cleanup the parent
+            if (meshParent != null)
+            {
+                meshParent.transform.DetachChildren();
+            }
+
+            meshParent.Destroy();
+
+            // Detach the surface objects (they are to be cleaned up by the observer) and cleanup the parent
+            if (surfaceParent != null)
+            {
+                surfaceParent.transform.DetachChildren();
+            }
+
+            surfaceParent.Destroy();
         }
 
         #region Mesh Events

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/StandardAssets/Textures/xrtk_logo_transparent_square.png.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/StandardAssets/Textures/xrtk_logo_transparent_square.png.meta
@@ -141,7 +141,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: ac7a3bbf92db3784e9a00fc5ed00fa5c
     internalID: 0
     vertices: []
     indices: 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/Lines/Renderers/StripMeshLineRenderer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/Lines/Renderers/StripMeshLineRenderer.cs
@@ -107,30 +107,8 @@ namespace XRTK.Utilities.Lines.Renderers
 
         private void OnDisable()
         {
-            if (lineMatInstance != null)
-            {
-                if (Application.isEditor)
-                {
-                    DestroyImmediate(lineMatInstance);
-                }
-                else
-                {
-                    Destroy(lineMatInstance);
-                }
-            }
-
-            if (meshRendererGameObject != null)
-            {
-                if (Application.isEditor)
-                {
-                    DestroyImmediate(meshRendererGameObject);
-                }
-                else
-                {
-                    Destroy(meshRendererGameObject);
-                }
-                stripMeshRenderer = null;
-            }
+            lineMatInstance.Destroy();
+            meshRendererGameObject.Destroy();
         }
 
         public static void GenerateStripMesh(List<Vector3> positionList, List<Color> colorList, List<float> thicknessList, float uvOffsetLocal, List<Vector3> forwardList, Mesh mesh, Vector3 up)

--- a/XRTK-Core/Packages/manifest.json
+++ b/XRTK-Core/Packages/manifest.json
@@ -9,6 +9,7 @@
     }
   ],
   "dependencies": {
+    "com.unity.mobile.android-logcat": "1.1.1",
     "com.unity.package-manager-ui": "2.1.2",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.xr.legacyinputhelpers": "2.1.4",

--- a/XRTK-Core/ProjectSettings/ProjectSettings.asset
+++ b/XRTK-Core/ProjectSettings/ProjectSettings.asset
@@ -266,7 +266,7 @@ PlayerSettings:
   AndroidEnableTango: 0
   androidEnableBanner: 1
   androidUseLowAccuracyLocation: 0
-  androidUseCustomKeystore: 1
+  androidUseCustomKeystore: 0
   m_AndroidBanners:
   - width: 320
     height: 180

--- a/XRTK-Core/ProjectSettings/ProjectSettings.asset
+++ b/XRTK-Core/ProjectSettings/ProjectSettings.asset
@@ -47,7 +47,7 @@ PlayerSettings:
   defaultScreenHeight: 768
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
-  m_StereoRenderingPath: 0
+  m_StereoRenderingPath: 2
   m_ActiveColorSpace: 1
   m_MTRendering: 1
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
@@ -166,7 +166,7 @@ PlayerSettings:
     Standalone: com.xrtk.core
   buildNumber: {}
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 19
+  AndroidMinSdkVersion: 26
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
@@ -174,7 +174,7 @@ PlayerSettings:
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
   ForceInternetPermission: 0
-  ForceSDCardPermission: 0
+  ForceSDCardPermission: 1
   CreateWallpaper: 0
   APKExpansionFiles: 0
   keepLoadedShadersAlive: 0
@@ -255,7 +255,7 @@ PlayerSettings:
   clonedFromGUID: c0afd0d1d80e3634a9dac47e8a0426ea
   templatePackageId: com.unity.template.3d@1.0.4
   templateDefaultScene: Assets/Scenes/SampleScene.unity
-  AndroidTargetArchitectures: 1
+  AndroidTargetArchitectures: 3
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: '{inproject}: '
@@ -266,7 +266,7 @@ PlayerSettings:
   AndroidEnableTango: 0
   androidEnableBanner: 1
   androidUseLowAccuracyLocation: 0
-  androidUseCustomKeystore: 0
+  androidUseCustomKeystore: 1
   m_AndroidBanners:
   - width: 320
     height: 180


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

This should fix the intermittent errors about the camera and event system being destroyed when leaving playmode.

- Added null check extension to properly check unity object and native object validity
- Added destroy extension to properly destroy `UnityEngine.Objects`
- Updated Rendering settings for all xr platforms to single pass instanced or single pass
- Added android logcat package
- Updated Ultraleap checkout

## Submodule Changes

https://github.com/XRTK/Examples/pull/10
https://github.com/XRTK/SDK/pull/195
https://github.com/XRTK/Ultraleap/pull/6