### PR TITLE
Fix to resolve issue where an error is generated if the MixedRealityToolkit is selected when a configuration is applied.

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
@@ -133,6 +133,12 @@ namespace XRTK.Editor
         {
             AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
 
+            try
+            {
+                Selection.activeGameObject = null;
+            }
+            catch { }
+
             foreach (var profile in profiles.Where(x => x.EndsWith(".asset")))
             {
                 var platformConfigurationProfile = AssetDatabase.LoadAssetAtPath<MixedRealityPlatformServiceConfigurationProfile>(profile);
@@ -193,6 +199,12 @@ namespace XRTK.Editor
         /// <param name="rootProfile">The root profile to install the </param>
         public static void InstallConfiguration(MixedRealityPlatformServiceConfigurationProfile platformConfigurationProfile, MixedRealityToolkitRootProfile rootProfile)
         {
+            try
+            {
+                Selection.activeGameObject = null;
+            }
+            catch { }
+
             foreach (var configuration in platformConfigurationProfile.Configurations)
             {
                 var configurationType = configuration.InstancedType.Type;

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
@@ -133,9 +133,10 @@ namespace XRTK.Editor
         {
             AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
 
+            //Clear the selection to ensure the inspector does not cause errors, Empty try catch to avoid Unity crashing when Selection is null
             try
             {
-                Selection.activeGameObject = null;
+                Selection.activeObject = null;
             }
             catch { }
 
@@ -199,9 +200,10 @@ namespace XRTK.Editor
         /// <param name="rootProfile">The root profile to install the </param>
         public static void InstallConfiguration(MixedRealityPlatformServiceConfigurationProfile platformConfigurationProfile, MixedRealityToolkitRootProfile rootProfile)
         {
+            //Clear the selection to ensure the inspector does not cause errors, Empty try catch to avoid Unity crashing when Selection is null
             try
             {
-                Selection.activeGameObject = null;
+                Selection.activeObject = null;
             }
             catch { }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Fix to resolve issue where an error is generated if the MixedRealityToolkit is selected when a configuration is applied.

## Changes

- Fixes #731 Updated package installer to clear the currently selected GameObject when applying configuration