### PR TITLE
Fixed issues around errors when starting and stopping playmode in editor

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/SpatialObservers/BaseMixedRealitySpatialMeshObserver.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/SpatialObservers/BaseMixedRealitySpatialMeshObserver.cs
@@ -134,10 +134,8 @@ namespace XRTK.Providers.SpatialObservers
             // Disable any spatial meshes we might have.
             foreach (var meshObject in spatialMeshObjects.Values)
             {
-                if (meshObject.GameObject != null)
-                {
-                    meshObject.GameObject.SetActive(false);
-                }
+                Debug.Assert(meshObject.GameObject != null);
+                meshObject.GameObject.SetActive(false);
             }
         }
 
@@ -152,7 +150,7 @@ namespace XRTK.Providers.SpatialObservers
                 meshObject.GameObject.Destroy();
             }
 
-            spatialMeshObjects.Clear();
+            Debug.Assert(spatialMeshObjects.Count == 0);
 
             lock (spatialMeshObjectPool)
             {
@@ -161,6 +159,8 @@ namespace XRTK.Providers.SpatialObservers
                     var meshObject = spatialMeshObjectPool.Pop();
                     meshObject.GameObject.Destroy();
                 }
+
+                Debug.Assert(spatialMeshObjectPool.Count == 0);
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
@@ -673,15 +673,7 @@ namespace XRTK.Services
 
             if (IsInitialized && instance != this)
             {
-                if (Application.isEditor)
-                {
-                    DestroyImmediate(gameObject);
-                }
-                else
-                {
-                    Destroy(gameObject);
-                }
-
+                gameObject.Destroy();
                 Debug.LogWarning($"Trying to instantiate a second instance of the {nameof(MixedRealityToolkit)}. Additional Instance was destroyed");
             }
             else if (!IsInitialized)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -202,25 +202,22 @@ namespace XRTK.Services.SpatialAwarenessSystem
             if (spatialAwarenessParent != null)
             {
                 spatialAwarenessParent.transform.DetachChildren();
+                spatialAwarenessParent.Destroy();
             }
-
-            spatialAwarenessParent.Destroy();
 
             // Detach the mesh objects (they are to be cleaned up by the observer) and cleanup the parent
             if (meshParent != null)
             {
                 meshParent.transform.DetachChildren();
+                meshParent.Destroy();
             }
-
-            meshParent.Destroy();
 
             // Detach the surface objects (they are to be cleaned up by the observer) and cleanup the parent
             if (surfaceParent != null)
             {
                 surfaceParent.transform.DetachChildren();
+                surfaceParent.Destroy();
             }
-
-            surfaceParent.Destroy();
         }
 
         #region Mesh Events


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

<!-- Please provide a clear and concise description of the pull request. -->
Resolves the errors when exiting playmode in the editor for the Windows Universal Platform.
Fixed a script reference in the SDK that improperly pointed to the LuminSpatialObserverProfile

## Changes

<!-- Brief list of the targeted features that are being changed. -->

- Fixes: https://github.com/XRTK/WindowsMixedReality/issues/97

## Submodule Changes

<!--  Include any submodule PR links here -->

- [SDK](https://github.com/XRTK/SDK/pull/198)
