### PR TITLE
fix/tracked pose access

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Simulation/Hands/SimulatedHandControllerDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/Controllers/Simulation/Hands/SimulatedHandControllerDataProvider.cs
@@ -98,8 +98,7 @@ namespace XRTK.Providers.Controllers.Simulation.Hands
         /// <inheritdoc />
         public HandRenderingMode RenderingMode { get; set; }
 
-        /// <inheritdoc />
-        public IReadOnlyList<HandControllerPoseProfile> TrackedPoses { get; }
+        private IReadOnlyList<HandControllerPoseProfile> TrackedPoses { get; }
 
         /// <inheritdoc />
         protected override void UpdateSimulatedController(IMixedRealitySimulatedController simulatedController)


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

<!-- Please provide a clear and concise description of the pull request. -->

Made `SimulatedHandControllerDataProvider.TrackedPoses` private since it is not part of the interface and profiles are not supposed to be accessible to other services, data providers.