### PR TITLE
Update legacy WMR UPM package to 1.0.21

### DIFF
--- a/XRTK-Core/Packages/manifest.json
+++ b/XRTK-Core/Packages/manifest.json
@@ -15,7 +15,7 @@
     "com.unity.xr.legacyinputhelpers": "2.1.4",
     "com.unity.xr.magicleap": "2.0.0-preview.19",
     "com.unity.xr.openvr.standalone": "1.0.5",
-    "com.unity.xr.windowsmr.metro": "1.0.19",
+    "com.unity.xr.windowsmr.metro": "1.0.21",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Package changelog:

`Update remoting plugins to version 2.1.3.`

This also most likely fixes the a workaround currently found in `WindowsMixedRealityMotionController`

## Changes

- Updated the wmr package