### PR TITLE
Pull out Quaternion.Approximately from hands PR

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/QuaternionExtensions.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Extensions/QuaternionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 
 namespace XRTK.Extensions
@@ -10,10 +11,35 @@ namespace XRTK.Extensions
     /// </summary>
     public static class QuaternionExtensions
     {
+        /// <summary>
+        /// Checks if a <see cref="Quaternion"/> instance is valid. A <see cref="Quaternion"/> is considered
+        /// valid, if none of its components is <see cref="float.IsInfinity(float)"/> nor <see cref="float.IsNaN(float)"/>.
+        /// </summary>
+        /// <param name="rotation">The <see cref="Quaternion"/> to validate.</param>
+        /// <returns>True, if valid rotation.</returns>
         public static bool IsValidRotation(this Quaternion rotation)
         {
             return !float.IsNaN(rotation.x) && !float.IsNaN(rotation.y) && !float.IsNaN(rotation.z) && !float.IsNaN(rotation.w) &&
                    !float.IsInfinity(rotation.x) && !float.IsInfinity(rotation.y) && !float.IsInfinity(rotation.z) && !float.IsInfinity(rotation.w);
+        }
+
+        /// <summary>
+        /// Checks the <see cref="Quaternion"/> can be approximately considered the same rotation when compared
+        /// to another <see cref="Quaternion"/>.
+        /// </summary>
+        /// <param name="quaternion">The original <see cref="Quaternion"/>.</param>
+        /// <param name="other">The <see cref="Quaternion"/> to compare against.</param>
+        /// <param name="threshold">Threshold in degrees to consider rotations the same.</param>
+        /// <returns>True, if both rotations are approximately the same.</returns>
+        public static bool Approximately(this Quaternion quaternion, Quaternion other, float threshold)
+        {
+            var qEuler = quaternion.eulerAngles;
+            var otherEuler = other.eulerAngles;
+
+            return
+                Math.Abs(qEuler.x - otherEuler.x) <= threshold &&
+                Math.Abs(qEuler.y - otherEuler.y) <= threshold &&
+                Math.Abs(qEuler.z - otherEuler.z) <= threshold;
         }
 
         /// <summary>


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

As requested pulled out `Quaternion.Approximately` extension from the hands PR.
It is a utility to decide whether two rotations are roughly the same.

https://github.com/XRTK/XRTK-Core/pull/552/files#r432893807
