### PR TITLE
Fix missing virtual keyword for OnApplicationPause in BaseService

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/BaseService.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/BaseService.cs
@@ -47,7 +47,7 @@ namespace XRTK.Services
         public virtual void OnApplicationFocus(bool isFocused) { }
 
         /// <inheritdoc />
-        public void OnApplicationPause(bool isPaused) { }
+        public virtual void OnApplicationPause(bool isPaused) { }
 
         #endregion IMixedRealityService Implementation
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

There was a missing virtual keyword in one of the base implementations in `BaseService`
