### PR TITLE
Changing the default for GUID regen to FALSE

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
@@ -27,7 +27,7 @@ namespace XRTK.Editor
         /// <param name="destinationPath">The destination path, typically inside the projects "Assets" directory.</param>
         /// <param name="regenerateGuids">Should the guids for the copied assets be regenerated?</param>
         /// <returns>Returns true if the profiles were successfully copies, installed, and added to the <see cref="MixedRealityToolkitRootProfile"/>.</returns>
-        public static bool TryInstallAssets(string sourcePath, string destinationPath, bool regenerateGuids = true)
+        public static bool TryInstallAssets(string sourcePath, string destinationPath, bool regenerateGuids = false)
         {
             return TryInstallAssets(new Dictionary<string, string> { { sourcePath, destinationPath } }, regenerateGuids);
         }
@@ -38,7 +38,7 @@ namespace XRTK.Editor
         /// <param name="installationPaths">The assets paths to be installed. Key is the source path of the assets to be installed. This should typically be from a hidden upm package folder marked with a "~". Value is the destination.</param>
         /// <param name="regenerateGuids">Should the guids for the copied assets be regenerated?</param>
         /// <returns>Returns true if the profiles were successfully copies, installed, and added to the <see cref="MixedRealityToolkitRootProfile"/>.</returns>
-        public static bool TryInstallAssets(Dictionary<string, string> installationPaths, bool regenerateGuids = true)
+        public static bool TryInstallAssets(Dictionary<string, string> installationPaths, bool regenerateGuids = false)
         {
             var anyFail = false;
             var newInstall = true;


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Since the move to place the default profiles and prefabs for all the various platforms to HIDDEN folders, there isn't actually a need to regenerate the GUID's for copied assets by default.

This ensures that any references between packages are retained as the asset guids remain unchanged when copied to a projects asset folder.  And since the originals are in hidden folders, there is no conflict anymore.

The facility remains should it be needed, it is simply now OFF by default

## Changes

Simply updated the default for GUID regeneration to FALSE within the Core Package Installer script.  No other changes needed.

- Fixes: #706

Tested in a new project without issue and previous referencing issues are no longer a problem.