### PR TITLE
Feature/721 teleport input action

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/TeleportSystem/MixedRealityTeleportSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/TeleportSystem/MixedRealityTeleportSystemProfileInspector.cs
@@ -11,12 +11,14 @@ namespace XRTK.Editor.Profiles.TeleportSystem
     public class MixedRealityTeleportSystemProfileInspector : MixedRealityServiceProfileInspector
     {
         private SerializedProperty teleportProvider;
+        private SerializedProperty teleportAction;
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
             teleportProvider = serializedObject.FindProperty(nameof(teleportProvider));
+            teleportAction = serializedObject.FindProperty(nameof(teleportAction));
         }
 
         public override void OnInspectorGUI()
@@ -27,6 +29,7 @@ namespace XRTK.Editor.Profiles.TeleportSystem
             EditorGUI.BeginChangeCheck();
 
             EditorGUILayout.PropertyField(teleportProvider);
+            EditorGUILayout.PropertyField(teleportAction);
 
             serializedObject.ApplyModifiedProperties();
 

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/TeleportSystem/MixedRealityTeleportValidationDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/TeleportSystem/MixedRealityTeleportValidationDataProviderProfileInspector.cs
@@ -13,6 +13,7 @@ namespace XRTK.Editor.Profiles.TeleportSystem
         private SerializedProperty invalidLayers;
         private SerializedProperty upDirectionThreshold;
         private SerializedProperty maxDistance;
+        private SerializedProperty maxHeightDistance;
 
         protected override void OnEnable()
         {
@@ -22,6 +23,7 @@ namespace XRTK.Editor.Profiles.TeleportSystem
             invalidLayers = serializedObject.FindProperty(nameof(invalidLayers));
             upDirectionThreshold = serializedObject.FindProperty(nameof(upDirectionThreshold));
             maxDistance = serializedObject.FindProperty(nameof(maxDistance));
+            maxHeightDistance = serializedObject.FindProperty(nameof(maxHeightDistance));
         }
 
         public override void OnInspectorGUI()
@@ -34,6 +36,7 @@ namespace XRTK.Editor.Profiles.TeleportSystem
             EditorGUILayout.PropertyField(invalidLayers);
             EditorGUILayout.PropertyField(upDirectionThreshold);
             EditorGUILayout.PropertyField(maxDistance);
+            EditorGUILayout.PropertyField(maxHeightDistance);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/TeleportSystem/MixedRealityTeleportSystemProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/TeleportSystem/MixedRealityTeleportSystemProfile.cs
@@ -3,6 +3,7 @@
 
 using UnityEngine;
 using XRTK.Attributes;
+using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.Utilities;
 using XRTK.Interfaces.TeleportSystem;
 using XRTK.Interfaces.TeleportSystem.Handlers;
@@ -28,6 +29,19 @@ namespace XRTK.Definitions.TeleportSystem
         {
             get => teleportProvider;
             internal set => teleportProvider = value;
+        }
+
+        [SerializeField]
+        [Tooltip("Input action to trigger a teleport request.")]
+        private MixedRealityInputAction teleportAction = MixedRealityInputAction.None;
+
+        /// <summary>
+        /// Input action to trigger a teleport request.
+        /// </summary>
+        public MixedRealityInputAction TeleportAction
+        {
+            get => teleportAction;
+            internal set => teleportAction = value;
         }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/TeleportSystem/MixedRealityTeleportValidationDataProviderProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/TeleportSystem/MixedRealityTeleportValidationDataProviderProfile.cs
@@ -66,5 +66,19 @@ namespace XRTK.Definitions.TeleportSystem
             get => maxDistance;
             internal set => maxDistance = value;
         }
+
+        [SerializeField]
+        [Min(.1f)]
+        [Tooltip("The maximum height distance from the player a teleport location can be away.")]
+        private float maxHeightDistance = 10f;
+
+        /// <summary>
+        /// The maximum height distance from the player a teleport location can be away.
+        /// </summary>
+        public float MaxHeightDistance
+        {
+            get => maxHeightDistance;
+            internal set => maxHeightDistance = value;
+        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/TeleportSystem/IMixedRealityTeleportSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/TeleportSystem/IMixedRealityTeleportSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using XRTK.Definitions.InputSystem;
 using XRTK.Interfaces.Events;
 using XRTK.Interfaces.InputSystem;
 
@@ -12,6 +13,12 @@ namespace XRTK.Interfaces.TeleportSystem
     /// </summary>
     public interface IMixedRealityTeleportSystem : IMixedRealityEventSystem
     {
+        /// <summary>
+        /// Gets the <see cref="MixedRealityInputAction"/> used to trigger a teleport
+        /// request.
+        /// </summary>
+        MixedRealityInputAction TeleportAction { get; }
+
         /// <summary>
         /// Raise a teleportation request event.
         /// </summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -1,9 +1,9 @@
 // Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.TeleportSystem;
 using XRTK.Definitions.Utilities;
 using XRTK.EventDatum.Teleport;
@@ -30,6 +30,7 @@ namespace XRTK.Services.Teleportation
             : base(profile)
         {
             teleportProvider = profile.TeleportProvider?.Type == null ? null : teleportProvider = profile.TeleportProvider;
+            TeleportAction = profile.TeleportAction;
         }
 
         private readonly SystemType teleportProvider;
@@ -124,6 +125,9 @@ namespace XRTK.Services.Teleportation
         #endregion IEventSystemManager Implementation
 
         #region IMixedRealityTeleportSystem Implementation
+
+        /// <inheritdoc />
+        public MixedRealityInputAction TeleportAction { get; private set; }
 
         private static readonly ExecuteEvents.EventFunction<IMixedRealityTeleportHandler> OnTeleportRequestHandler =
             delegate (IMixedRealityTeleportHandler handler, BaseEventData eventData)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportValidationDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/TeleportSystem/MixedRealityTeleportValidationDataProvider.cs
@@ -23,12 +23,14 @@ namespace XRTK.Services.Teleportation
             invalidLayers = profile.InvalidLayers;
             upDirectionThreshold = profile.UpDirectionThreshold;
             maxDistanceSquare = profile.MaxDistance * profile.MaxDistance;
+            maxHeightDistance = profile.MaxHeightDistance;
         }
 
         private readonly LayerMask validLayers;
         private readonly LayerMask invalidLayers;
         private readonly float upDirectionThreshold;
         private readonly float maxDistanceSquare;
+        private readonly float maxHeightDistance;
 
         /// <inheritdoc />
         public TeleportValidationResult IsValid(IPointerResult pointerResult, IMixedRealityTeleportHotSpot teleportHotSpot = null)
@@ -36,7 +38,8 @@ namespace XRTK.Services.Teleportation
             TeleportValidationResult teleportValidationResult;
 
             // Check distance.
-            if ((pointerResult.EndPoint - CameraCache.Main.transform.position).sqrMagnitude > maxDistanceSquare)
+            if ((pointerResult.EndPoint - CameraCache.Main.transform.position).sqrMagnitude > maxDistanceSquare ||
+                Mathf.Abs(pointerResult.EndPoint.y - CameraCache.Main.transform.position.y) > maxHeightDistance)
             {
                 teleportValidationResult = TeleportValidationResult.Invalid;
             }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

This PR is the conclusion to my Teleport System series for v0.2. It implements the feature request described in https://github.com/XRTK/XRTK-Core/issues/721 and fixes some other issues. Full Content:

- Added a "Teleport Action" configuration option to the `MixedRealityTeleportSystemProfile`
- Implemented another `MixedRealityTeleportValidationDataProvider` constraint `maxHeightDistance`, which allows restricting teleport distance on the y-axis
- Fixed `TeleportPointerInspector`, I missed removing obsolete serialized properties in my previous PRs
- Implemented support for `Digital` and `SingleAxis` input actions for `TeleportPointer`. Overall the teleport system now supports `Digital | SingleAxis | DualAxis` input actions for teleport

### How To Test

- Create a Digital input action or use an existing one and map it to some controller input, then assign it as the teleport action in the teleport system profile
- Create a SingleAxis input action or use an existing one and map it to some controller input, then assign it as the teleport action in the teleport system profile
- Use the existing "Teleport Direction" input action to test and verify dual axis still works

## Changes

<!-- Brief list of the targeted features that are being changed. -->

- Implements: https://github.com/XRTK/XRTK-Core/issues/721

## Submodule Changes

- [SDK](https://github.com/XRTK/SDK/pull/217)
- [Examples](https://github.com/XRTK/Examples/pull/24)
