### PR TITLE
Fix profiles reset and services reinitialized when already running

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
@@ -92,6 +92,14 @@ namespace XRTK.Services
         /// <param name="profile"></param>
         public void ResetProfile(MixedRealityToolkitRootProfile profile)
         {
+            if (Application.isEditor && Application.isPlaying)
+            {
+                // The application is running in editor play mode, can't
+                // reset profiles in this state as it will cause destruction
+                // and reinitialization of services in use.
+                return;
+            }
+
             if (isResetting)
             {
                 Debug.LogWarning("Already attempting to reset the root profile!");


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Fixes the issue reported by @SimonDarksideJ in the hands PR https://github.com/XRTK/XRTK-Core/pull/552

```
Simulated Hands inspector spams console if looked at in runtime

Replication Steps:

Open Demo Scene
Run on any platforms
Select the MRT Game Object
Navigate to "Input System profile"
Expand / touch the IMixedRealityInputDataProvider list
See error SPAM
Error Details

Object reference not set to an instance of an object
  at XRTK.Providers.Controllers.Simulation.BaseSimulatedControllerDataProvider.RefreshSimulatedDevices () [0x00001] in C:\LocalDevelopment\XRTK-Core\XRTK-Core\Packages\com.xrtk.core\Runtime\Providers\Controllers\Simulation\BaseSimulatedControllerDataProvider.cs:129 
  at XRTK.Providers.Controllers.Simulation.BaseSimulatedControllerDataProvider.Update () [0x00008] in C:\LocalDevelopment\XRTK-Core\XRTK-Core\Packages\com.xrtk.core\Runtime\Providers\Controllers\Simulation\BaseSimulatedControllerDataProvider.cs:111 
  at XRTK.Services.MixedRealityToolkit.UpdateAllServices () [0x00095] in C:\LocalDevelopment\XRTK-Core\XRTK-Core\Packages\com.xrtk.core\Runtime\Services\MixedRealityToolkit.cs:1479 
UnityEngine.Debug:LogError(Object)
XRTK.Services.MixedRealityToolkit:UpdateAllServices() (at Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs:1483)
XRTK.Services.MixedRealityToolkit:Update() (at Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs:697)
Expected Behaviour:
No errors while navigating the inspector, whether editor or runtime
```

## Changes

What would happen is that upon selecting / unfolding any data provider configuration in the profiles, while the application is in play mode, causes a full profile reset. This destroys all services and does a full reinitialization of the toolkit. As a side effect of this, the playspace would also get destroyed and recreated. It would then not appear in `DontDestroyOnLoad` collection anymore but in the base scene itself.

To prevent these issues, I disabled resetting profiles when the application is running in editor play mode.

