### PR TITLE
Misc fixes for GUID regeneration issues

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
@@ -27,7 +27,7 @@ namespace XRTK.Editor
         /// <param name="destinationPath">The destination path, typically inside the projects "Assets" directory.</param>
         /// <param name="regenerateGuids">Should the guids for the copied assets be regenerated?</param>
         /// <returns>Returns true if the profiles were successfully copies, installed, and added to the <see cref="MixedRealityToolkitRootProfile"/>.</returns>
-        public static bool TryInstallAssets(string sourcePath, string destinationPath, bool regenerateGuids = true)
+        public static bool TryInstallAssets(string sourcePath, string destinationPath, bool regenerateGuids = false)
         {
             return TryInstallAssets(new Dictionary<string, string> { { sourcePath, destinationPath } }, regenerateGuids);
         }
@@ -38,7 +38,7 @@ namespace XRTK.Editor
         /// <param name="installationPaths">The assets paths to be installed. Key is the source path of the assets to be installed. This should typically be from a hidden upm package folder marked with a "~". Value is the destination.</param>
         /// <param name="regenerateGuids">Should the guids for the copied assets be regenerated?</param>
         /// <returns>Returns true if the profiles were successfully copies, installed, and added to the <see cref="MixedRealityToolkitRootProfile"/>.</returns>
-        public static bool TryInstallAssets(Dictionary<string, string> installationPaths, bool regenerateGuids = true)
+        public static bool TryInstallAssets(Dictionary<string, string> installationPaths, bool regenerateGuids = false)
         {
             var anyFail = false;
             var newInstall = true;

--- a/articles/00-GettingStarted.md
+++ b/articles/00-GettingStarted.md
@@ -99,6 +99,7 @@ Once the build completes, you can install and run it on the device.
 
 * [Downloading the XRTK](01-DownloadingTheXRTK.md)
 * [Configuring your project](02-Configuration.md)
+* [Known Issues](04-KnownIssues.md)
 
 ---
 

--- a/articles/04-KnownIssues.md
+++ b/articles/04-KnownIssues.md
@@ -2,4 +2,7 @@
 
 > Current known issues up to and including the 0.2 release
 
-- Currently xrtk assets are copied from the packages for developers to use. Assets may potentially be overwritten, corrupted, or conflict if a copy already exists in the project. We're working on updating the import process to provide developers a clean copy they can modify safely without fear of this.
+Issue | Severity | Description | Mitigation
+|---|---|---|---|
+| 1 | **Low** | Currently XRTK assets are copied from the individual packages to the Unity project for developers to use. Existing assets may potentially be overwritten, corrupted, or conflict if a copy already exists in the project. We're working on updating the import process to provide developers a clean copy they can modify safely without fear of this. | Developers are advised not to replace assets in the XRTK.Generated folder.  When profiles / assets are cloned, place them outside this folder to prevent overwriting following an upgrade.
+||||

--- a/articles/04-KnownIssues.md
+++ b/articles/04-KnownIssues.md
@@ -1,0 +1,5 @@
+# Known issues 
+
+> Current known issues up to and including the 0.2 release
+
+- Currently xrtk assets are copied from the packages for developers to use. Assets may potentially be overwritten, corrupted, or conflict if a copy already exists in the project. We're working on updating the import process to provide developers a clean copy they can modify safely without fear of this.

--- a/articles/toc.yml
+++ b/articles/toc.yml
@@ -8,6 +8,8 @@
       href: 02-Configuration.md
     - name: Platform Template Generator
       href: 03-Template-Generator.md
+    - name: Known Issues
+      href: 04-KnownIssues.md
 - name: Test Plans
   items:
     - name: Overview


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Since the move to place the default profiles and prefabs for all the various platforms to HIDDEN folders, there isn't actually a need to regenerate the GUID's for copied assets by default.

This ensures that any references between packages are retained as the asset guids remain unchanged when copied to a project's asset folder. And since the originals are in hidden folders, there is no conflict anymore.

The facility remains should it be needed, it is simply now OFF by default

## Changes

Following discussions, the following changes were agreed (following on from PR #717 

- [X] Updated the default for GUID regeneration to FALSE within the Core Package Installer script. 
- [X] Reverted GUID cache changes 
- [X] Added Known Issues documentation to warn developers about changing XRTK.Generated content

- Fixes: #706

Tested in a new project without issue and previous referencing issues are no longer a problem.