### PR TITLE
Teleport Mode for Teleport System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ obj/
 *.log
 *.idb
 *.opendb
+.vsconfig
 
 # ============================ #
 # Visual Studio Code Generated #

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityTeleportSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/MixedRealityTeleportSystemProfileInspector.cs
@@ -4,29 +4,42 @@
 using UnityEditor;
 using XRTK.Definitions.TeleportSystem;
 using XRTK.Services;
+using XRTK.Services.Teleportation;
 
 namespace XRTK.Editor.Profiles
 {
     [CustomEditor(typeof(MixedRealityTeleportSystemProfile))]
     public class MixedRealityTeleportSystemProfileInspector : MixedRealityServiceProfileInspector
     {
+        private SerializedProperty teleportMode;
         private SerializedProperty teleportProvider;
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
+            teleportMode = serializedObject.FindProperty(nameof(teleportMode));
             teleportProvider = serializedObject.FindProperty(nameof(teleportProvider));
         }
 
         public override void OnInspectorGUI()
         {
-            RenderHeader("The teleport system profile defines default behaviour for the teleport system.");
+            RenderHeader("The teleport system profile defines behaviour for the teleport system.");
 
             serializedObject.Update();
             EditorGUI.BeginChangeCheck();
 
-            EditorGUILayout.PropertyField(teleportProvider);
+            EditorGUILayout.PropertyField(teleportMode);
+
+            var activeTeleportMode = (TeleportMode)teleportMode.intValue;
+            switch (activeTeleportMode)
+            {
+                case TeleportMode.Provider:
+                    EditorGUI.indentLevel++;
+                    EditorGUILayout.PropertyField(teleportProvider);
+                    EditorGUI.indentLevel--;
+                    break;
+            }
 
             serializedObject.ApplyModifiedProperties();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/TeleportSystem/MixedRealityTeleportSystemProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/TeleportSystem/MixedRealityTeleportSystemProfile.cs
@@ -6,15 +6,29 @@ using XRTK.Attributes;
 using XRTK.Definitions.Utilities;
 using XRTK.Interfaces.TeleportSystem;
 using XRTK.Interfaces.TeleportSystem.Handlers;
+using XRTK.Services.Teleportation;
 
 namespace XRTK.Definitions.TeleportSystem
 {
     /// <summary>
-    /// Configuration profile for the <see cref="Services.Teleportation.MixedRealityTeleportSystem"/>.
+    /// Configuration profile for the <see cref="MixedRealityTeleportSystem"/>.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Teleport System Profile", fileName = "MixedRealityTeleportSystemProfile", order = (int)CreateProfileMenuItemIndices.Input)]
     public class MixedRealityTeleportSystemProfile : BaseMixedRealityServiceProfile<IMixedRealityTeleportDataProvider>
     {
+        [SerializeField]
+        [Tooltip("The teleportation mode to use.")]
+        private TeleportMode teleportMode = TeleportMode.Default;
+
+        /// <summary>
+        /// The teleportation mode to use.
+        /// </summary>
+        public TeleportMode TeleportMode
+        {
+            get => teleportMode;
+            internal set => teleportMode = value;
+        }
+
         [SerializeField]
         [Tooltip("The concrete teleport provider to use for teleportation.")]
         [Implements(typeof(IMixedRealityTeleportProvider), TypeGrouping.ByNamespaceFlat)]

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -29,15 +29,21 @@ namespace XRTK.Services.Teleportation
         public MixedRealityTeleportSystem(MixedRealityTeleportSystemProfile profile)
             : base(profile)
         {
-            if (profile.TeleportProvider?.Type == null)
+            teleportMode = profile.TeleportMode;
+            if (teleportMode == TeleportMode.Provider)
             {
-                throw new Exception($"The {nameof(MixedRealityTeleportSystemProfile)} is missing the required {teleportProvider}!");
-            }
+                if (profile.TeleportProvider?.Type == null)
+                {
+                    throw new Exception($"The {nameof(MixedRealityTeleportSystemProfile)} is configured for " +
+                        $"{TeleportMode.Provider} but is missing the required {teleportProvider}!");
+                }
 
-            teleportProvider = profile.TeleportProvider;
+                teleportProvider = profile.TeleportProvider;
+            }
         }
 
         private readonly SystemType teleportProvider;
+        private readonly TeleportMode teleportMode;
 
         private TeleportEventData teleportEventData;
         private bool isTeleporting = false;
@@ -54,7 +60,10 @@ namespace XRTK.Services.Teleportation
                 teleportEventData = new TeleportEventData(EventSystem.current);
             }
 
-            CameraCache.Main.gameObject.EnsureComponent(teleportProvider.Type);
+            if (teleportMode == TeleportMode.Provider)
+            {
+                CameraCache.Main.gameObject.EnsureComponent(teleportProvider.Type);
+            }
         }
 
         /// <inheritdoc />
@@ -65,7 +74,6 @@ namespace XRTK.Services.Teleportation
             if (!Application.isPlaying)
             {
                 var component = CameraCache.Main.GetComponent<IMixedRealityTeleportProvider>() as Component;
-
                 if (!component.IsNull())
                 {
                     Object.DestroyImmediate(component);
@@ -151,6 +159,13 @@ namespace XRTK.Services.Teleportation
 
             // Pass handler
             HandleEvent(teleportEventData, OnTeleportStartedHandler);
+
+            // In default teleportation mode we do not expect any provider
+            // to handle teleportation, instead we simply perform an instant teleport.
+            if (teleportMode == TeleportMode.Default)
+            {
+                PerformDefaultTeleport(teleportEventData);
+            }
         }
 
         private static readonly ExecuteEvents.EventFunction<IMixedRealityTeleportHandler> OnTeleportCompletedHandler =
@@ -198,5 +213,36 @@ namespace XRTK.Services.Teleportation
         }
 
         #endregion IMixedRealityTeleportSystem Implementation
+
+        private void PerformDefaultTeleport(TeleportEventData eventData)
+        {
+            var cameraTransform = MixedRealityToolkit.CameraSystem != null ?
+                MixedRealityToolkit.CameraSystem.MainCameraRig.CameraTransform :
+                CameraCache.Main.transform;
+            var teleportTransform = cameraTransform.parent;
+            Debug.Assert(teleportTransform != null,
+                $"{nameof(TeleportMode.Default)} requires that the camera be parented under another object!");
+
+            var targetRotation = Vector3.zero;
+            var targetPosition = eventData.Pointer.Result.EndPoint;
+            targetRotation.y = eventData.Pointer.PointerOrientation;
+
+            if (eventData.HotSpot != null)
+            {
+                targetPosition = eventData.HotSpot.Position;
+                if (eventData.HotSpot.OverrideTargetOrientation)
+                {
+                    targetRotation.y = eventData.HotSpot.TargetOrientation;
+                }
+            }
+
+            var height = targetPosition.y;
+            targetPosition -= cameraTransform.position - teleportTransform.position;
+            targetPosition.y = height;
+            teleportTransform.position = targetPosition;
+            teleportTransform.RotateAround(cameraTransform.position, Vector3.up, targetRotation.y - cameraTransform.eulerAngles.y);
+
+            RaiseTeleportComplete(eventData.Pointer, eventData.HotSpot);
+        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -60,9 +60,25 @@ namespace XRTK.Services.Teleportation
                 teleportEventData = new TeleportEventData(EventSystem.current);
             }
 
-            if (teleportMode == TeleportMode.Provider)
+            switch (teleportMode)
             {
-                CameraCache.Main.gameObject.EnsureComponent(teleportProvider.Type);
+                case TeleportMode.Default:
+                    var component = CameraCache.Main.GetComponent<IMixedRealityTeleportProvider>() as Component;
+                    if (!component.IsNull())
+                    {
+                        if (Application.isPlaying)
+                        {
+                            Object.Destroy(component);
+                        }
+                        else
+                        {
+                            Object.DestroyImmediate(component);
+                        }
+                    }
+                    break;
+                case TeleportMode.Provider:
+                    CameraCache.Main.gameObject.EnsureComponent(teleportProvider.Type);
+                    break;
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/TeleportMode.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/TeleportMode.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace XRTK.Services.Teleportation
+{
+    /// <summary>
+    /// Supported teleport modes in the <see cref="MixedRealityTeleportSystem"/> implementation.
+    /// </summary>
+    public enum TeleportMode
+    {
+        /// <summary>
+        /// <see cref="Default"/> will instantly teleport the player
+        /// to the selected location and does not require any additional setup.
+        /// </summary>
+        Default = 0,
+        /// <summary>
+        /// <see cref="Provider"/> mode lets <see cref="Interfaces.TeleportSystem.Handlers.IMixedRealityTeleportProvider"/>'s
+        /// handle teleportation. This mode requires <see cref="Definitions.TeleportSystem.MixedRealityTeleportSystemProfile.TeleportProvider"/>
+        /// to be configured with a concrete <see cref="Interfaces.TeleportSystem.Handlers.IMixedRealityTeleportProvider"/> implementation.
+        /// </summary>
+        Provider
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/TeleportMode.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/TeleportMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8d3a2f4a39c7024493058f95c033cda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

This PR introduces `TeleportMode` to the teleport system and fixes https://github.com/XRTK/XRTK-Core/issues/725

Teleport Mode has two options:
- Default: The teleport system will instantly teleport the user to the selected location. This mode works out of the box and is the toolkit's default. This mode also works without SDK
- Provider: In provider mode the teleport system will not teleport the user itself but instead attach a teleport provider to the camera game object. Teleport providers can be customized and implemented using the `IMixedRealityTeleportProvider` interface. SDK has a `BaseTeleportProvider` for users to get started implementing their own provider. SDK also comes with a `FadingTeleportProvider` as an example of fully implemented teleport provider

![defaultmode](https://user-images.githubusercontent.com/9565734/102693547-bf8a6380-421b-11eb-97f6-b11ee385757a.PNG)
![providermode](https://user-images.githubusercontent.com/9565734/102693549-c1542700-421b-11eb-9a95-5399bfe82634.PNG)


## Changes

- The teleport system default is now the `TeleportMode.Default` that works without SDK

- Fixes: https://github.com/XRTK/XRTK-Core/issues/725

## Submodule Changes

<!--  Include any submodule PR links here -->

- [SDK](https://github.com/XRTK/SDK/pull/215)
- [Examples](https://github.com/XRTK/Examples/pull/22)
