### PR TITLE
Only apply default head height if not managed by device

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/CameraSystem/IMixedRealityCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/CameraSystem/IMixedRealityCameraDataProvider.cs
@@ -19,6 +19,13 @@ namespace XRTK.Interfaces.CameraSystem
         bool IsStereoscopic { get; }
 
         /// <summary>
+        /// Is the head height, and thus the camera y-position, managed by the device itself?
+        /// If true, the <see cref="DefaultHeadHeight"/> setting is ignored and has no effect
+        /// on camera positioning.
+        /// </summary>
+        bool HeadHeightIsManagedByDevice { get; }
+
+        /// <summary>
         /// The <see cref="IMixedRealityCameraRig"/> reference for this data provider.
         /// </summary>
         IMixedRealityCameraRig CameraRig { get; }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using UnityEngine;
+using UnityEngine.XR;
 using XRTK.Definitions.CameraSystem;
 using XRTK.Extensions;
 using XRTK.Interfaces.CameraSystem;
@@ -84,6 +85,9 @@ namespace XRTK.Providers.CameraSystem
 
         /// <inheritdoc />
         public virtual bool IsStereoscopic => CameraRig.PlayerCamera.stereoEnabled;
+
+        /// <inheritdoc />
+        public virtual bool HeadHeightIsManagedByDevice => XRDevice.isPresent;
 
         /// <inheritdoc />
         public IMixedRealityCameraRig CameraRig { get; private set; }
@@ -239,7 +243,11 @@ namespace XRTK.Providers.CameraSystem
         /// </summary>
         protected virtual void ApplySettingsForDefaultHeadHeight()
         {
-            HeadHeight = DefaultHeadHeight;
+            if (!HeadHeightIsManagedByDevice)
+            {
+                HeadHeight = DefaultHeadHeight;
+            }
+
             ResetRigTransforms();
             SyncRigTransforms();
         }
@@ -274,8 +282,10 @@ namespace XRTK.Providers.CameraSystem
         {
             CameraRig.PlayspaceTransform.position = Vector3.zero;
             CameraRig.PlayspaceTransform.rotation = Quaternion.identity;
-            // If the camera is a 2d camera when we can adjust the camera's height to match the head height.
+
+            // If the camera is a 2d camera then we can adjust the camera's height to match the head height.
             CameraRig.CameraTransform.position = IsStereoscopic ? Vector3.zero : new Vector3(0f, HeadHeight, 0f);
+
             CameraRig.CameraTransform.rotation = Quaternion.identity;
             CameraRig.BodyTransform.position = Vector3.zero;
             CameraRig.BodyTransform.rotation = Quaternion.identity;


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Introduced 

```
/// <summary>
/// Is the head height, and thus the camera y-position, managed by the device itself?
/// If true, the <see cref="DefaultHeadHeight"/> setting is ignored and has no effect
/// on camera positioning.
/// </summary>
bool HeadHeightIsManagedByDevice { get; }
```

to `IMixedRealityCameraDataProvider` and implemented as

```
/// <inheritdoc />
public virtual bool HeadHeightIsManagedByDevice => XRDevice.isPresent;
```

in `BaseCameraDataProvider`

to only apply the `DefaultHeadHeight` setting, if the device does not manage head height itself, which is the case
with many devices, like HoloLens e.g.

By default we will assume as soon as an XR Device is connected that it manages head height, since most devices these days will do. The developer has the option to override the default value per platform.

## Changes

- Fixes: #656 