### PR TITLE
Fix auto scene switcher

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/AutoSceneSwitcher.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/AutoSceneSwitcher.cs
@@ -1,10 +1,12 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEditor;
 using UnityEditor.Experimental.SceneManagement;
 using UnityEditor.SceneManagement;
 using UnityEngine.SceneManagement;
+using XRTK.Services;
+using XRTK.Extensions;
 using XRTK.Editor.Utilities.SymbolicLinks;
 
 namespace XRTK.Editor.Utilities
@@ -20,6 +22,9 @@ namespace XRTK.Editor.Utilities
         {
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
 
+            // If a start scene hasn't been configured yet for XRTK but the project
+            // has build scenes configured, we assume the scene at index 0 of the build scenes
+            // is our start scene and save it to preferences, unless it's the Unity default sample scene.
             if (MixedRealityPreferences.StartSceneAsset == null &&
                 EditorBuildSettings.scenes.Length > 0 &&
                 !EditorBuildSettings.scenes[0].path.Contains("SampleScene"))
@@ -41,46 +46,64 @@ namespace XRTK.Editor.Utilities
             var startSceneAsset = MixedRealityPreferences.StartSceneAsset;
             var startSceneLoaded = false;
 
+            // If we have a start scene configured in the XRTK preferences
+            // make sure it's loaded.
             if (startSceneAsset != null)
             {
                 for (int i = 0; i < SceneManager.sceneCount; i++)
                 {
-                    var scene = SceneManager.GetSceneAt(i);
-
-                    if (scene.name == startSceneAsset.name &&
-                        SceneManager.GetActiveScene().name != startSceneAsset.name)
+                    var loadedScene = SceneManager.GetSceneAt(i);
+                    if (string.Equals(loadedScene.name, startSceneAsset.name))
                     {
-                        SceneManager.SetActiveScene(scene);
                         startSceneLoaded = true;
                         break;
                     }
                 }
 
+                // A start scene was configured in preferences, but it's not loaded
+                // into hierarchy yet, so we force load it for the user now.
                 if (!startSceneLoaded && startSceneAsset != null)
                 {
                     var startScene = EditorSceneManager.OpenScene(AssetDatabase.GetAssetOrScenePath(startSceneAsset), OpenSceneMode.Additive);
-                    SceneManager.SetActiveScene(startScene);
+
+                    // Move the start scene to be first in hierarchy, if multiples scenes are loaded.
+                    if (SceneManager.sceneCount > 1)
+                    {
+                        EditorSceneManager.MoveSceneBefore(startScene, SceneManager.GetSceneAt(1));
+                    }
+
+                    startSceneLoaded = true;
                 }
             }
 
-            if (startSceneAsset != null && SceneManager.GetActiveScene().name == startSceneAsset.name) { return; }
-
-            var dialogResult = EditorUtility.DisplayDialogComplex(
-                    title: "Missing the MixedRealityToolkit",
-                    message: "Would you like to configure the Mixed Reality Toolkit now?",
-                    "No, play anyway",
-                    "Configure, then play",
-                    "Cancel");
-
-            switch (dialogResult)
+            // If the start scene was successfully loaded, we're good and can continue playing.
+            if (startSceneLoaded)
             {
-                case 1:
-                    MixedRealityToolkitInspector.CreateMixedRealityToolkitGameObject();
-                    EditorApplication.isPlaying = true;
-                    break;
-                case 2:
-                    EditorApplication.isPlaying = false;
-                    break;
+                return;
+            }
+
+            // We couldn't auto setup the XRTK start scene for the user. Thus, the currently
+            // loaded scene(s) may not contain a proper XRTK service locator game object configuration.
+            // Least we can do now is offer the user to auto configure the current scene, if none of the
+            // loaded scenes already contains a XRTK configuration.
+            if (MixedRealityToolkit.Instance.IsNull())
+            {
+                var dialogResult = EditorUtility.DisplayDialogComplex(
+                        title: "Missing the MixedRealityToolkit",
+                        message: "Would you like to configure the Mixed Reality Toolkit now?",
+                        "No, play anyway",
+                        "Configure, then play",
+                        "Cancel");
+
+                switch (dialogResult)
+                {
+                    case 1:
+                        MixedRealityToolkitInspector.CreateMixedRealityToolkitGameObject();
+                        break;
+                    case 2:
+                        EditorApplication.isPlaying = false;
+                        break;
+                }
             }
         }
     }

--- a/docs/api/XRTK.ARCore.Editor.ARCorePathFinder.html
+++ b/docs/api/XRTK.ARCore.Editor.ARCorePathFinder.html
@@ -155,24 +155,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -189,6 +171,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.ARCore.Profiles.ARCoreControllerDataProviderProfile.html
+++ b/docs/api/XRTK.ARCore.Profiles.ARCoreControllerDataProviderProfile.html
@@ -159,6 +159,24 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,24 +199,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.BaseMixedRealityExtensionDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.BaseMixedRealityExtensionDataProviderProfile.html
@@ -118,6 +118,24 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -140,24 +158,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.BaseMixedRealityExtensionServiceProfile.html
+++ b/docs/api/XRTK.Definitions.BaseMixedRealityExtensionServiceProfile.html
@@ -131,6 +131,27 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -153,27 +174,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.BaseMixedRealityProfile.html
+++ b/docs/api/XRTK.Definitions.BaseMixedRealityProfile.html
@@ -166,6 +166,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -188,24 +206,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.BaseMixedRealityServiceProfile-1.html
+++ b/docs/api/XRTK.Definitions.BaseMixedRealityServiceProfile-1.html
@@ -186,6 +186,27 @@ Only types that implement the <see cref="!:TService"></see> will show up in the 
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -208,27 +229,6 @@ Only types that implement the <see cref="!:TService"></see> will show up in the 
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.BoundarySystem.MixedRealityBoundaryProfile.html
+++ b/docs/api/XRTK.Definitions.BoundarySystem.MixedRealityBoundaryProfile.html
@@ -447,6 +447,27 @@ public class MixedRealityBoundaryProfile : BaseMixedRealityServiceProfile&lt;IMi
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -469,27 +490,6 @@ public class MixedRealityBoundaryProfile : BaseMixedRealityServiceProfile&lt;IMi
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.CameraSystem.BaseMixedRealityCameraDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.CameraSystem.BaseMixedRealityCameraDataProviderProfile.html
@@ -525,6 +525,24 @@ If so, then the camera's root will be flagged so it is not destroyed when the sc
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -547,24 +565,6 @@ If so, then the camera's root will be flagged so it is not destroyed when the sc
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.CameraSystem.MixedRealityCameraSystemProfile.html
+++ b/docs/api/XRTK.Definitions.CameraSystem.MixedRealityCameraSystemProfile.html
@@ -165,6 +165,27 @@ public class MixedRealityCameraSystemProfile : BaseMixedRealityServiceProfile&lt
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -187,27 +208,6 @@ public class MixedRealityCameraSystemProfile : BaseMixedRealityServiceProfile&lt
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html
@@ -96,6 +96,7 @@
       <div class="level5"><a class="xref" href="XRTK.Oculus.Profiles.OculusControllerDataProviderProfile.html">OculusControllerDataProviderProfile</a></div>
       <div class="level5"><a class="xref" href="XRTK.SteamVR.Profiles.SteamVRControllerDataProviderProfile.html">SteamVRControllerDataProviderProfile</a></div>
       <div class="level5"><a class="xref" href="XRTK.Ultraleap.Profiles.UltraleapControllerDataProviderProfile.html">UltraleapControllerDataProviderProfile</a></div>
+      <div class="level5"><a class="xref" href="XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.html">WebXRControllerDataProviderProfile</a></div>
       <div class="level5"><a class="xref" href="XRTK.WindowsMixedReality.Profiles.WindowsMixedRealityControllerDataProviderProfile.html">WindowsMixedRealityControllerDataProviderProfile</a></div>
   </div>
   <div class="inheritedMembers">
@@ -228,6 +229,27 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -250,27 +272,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.Hands.BaseHandControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.Hands.BaseHandControllerDataProviderProfile.html
@@ -320,6 +320,27 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -342,27 +363,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.Hands.HandControllerPoseProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.Hands.HandControllerPoseProfile.html
@@ -402,6 +402,27 @@ public class HandControllerPoseProfile : BaseMixedRealityProfile</code></pre>
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.HandControllerPoseProfileExtensions.html#XRTK_Extensions_HandControllerPoseProfileExtensions_ToHandData_XRTK_Definitions_Controllers_Hands_HandControllerPoseProfile_">HandControllerPoseProfileExtensions.ToHandData(HandControllerPoseProfile)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -424,27 +445,6 @@ public class HandControllerPoseProfile : BaseMixedRealityProfile</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.HandControllerPoseProfileExtensions.html#XRTK_Extensions_HandControllerPoseProfileExtensions_ToHandData_XRTK_Definitions_Controllers_Hands_HandControllerPoseProfile_">HandControllerPoseProfileExtensions.ToHandData(HandControllerPoseProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.MixedRealityControllerMappingProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.MixedRealityControllerMappingProfile.html
@@ -242,6 +242,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -264,24 +282,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.MixedRealityControllerVisualizationProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.MixedRealityControllerVisualizationProfile.html
@@ -275,6 +275,24 @@ public class MixedRealityControllerVisualizationProfile : BaseMixedRealityProfil
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -297,24 +315,6 @@ public class MixedRealityControllerVisualizationProfile : BaseMixedRealityProfil
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.MixedRealityInteractionMappingProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.MixedRealityInteractionMappingProfile.html
@@ -181,6 +181,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -203,24 +221,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.OpenVR.Profiles.OpenVRControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.OpenVR.Profiles.OpenVRControllerDataProviderProfile.html
@@ -160,6 +160,27 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.UnityInput.Profiles.UnityInputControllerDataProfile.html#XRTK_Definitions_Controllers_UnityInput_Profiles_UnityInputControllerDataProfile_GetDefaultControllerOptions">UnityInputControllerDataProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -182,27 +203,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.Simulation.Hands.SimulatedHandControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.Simulation.Hands.SimulatedHandControllerDataProviderProfile.html
@@ -378,6 +378,27 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.Simulation.SimulatedControllerDataProviderProfile.html#XRTK_Definitions_Controllers_Simulation_SimulatedControllerDataProviderProfile_GetDefaultControllerOptions">SimulatedControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -400,27 +421,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.Simulation.SimulatedControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.Simulation.SimulatedControllerDataProviderProfile.html
@@ -474,6 +474,27 @@ updates every frame.</p>
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -496,27 +517,6 @@ updates every frame.</p>
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.UnityInput.Profiles.MouseControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.UnityInput.Profiles.MouseControllerDataProviderProfile.html
@@ -159,6 +159,27 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,27 +202,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.UnityInput.Profiles.TouchScreenControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.UnityInput.Profiles.TouchScreenControllerDataProviderProfile.html
@@ -160,6 +160,27 @@ public class TouchScreenControllerDataProviderProfile : BaseMixedRealityControll
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -182,27 +203,6 @@ public class TouchScreenControllerDataProviderProfile : BaseMixedRealityControll
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Controllers.UnityInput.Profiles.UnityInputControllerDataProfile.html
+++ b/docs/api/XRTK.Definitions.Controllers.UnityInput.Profiles.UnityInputControllerDataProfile.html
@@ -160,6 +160,27 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -182,27 +203,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateControllerProfiles_XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_System_Type___System_Boolean_">ValidateConfiguration.ValidateControllerProfiles(BaseMixedRealityControllerDataProviderProfile, Type[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Devices.InputProcessor-1.html
+++ b/docs/api/XRTK.Definitions.Devices.InputProcessor-1.html
@@ -172,6 +172,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -194,24 +212,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Devices.InputProcessor.html
+++ b/docs/api/XRTK.Definitions.Devices.InputProcessor.html
@@ -120,6 +120,24 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -142,24 +160,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Devices.InvertDualAxisProcessor.html
+++ b/docs/api/XRTK.Definitions.Devices.InvertDualAxisProcessor.html
@@ -220,6 +220,24 @@ public class InvertDualAxisProcessor : InputProcessor&lt;Vector2&gt;</code></pre
   <div><span class="xref">XRTK.Definitions.Devices.InputProcessor&lt;UnityEngine.Vector2&gt;.Process(UnityEngine.Vector2)</span></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -242,24 +260,6 @@ public class InvertDualAxisProcessor : InputProcessor&lt;Vector2&gt;</code></pre
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Devices.InvertSingleAxisProcessor.html
+++ b/docs/api/XRTK.Definitions.Devices.InvertSingleAxisProcessor.html
@@ -190,6 +190,24 @@ public class InvertSingleAxisProcessor : InputProcessor&lt;float&gt;</code></pre
   <div><span class="xref">XRTK.Definitions.Devices.InputProcessor&lt;System.Single&gt;.Process(System.Single)</span></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -212,24 +230,6 @@ public class InvertSingleAxisProcessor : InputProcessor&lt;float&gt;</code></pre
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.DiagnosticsSystem.MixedRealityDiagnosticsSystemProfile.html
+++ b/docs/api/XRTK.Definitions.DiagnosticsSystem.MixedRealityDiagnosticsSystemProfile.html
@@ -196,6 +196,27 @@ public class MixedRealityDiagnosticsSystemProfile : BaseMixedRealityServiceProfi
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -218,27 +239,6 @@ public class MixedRealityDiagnosticsSystemProfile : BaseMixedRealityServiceProfi
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.InputSystem.MixedRealityGesturesProfile.html
+++ b/docs/api/XRTK.Definitions.InputSystem.MixedRealityGesturesProfile.html
@@ -153,6 +153,24 @@ public class MixedRealityGesturesProfile : BaseMixedRealityProfile</code></pre>
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -175,24 +193,6 @@ public class MixedRealityGesturesProfile : BaseMixedRealityProfile</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.InputSystem.MixedRealityInputActionsProfile.html
+++ b/docs/api/XRTK.Definitions.InputSystem.MixedRealityInputActionsProfile.html
@@ -156,6 +156,24 @@ public class MixedRealityInputActionsProfile : BaseMixedRealityProfile</code></p
 </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -178,24 +196,6 @@ public class MixedRealityInputActionsProfile : BaseMixedRealityProfile</code></p
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.InputSystem.MixedRealityInputSystemProfile.html
+++ b/docs/api/XRTK.Definitions.InputSystem.MixedRealityInputSystemProfile.html
@@ -599,6 +599,27 @@ public class MixedRealityInputSystemProfile : BaseMixedRealityServiceProfile&lt;
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -621,27 +642,6 @@ public class MixedRealityInputSystemProfile : BaseMixedRealityServiceProfile&lt;
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.InputSystem.MixedRealityPointerProfile.html
+++ b/docs/api/XRTK.Definitions.InputSystem.MixedRealityPointerProfile.html
@@ -276,6 +276,24 @@ public class MixedRealityPointerProfile : BaseMixedRealityProfile</code></pre>
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -298,24 +316,6 @@ public class MixedRealityPointerProfile : BaseMixedRealityProfile</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.InputSystem.MixedRealitySpeechCommandsProfile.html
+++ b/docs/api/XRTK.Definitions.InputSystem.MixedRealitySpeechCommandsProfile.html
@@ -215,6 +215,24 @@ public class MixedRealitySpeechCommandsProfile : BaseMixedRealityProfile</code><
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -237,24 +255,6 @@ public class MixedRealitySpeechCommandsProfile : BaseMixedRealityProfile</code><
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.MixedRealityPlatformServiceConfigurationProfile.html
+++ b/docs/api/XRTK.Definitions.MixedRealityPlatformServiceConfigurationProfile.html
@@ -181,6 +181,24 @@ public class MixedRealityPlatformServiceConfigurationProfile : BaseMixedRealityP
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -203,24 +221,6 @@ public class MixedRealityPlatformServiceConfigurationProfile : BaseMixedRealityP
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.MixedRealityRegisteredServiceProvidersProfile.html
+++ b/docs/api/XRTK.Definitions.MixedRealityRegisteredServiceProvidersProfile.html
@@ -131,6 +131,27 @@ public class MixedRealityRegisteredServiceProvidersProfile : BaseMixedRealitySer
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -153,27 +174,6 @@ public class MixedRealityRegisteredServiceProvidersProfile : BaseMixedRealitySer
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.MixedRealityToolkitRootProfile.html
+++ b/docs/api/XRTK.Definitions.MixedRealityToolkitRootProfile.html
@@ -805,6 +805,24 @@ head mounted display (HMD) is a transparent device or an occluded device.</p>
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -827,24 +845,6 @@ head mounted display (HMD) is a transparent device or an occluded device.</p>
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.NetworkingSystem.MixedRealityNetworkSystemProfile.html
+++ b/docs/api/XRTK.Definitions.NetworkingSystem.MixedRealityNetworkSystemProfile.html
@@ -132,6 +132,27 @@ public class MixedRealityNetworkSystemProfile : BaseMixedRealityServiceProfile&l
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -154,27 +175,6 @@ public class MixedRealityNetworkSystemProfile : BaseMixedRealityServiceProfile&l
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Platforms.BasePlatform.html
+++ b/docs/api/XRTK.Definitions.Platforms.BasePlatform.html
@@ -94,6 +94,7 @@
       <div class="level2"><a class="xref" href="XRTK.Definitions.Platforms.UltraleapPlatform.html">UltraleapPlatform</a></div>
       <div class="level2"><a class="xref" href="XRTK.Definitions.Platforms.UniversalWindowsPlatform.html">UniversalWindowsPlatform</a></div>
       <div class="level2"><a class="xref" href="XRTK.Definitions.Platforms.WebGlPlatform.html">WebGlPlatform</a></div>
+      <div class="level2"><a class="xref" href="XRTK.Definitions.Platforms.WebXRPlatform.html">WebXRPlatform</a></div>
       <div class="level2"><a class="xref" href="XRTK.Definitions.Platforms.WindowsStandalonePlatform.html">WindowsStandalonePlatform</a></div>
       <div class="level2"><a class="xref" href="XRTK.Oculus.OculusPlatform.html">OculusPlatform</a></div>
   </div>

--- a/docs/api/XRTK.Definitions.Platforms.WebXRPlatform.html
+++ b/docs/api/XRTK.Definitions.Platforms.WebXRPlatform.html
@@ -1,0 +1,250 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class WebXRPlatform
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class WebXRPlatform
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.Definitions.Platforms.WebXRPlatform">
+  
+  
+  <h1 id="XRTK_Definitions_Platforms_WebXRPlatform" data-uid="XRTK.Definitions.Platforms.WebXRPlatform" class="text-break">Class WebXRPlatform
+  </h1>
+  <div class="markdown level0 summary"><p>Used by the XRTK to signal that the feature is available on the WebXR platform.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="XRTK.Definitions.Platforms.BasePlatform.html">BasePlatform</a></div>
+    <div class="level2"><span class="xref">WebXRPlatform</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="XRTK.Interfaces.IMixedRealityPlatform.html">IMixedRealityPlatform</a></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="XRTK.Definitions.Platforms.BasePlatform.html#XRTK_Definitions_Platforms_BasePlatform_PlatformOverrides">BasePlatform.PlatformOverrides</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="XRTK.Definitions.Platforms.html">XRTK.Definitions.Platforms</a></h6>
+  <h6><strong>Assembly</strong>: XRTK.WebXR.dll</h6>
+  <h5 id="XRTK_Definitions_Platforms_WebXRPlatform_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Guid(&quot;014aed5a-a0d8-4db3-a3c0-0b33ff7c065b&quot;)]
+public class WebXRPlatform : BasePlatform, IMixedRealityPlatform</code></pre>
+  </div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_Definitions_Platforms_WebXRPlatform_IsAvailable.md&amp;value=---%0Auid%3A%20XRTK.Definitions.Platforms.WebXRPlatform.IsAvailable%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/WebXRPlatform.cs/#L15">View Source</a>
+  </span>
+  <a id="XRTK_Definitions_Platforms_WebXRPlatform_IsAvailable_" data-uid="XRTK.Definitions.Platforms.WebXRPlatform.IsAvailable*"></a>
+  <h4 id="XRTK_Definitions_Platforms_WebXRPlatform_IsAvailable" data-uid="XRTK.Definitions.Platforms.WebXRPlatform.IsAvailable">IsAvailable</h4>
+  <div class="markdown level1 summary"><p>Is this platform currently available?</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override bool IsAvailable { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="XRTK.Definitions.Platforms.BasePlatform.html#XRTK_Definitions_Platforms_BasePlatform_IsAvailable">BasePlatform.IsAvailable</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_Definitions_Platforms_WebXRPlatform_IsBuildTargetAvailable.md&amp;value=---%0Auid%3A%20XRTK.Definitions.Platforms.WebXRPlatform.IsBuildTargetAvailable%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/WebXRPlatform.cs/#L24">View Source</a>
+  </span>
+  <a id="XRTK_Definitions_Platforms_WebXRPlatform_IsBuildTargetAvailable_" data-uid="XRTK.Definitions.Platforms.WebXRPlatform.IsBuildTargetAvailable*"></a>
+  <h4 id="XRTK_Definitions_Platforms_WebXRPlatform_IsBuildTargetAvailable" data-uid="XRTK.Definitions.Platforms.WebXRPlatform.IsBuildTargetAvailable">IsBuildTargetAvailable</h4>
+  <div class="markdown level1 summary"><p>The this platform build target available?</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override bool IsBuildTargetAvailable { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="XRTK.Definitions.Platforms.BasePlatform.html#XRTK_Definitions_Platforms_BasePlatform_IsBuildTargetAvailable">BasePlatform.IsBuildTargetAvailable</a></div>
+  <h5 id="XRTK_Definitions_Platforms_WebXRPlatform_IsBuildTargetAvailable_remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Only returns true in editor.</p>
+</div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.IMixedRealityPlatform.html">IMixedRealityPlatform</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_Definitions_Platforms_WebXRPlatform.md&amp;value=---%0Auid%3A%20XRTK.Definitions.Platforms.WebXRPlatform%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/WebXRPlatform.cs/#L11" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.Definitions.Platforms.html
+++ b/docs/api/XRTK.Definitions.Platforms.html
@@ -122,6 +122,9 @@
       <h4><a class="xref" href="XRTK.Definitions.Platforms.WebGlPlatform.html">WebGlPlatform</a></h4>
       <section><p>Used by the XRTK to signal that the feature is available on the WebGL platform.</p>
 </section>
+      <h4><a class="xref" href="XRTK.Definitions.Platforms.WebXRPlatform.html">WebXRPlatform</a></h4>
+      <section><p>Used by the XRTK to signal that the feature is available on the WebXR platform.</p>
+</section>
       <h4><a class="xref" href="XRTK.Definitions.Platforms.WindowsStandalonePlatform.html">WindowsStandalonePlatform</a></h4>
       <section><p>Used by the XRTK to signal that the feature is available on the Windows Standalone platform.</p>
 </section>

--- a/docs/api/XRTK.Definitions.SpatialAwarenessSystem.MixedRealitySpatialAwarenessSystemProfile.html
+++ b/docs/api/XRTK.Definitions.SpatialAwarenessSystem.MixedRealitySpatialAwarenessSystemProfile.html
@@ -289,6 +289,27 @@ public class MixedRealitySpatialAwarenessSystemProfile : BaseMixedRealityService
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -311,27 +332,6 @@ public class MixedRealitySpatialAwarenessSystemProfile : BaseMixedRealityService
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.TeleportSystem.MixedRealityTeleportSystemProfile.html
+++ b/docs/api/XRTK.Definitions.TeleportSystem.MixedRealityTeleportSystemProfile.html
@@ -196,6 +196,27 @@ public class MixedRealityTeleportSystemProfile : BaseMixedRealityServiceProfile&
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -218,27 +239,6 @@ public class MixedRealityTeleportSystemProfile : BaseMixedRealityServiceProfile&
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.ValidateConfiguration.html#XRTK_Utilities_ValidateConfiguration_ValidateService__1_XRTK_Definitions_BaseMixedRealityServiceProfile___0__System_Type___XRTK_Interfaces_IMixedRealityServiceConfiguration___0____System_Boolean_">ValidateConfiguration.ValidateService&lt;T&gt;(BaseMixedRealityServiceProfile&lt;T&gt;, Type[], IMixedRealityServiceConfiguration&lt;T&gt;[], Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.TeleportSystem.MixedRealityTeleportValidationDataProviderProfile.html
+++ b/docs/api/XRTK.Definitions.TeleportSystem.MixedRealityTeleportValidationDataProviderProfile.html
@@ -277,6 +277,24 @@ public class MixedRealityTeleportValidationDataProviderProfile : BaseMixedRealit
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -299,24 +317,6 @@ public class MixedRealityTeleportValidationDataProviderProfile : BaseMixedRealit
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Definitions.Utilities.Handedness.html
+++ b/docs/api/XRTK.Definitions.Utilities.Handedness.html
@@ -129,6 +129,18 @@ public enum Handedness</code></pre>
   </thead></thead></table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.HandednessExtensions.html#XRTK_Oculus_Extensions_HandednessExtensions_ToHand_XRTK_Definitions_Utilities_Handedness_">HandednessExtensions.ToHand()</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.HandednessExtensions.html#XRTK_Oculus_Extensions_HandednessExtensions_ToNode_XRTK_Definitions_Utilities_Handedness_">HandednessExtensions.ToNode()</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.HandednessExtensions.html#XRTK_Oculus_Extensions_HandednessExtensions_ToMeshType_XRTK_Definitions_Utilities_Handedness_">HandednessExtensions.ToMeshType()</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.HandednessExtensions.html#XRTK_Oculus_Extensions_HandednessExtensions_ToSkeletonType_XRTK_Definitions_Utilities_Handedness_">HandednessExtensions.ToSkeletonType()</a>
+  </div>
+  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(String)</a>
   </div>
   <div>
@@ -151,18 +163,6 @@ public enum Handedness</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;Handedness&gt;(Func&lt;Handedness, Boolean&gt;, Int32)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.HandednessExtensions.html#XRTK_Oculus_Extensions_HandednessExtensions_ToHand_XRTK_Definitions_Utilities_Handedness_">HandednessExtensions.ToHand()</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.HandednessExtensions.html#XRTK_Oculus_Extensions_HandednessExtensions_ToNode_XRTK_Definitions_Utilities_Handedness_">HandednessExtensions.ToNode()</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.HandednessExtensions.html#XRTK_Oculus_Extensions_HandednessExtensions_ToMeshType_XRTK_Definitions_Utilities_Handedness_">HandednessExtensions.ToMeshType()</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.HandednessExtensions.html#XRTK_Oculus_Extensions_HandednessExtensions_ToSkeletonType_XRTK_Definitions_Utilities_Handedness_">HandednessExtensions.ToSkeletonType()</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.DemoCustomExtensionServiceProfileInspector.html
+++ b/docs/api/XRTK.DemoCustomExtensionServiceProfileInspector.html
@@ -177,6 +177,15 @@ public class DemoCustomExtensionServiceProfileInspector : MixedRealityRegistered
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityRegisteredServiceProvidersProfileInspector.html#XRTK_Editor_Profiles_MixedRealityRegisteredServiceProvidersProfileInspector_OnInspectorGUI">MixedRealityRegisteredServiceProvidersProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -193,15 +202,6 @@ public class DemoCustomExtensionServiceProfileInspector : MixedRealityRegistered
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.ChannelPackerWindow.html
+++ b/docs/api/XRTK.Editor.ChannelPackerWindow.html
@@ -115,6 +115,24 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -134,24 +152,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.MixedRealityInspectorUtility.html#XRTK_Editor_Utilities_MixedRealityInspectorUtility_CenterOnMainWin_UnityEditor_EditorWindow_">MixedRealityInspectorUtility.CenterOnMainWin(EditorWindow)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.ClippingBoxEditor.html
+++ b/docs/api/XRTK.Editor.ClippingBoxEditor.html
@@ -116,24 +116,6 @@ public class ClippingBoxEditor : Editor, IPreviewable, IToolModeOwner</code></pr
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -150,6 +132,24 @@ public class ClippingBoxEditor : Editor, IPreviewable, IToolModeOwner</code></pr
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.ClippingPlaneEditor.html
+++ b/docs/api/XRTK.Editor.ClippingPlaneEditor.html
@@ -116,24 +116,6 @@ public class ClippingPlaneEditor : Editor, IPreviewable, IToolModeOwner</code></
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -150,6 +132,24 @@ public class ClippingPlaneEditor : Editor, IPreviewable, IToolModeOwner</code></
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.ClippingSphereEditor.html
+++ b/docs/api/XRTK.Editor.ClippingSphereEditor.html
@@ -116,24 +116,6 @@ public class ClippingSphereEditor : Editor, IPreviewable, IToolModeOwner</code><
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -150,6 +132,24 @@ public class ClippingSphereEditor : Editor, IPreviewable, IToolModeOwner</code><
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.ControllerPopupWindow.html
+++ b/docs/api/XRTK.Editor.ControllerPopupWindow.html
@@ -155,6 +155,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -174,24 +192,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.MixedRealityInspectorUtility.html#XRTK_Editor_Utilities_MixedRealityInspectorUtility_CenterOnMainWin_UnityEditor_EditorWindow_">MixedRealityInspectorUtility.CenterOnMainWin(EditorWindow)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Data.Controllers.Hands.HandControllerPoseProfileInspector.html
+++ b/docs/api/XRTK.Editor.Data.Controllers.Hands.HandControllerPoseProfileInspector.html
@@ -168,24 +168,6 @@ public class HandControllerPoseProfileInspector : BaseMixedRealityProfileInspect
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class HandControllerPoseProfileInspector : BaseMixedRealityProfileInspect
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.HoverLightInspector.html
+++ b/docs/api/XRTK.Editor.HoverLightInspector.html
@@ -116,24 +116,6 @@ public class HoverLightInspector : Editor, IPreviewable, IToolModeOwner</code></
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -150,6 +132,24 @@ public class HoverLightInspector : Editor, IPreviewable, IToolModeOwner</code></
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.MixedRealityToolkitInspector.html
+++ b/docs/api/XRTK.Editor.MixedRealityToolkitInspector.html
@@ -151,24 +151,6 @@ public static void CreateMixedRealityToolkitGameObject()</code></pre>
   <div><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEditor.Editor.html#UnityEditor_Editor_OnInspectorGUI">Editor.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -185,6 +167,24 @@ public static void CreateMixedRealityToolkitGameObject()</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html
@@ -314,24 +314,6 @@ protected static void CreateCloneProfile()</code></pre>
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -348,6 +330,24 @@ protected static void CreateCloneProfile()</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.CameraSystem.BaseMixedRealityCameraDataProviderProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.CameraSystem.BaseMixedRealityCameraDataProviderProfileInspector.html
@@ -168,24 +168,6 @@ public class BaseMixedRealityCameraDataProviderProfileInspector : BaseMixedReali
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class BaseMixedRealityCameraDataProviderProfileInspector : BaseMixedReali
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.CameraSystem.MixedRealityCameraSystemProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.CameraSystem.MixedRealityCameraSystemProfileInspector.html
@@ -175,24 +175,6 @@ public class MixedRealityCameraSystemProfileInspector : MixedRealityServiceProfi
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html#XRTK_Editor_Profiles_MixedRealityServiceProfileInspector_OnInspectorGUI">MixedRealityServiceProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -209,6 +191,24 @@ public class MixedRealityCameraSystemProfileInspector : MixedRealityServiceProfi
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.DiagnosticsSystem.MixedRealityDiagnosticsSystemProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.DiagnosticsSystem.MixedRealityDiagnosticsSystemProfileInspector.html
@@ -175,24 +175,6 @@ public class MixedRealityDiagnosticsSystemProfileInspector : MixedRealityService
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html#XRTK_Editor_Profiles_MixedRealityServiceProfileInspector_OnInspectorGUI">MixedRealityServiceProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -209,6 +191,24 @@ public class MixedRealityDiagnosticsSystemProfileInspector : MixedRealityService
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerDataProviderProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerDataProviderProfileInspector.html
@@ -171,24 +171,6 @@ public class BaseMixedRealityControllerDataProviderProfileInspector : BaseMixedR
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -205,6 +187,24 @@ public class BaseMixedRealityControllerDataProviderProfileInspector : BaseMixedR
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerMappingProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerMappingProfileInspector.html
@@ -168,24 +168,6 @@ public class BaseMixedRealityControllerMappingProfileInspector : BaseMixedRealit
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class BaseMixedRealityControllerMappingProfileInspector : BaseMixedRealit
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityHandControllerDataProviderProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityHandControllerDataProviderProfileInspector.html
@@ -171,24 +171,6 @@ public class BaseMixedRealityHandControllerDataProviderProfileInspector : BaseMi
   <div><a class="xref" href="XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerDataProviderProfileInspector.html#XRTK_Editor_Profiles_InputSystem_Controllers_BaseMixedRealityControllerDataProviderProfileInspector_OnInspectorGUI">BaseMixedRealityControllerDataProviderProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -205,6 +187,24 @@ public class BaseMixedRealityHandControllerDataProviderProfileInspector : BaseMi
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.MixedRealityControllerVisualizationProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.MixedRealityControllerVisualizationProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealityControllerVisualizationProfileInspector : BaseMixedReal
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealityControllerVisualizationProfileInspector : BaseMixedReal
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.MixedRealityInteractionMappingProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.MixedRealityInteractionMappingProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealityInteractionMappingProfileInspector : BaseMixedRealityPr
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealityInteractionMappingProfileInspector : BaseMixedRealityPr
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.Simulation.SimulatedControllerDataProviderProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.Simulation.SimulatedControllerDataProviderProfileInspector.html
@@ -170,24 +170,6 @@ public class SimulatedControllerDataProviderProfileInspector : BaseMixedRealityC
   <div><a class="xref" href="XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerDataProviderProfileInspector.html#XRTK_Editor_Profiles_InputSystem_Controllers_BaseMixedRealityControllerDataProviderProfileInspector_OnInspectorGUI">BaseMixedRealityControllerDataProviderProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -204,6 +186,24 @@ public class SimulatedControllerDataProviderProfileInspector : BaseMixedRealityC
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.Simulation.SimulatedHandControllerDataProviderProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.Controllers.Simulation.SimulatedHandControllerDataProviderProfileInspector.html
@@ -170,24 +170,6 @@ public class SimulatedHandControllerDataProviderProfileInspector : SimulatedCont
   <div><a class="xref" href="XRTK.Editor.Profiles.InputSystem.Controllers.Simulation.SimulatedControllerDataProviderProfileInspector.html#XRTK_Editor_Profiles_InputSystem_Controllers_Simulation_SimulatedControllerDataProviderProfileInspector_OnInspectorGUI">SimulatedControllerDataProviderProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -204,6 +186,24 @@ public class SimulatedHandControllerDataProviderProfileInspector : SimulatedCont
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealityGesturesProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealityGesturesProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealityGesturesProfileInspector : BaseMixedRealityProfileInspe
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealityGesturesProfileInspector : BaseMixedRealityProfileInspe
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealityInputActionsProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealityInputActionsProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealityInputActionsProfileInspector : BaseMixedRealityProfileI
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealityInputActionsProfileInspector : BaseMixedRealityProfileI
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealityInputSystemProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealityInputSystemProfileInspector.html
@@ -175,24 +175,6 @@ public class MixedRealityInputSystemProfileInspector : MixedRealityServiceProfil
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html#XRTK_Editor_Profiles_MixedRealityServiceProfileInspector_OnInspectorGUI">MixedRealityServiceProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -209,6 +191,24 @@ public class MixedRealityInputSystemProfileInspector : MixedRealityServiceProfil
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealityPointerProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealityPointerProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealityPointerProfileInspector : BaseMixedRealityProfileInspec
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealityPointerProfileInspector : BaseMixedRealityProfileInspec
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealitySpeechCommandsProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.InputSystem.MixedRealitySpeechCommandsProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealitySpeechCommandsProfileInspector : BaseMixedRealityProfil
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealitySpeechCommandsProfileInspector : BaseMixedRealityProfil
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.MixedRealityBoundaryVisualizationProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.MixedRealityBoundaryVisualizationProfileInspector.html
@@ -175,24 +175,6 @@ public class MixedRealityBoundaryVisualizationProfileInspector : MixedRealitySer
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html#XRTK_Editor_Profiles_MixedRealityServiceProfileInspector_OnInspectorGUI">MixedRealityServiceProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -209,6 +191,24 @@ public class MixedRealityBoundaryVisualizationProfileInspector : MixedRealitySer
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.MixedRealityNetworkSystemProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.MixedRealityNetworkSystemProfileInspector.html
@@ -161,24 +161,6 @@ public class MixedRealityNetworkSystemProfileInspector : MixedRealityServiceProf
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html#XRTK_Editor_Profiles_MixedRealityServiceProfileInspector_OnInspectorGUI">MixedRealityServiceProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -195,6 +177,24 @@ public class MixedRealityNetworkSystemProfileInspector : MixedRealityServiceProf
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.MixedRealityPlatformServiceConfigurationProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.MixedRealityPlatformServiceConfigurationProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealityPlatformServiceConfigurationProfileInspector : BaseMixe
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealityPlatformServiceConfigurationProfileInspector : BaseMixe
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.MixedRealityRegisteredServiceProvidersProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.MixedRealityRegisteredServiceProvidersProfileInspector.html
@@ -162,24 +162,6 @@ public class MixedRealityRegisteredServiceProvidersProfileInspector : MixedReali
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html#XRTK_Editor_Profiles_MixedRealityServiceProfileInspector_OnInspectorGUI">MixedRealityServiceProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -196,6 +178,24 @@ public class MixedRealityRegisteredServiceProvidersProfileInspector : MixedReali
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html
@@ -241,24 +241,6 @@ public class MixedRealityServiceProfileInspector : BaseMixedRealityProfileInspec
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -275,6 +257,24 @@ public class MixedRealityServiceProfileInspector : BaseMixedRealityProfileInspec
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.MixedRealityToolkitRootProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.MixedRealityToolkitRootProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealityToolkitRootProfileInspector : BaseMixedRealityProfileIn
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealityToolkitRootProfileInspector : BaseMixedRealityProfileIn
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySpatialMeshObserverProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySpatialMeshObserverProfileInspector.html
@@ -169,24 +169,6 @@ public class BaseMixedRealitySpatialMeshObserverProfileInspector : BaseMixedReal
   <div><a class="xref" href="XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySpatialObserverProfileInspector.html#XRTK_Editor_Profiles_SpatialAwareness_BaseMixedRealitySpatialObserverProfileInspector_OnInspectorGUI">BaseMixedRealitySpatialObserverProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -203,6 +185,24 @@ public class BaseMixedRealitySpatialMeshObserverProfileInspector : BaseMixedReal
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySpatialObserverProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySpatialObserverProfileInspector.html
@@ -170,24 +170,6 @@ public abstract class BaseMixedRealitySpatialObserverProfileInspector : BaseMixe
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -204,6 +186,24 @@ public abstract class BaseMixedRealitySpatialObserverProfileInspector : BaseMixe
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySurfaceObserverProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySurfaceObserverProfileInspector.html
@@ -169,24 +169,6 @@ public class BaseMixedRealitySurfaceObserverProfileInspector : BaseMixedRealityS
   <div><a class="xref" href="XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySpatialObserverProfileInspector.html#XRTK_Editor_Profiles_SpatialAwareness_BaseMixedRealitySpatialObserverProfileInspector_OnInspectorGUI">BaseMixedRealitySpatialObserverProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -203,6 +185,24 @@ public class BaseMixedRealitySurfaceObserverProfileInspector : BaseMixedRealityS
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.SpatialAwareness.MixedRealitySpatialAwarenessSystemProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.SpatialAwareness.MixedRealitySpatialAwarenessSystemProfileInspector.html
@@ -175,24 +175,6 @@ public class MixedRealitySpatialAwarenessSystemProfileInspector : MixedRealitySe
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html#XRTK_Editor_Profiles_MixedRealityServiceProfileInspector_OnInspectorGUI">MixedRealityServiceProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -209,6 +191,24 @@ public class MixedRealitySpatialAwarenessSystemProfileInspector : MixedRealitySe
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.TeleportSystem.MixedRealityTeleportSystemProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.TeleportSystem.MixedRealityTeleportSystemProfileInspector.html
@@ -175,24 +175,6 @@ public class MixedRealityTeleportSystemProfileInspector : MixedRealityServicePro
   <div><a class="xref" href="XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html#XRTK_Editor_Profiles_MixedRealityServiceProfileInspector_OnInspectorGUI">MixedRealityServiceProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -209,6 +191,24 @@ public class MixedRealityTeleportSystemProfileInspector : MixedRealityServicePro
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Profiles.TeleportSystem.MixedRealityTeleportValidationDataProviderProfileInspector.html
+++ b/docs/api/XRTK.Editor.Profiles.TeleportSystem.MixedRealityTeleportValidationDataProviderProfileInspector.html
@@ -168,24 +168,6 @@ public class MixedRealityTeleportValidationDataProviderProfileInspector : BaseMi
   <div><a class="xref" href="XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html#XRTK_Editor_Profiles_BaseMixedRealityProfileInspector_OnInspectorGUI">BaseMixedRealityProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -202,6 +184,24 @@ public class MixedRealityTeleportValidationDataProviderProfileInspector : BaseMi
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.SystemTypeRepairWindow.html
+++ b/docs/api/XRTK.Editor.SystemTypeRepairWindow.html
@@ -190,6 +190,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -209,24 +227,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.MixedRealityInspectorUtility.html#XRTK_Editor_Utilities_MixedRealityInspectorUtility_CenterOnMainWin_UnityEditor_EditorWindow_">MixedRealityInspectorUtility.CenterOnMainWin(EditorWindow)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.AutoSceneSwitcher.html
+++ b/docs/api/XRTK.Editor.Utilities.AutoSceneSwitcher.html
@@ -124,7 +124,7 @@ public static class AutoSceneSwitcher</code></pre>
                     <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_Editor_Utilities_AutoSceneSwitcher.md&amp;value=---%0Auid%3A%20XRTK.Editor.Utilities.AutoSceneSwitcher%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/AutoSceneSwitcher.cs/#L16" class="contribution-link">View Source</a>
+                    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/AutoSceneSwitcher.cs/#L18" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/XRTK.Editor.Utilities.CanvasEditorExtension.html
+++ b/docs/api/XRTK.Editor.Utilities.CanvasEditorExtension.html
@@ -136,24 +136,6 @@ public class CanvasEditorExtension : Editor, IPreviewable, IToolModeOwner</code>
   <div><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEditor.Editor.html#UnityEditor_Editor_OnInspectorGUI">Editor.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -170,6 +152,24 @@ public class CanvasEditorExtension : Editor, IPreviewable, IToolModeOwner</code>
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html
@@ -406,24 +406,6 @@ public class BaseMixedRealityLineDataProviderInspector : Editor, IPreviewable, I
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -440,6 +422,24 @@ public class BaseMixedRealityLineDataProviderInspector : Editor, IPreviewable, I
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.BezierDataProviderInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.BezierDataProviderInspector.html
@@ -194,24 +194,6 @@ public class BezierDataProviderInspector : BaseMixedRealityLineDataProviderInspe
   <div><a class="xref" href="XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html#XRTK_Editor_Utilities_Lines_DataProviders_BaseMixedRealityLineDataProviderInspector_OnSceneGUI">BaseMixedRealityLineDataProviderInspector.OnSceneGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -228,6 +210,24 @@ public class BezierDataProviderInspector : BaseMixedRealityLineDataProviderInspe
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.EllipseLineDataProviderInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.EllipseLineDataProviderInspector.html
@@ -180,24 +180,6 @@ public class EllipseLineDataProviderInspector : BaseMixedRealityLineDataProvider
   <div><a class="xref" href="XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html#XRTK_Editor_Utilities_Lines_DataProviders_BaseMixedRealityLineDataProviderInspector_OnInspectorGUI">BaseMixedRealityLineDataProviderInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -214,6 +196,24 @@ public class EllipseLineDataProviderInspector : BaseMixedRealityLineDataProvider
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.ParabolaPhysicalLineDataProviderInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.ParabolaPhysicalLineDataProviderInspector.html
@@ -180,24 +180,6 @@ public class ParabolaPhysicalLineDataProviderInspector : BaseMixedRealityLineDat
   <div><a class="xref" href="XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html#XRTK_Editor_Utilities_Lines_DataProviders_BaseMixedRealityLineDataProviderInspector_OnInspectorGUI">BaseMixedRealityLineDataProviderInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -214,6 +196,24 @@ public class ParabolaPhysicalLineDataProviderInspector : BaseMixedRealityLineDat
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.ParabolicConstrainedLineDataProviderInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.ParabolicConstrainedLineDataProviderInspector.html
@@ -194,24 +194,6 @@ public class ParabolicConstrainedLineDataProviderInspector : BaseMixedRealityLin
   <div><a class="xref" href="XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html#XRTK_Editor_Utilities_Lines_DataProviders_BaseMixedRealityLineDataProviderInspector_OnSceneGUI">BaseMixedRealityLineDataProviderInspector.OnSceneGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -228,6 +210,24 @@ public class ParabolicConstrainedLineDataProviderInspector : BaseMixedRealityLin
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.RectangleLineDataProviderInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.RectangleLineDataProviderInspector.html
@@ -194,24 +194,6 @@ public class RectangleLineDataProviderInspector : BaseMixedRealityLineDataProvid
   <div><a class="xref" href="XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html#XRTK_Editor_Utilities_Lines_DataProviders_BaseMixedRealityLineDataProviderInspector_OnSceneGUI">BaseMixedRealityLineDataProviderInspector.OnSceneGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -228,6 +210,24 @@ public class RectangleLineDataProviderInspector : BaseMixedRealityLineDataProvid
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.SimpleLineDataProviderInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.SimpleLineDataProviderInspector.html
@@ -194,24 +194,6 @@ public class SimpleLineDataProviderInspector : BaseMixedRealityLineDataProviderI
   <div><a class="xref" href="XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html#XRTK_Editor_Utilities_Lines_DataProviders_BaseMixedRealityLineDataProviderInspector_OnSceneGUI">BaseMixedRealityLineDataProviderInspector.OnSceneGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -228,6 +210,24 @@ public class SimpleLineDataProviderInspector : BaseMixedRealityLineDataProviderI
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.SplineDataProviderInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.Lines.DataProviders.SplineDataProviderInspector.html
@@ -194,24 +194,6 @@ public class SplineDataProviderInspector : BaseMixedRealityLineDataProviderInspe
   <div><a class="xref" href="XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html#XRTK_Editor_Utilities_Lines_DataProviders_BaseMixedRealityLineDataProviderInspector_OnSceneGUI">BaseMixedRealityLineDataProviderInspector.OnSceneGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -228,6 +210,24 @@ public class SplineDataProviderInspector : BaseMixedRealityLineDataProviderInspe
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.MixedRealityServiceWizard.html
+++ b/docs/api/XRTK.Editor.Utilities.MixedRealityServiceWizard.html
@@ -149,6 +149,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -168,24 +186,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.MixedRealityInspectorUtility.html#XRTK_Editor_Utilities_MixedRealityInspectorUtility_CenterOnMainWin_UnityEditor_EditorWindow_">MixedRealityInspectorUtility.CenterOnMainWin(EditorWindow)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkSettings.html
+++ b/docs/api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkSettings.html
@@ -148,24 +148,6 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -182,6 +164,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkSettingsInspector.html
+++ b/docs/api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkSettingsInspector.html
@@ -135,24 +135,6 @@ public class SymbolicLinkSettingsInspector : Editor, IPreviewable, IToolModeOwne
   <div><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEditor.Editor.html#UnityEditor_Editor_OnInspectorGUI">Editor.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -169,6 +151,24 @@ public class SymbolicLinkSettingsInspector : Editor, IPreviewable, IToolModeOwne
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkerWindow.html
+++ b/docs/api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkerWindow.html
@@ -116,6 +116,24 @@ public class SymbolicLinkerWindow : EditorWindow</code></pre>
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -135,24 +153,6 @@ public class SymbolicLinkerWindow : EditorWindow</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.MixedRealityInspectorUtility.html#XRTK_Editor_Utilities_MixedRealityInspectorUtility_CenterOnMainWin_UnityEditor_EditorWindow_">MixedRealityInspectorUtility.CenterOnMainWin(EditorWindow)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Etee.Editor.EteePathFinder.html
+++ b/docs/api/XRTK.Etee.Editor.EteePathFinder.html
@@ -155,24 +155,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -189,6 +171,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Etee.Profiles.EteeControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Etee.Profiles.EteeControllerDataProviderProfile.html
@@ -159,6 +159,24 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,24 +199,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Examples.Demos.CustomExtensionServices.DemoCustomExtensionServiceProfile.html
+++ b/docs/api/XRTK.Examples.Demos.CustomExtensionServices.DemoCustomExtensionServiceProfile.html
@@ -167,6 +167,24 @@ public class DemoCustomExtensionServiceProfile : BaseMixedRealityExtensionServic
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -189,24 +207,6 @@ public class DemoCustomExtensionServiceProfile : BaseMixedRealityExtensionServic
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Lenovo.A6.Profiles.A6ControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Lenovo.A6.Profiles.A6ControllerDataProviderProfile.html
@@ -159,6 +159,24 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,24 +199,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Lenovo.Editor.LenovoPathFinder.html
+++ b/docs/api/XRTK.Lenovo.Editor.LenovoPathFinder.html
@@ -155,24 +155,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -189,6 +171,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Lumin.Editor.LuminHandControllerDataProviderProfileInspector.html
+++ b/docs/api/XRTK.Lumin.Editor.LuminHandControllerDataProviderProfileInspector.html
@@ -170,6 +170,15 @@ public class LuminHandControllerDataProviderProfileInspector : BaseMixedRealityH
   <div><a class="xref" href="XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityHandControllerDataProviderProfileInspector.html#XRTK_Editor_Profiles_InputSystem_Controllers_BaseMixedRealityHandControllerDataProviderProfileInspector_OnInspectorGUI">BaseMixedRealityHandControllerDataProviderProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -186,15 +195,6 @@ public class LuminHandControllerDataProviderProfileInspector : BaseMixedRealityH
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Lumin.Editor.LuminPathFinder.html
+++ b/docs/api/XRTK.Lumin.Editor.LuminPathFinder.html
@@ -159,24 +159,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -193,6 +175,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Lumin.Profiles.LuminControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Lumin.Profiles.LuminControllerDataProviderProfile.html
@@ -159,6 +159,24 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,24 +199,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Lumin.Profiles.LuminHandControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Lumin.Profiles.LuminHandControllerDataProviderProfile.html
@@ -208,6 +208,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -230,24 +248,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Lumin.Profiles.LuminSpatialMeshObserverProfile.html
+++ b/docs/api/XRTK.Lumin.Profiles.LuminSpatialMeshObserverProfile.html
@@ -154,6 +154,24 @@ public class LuminSpatialMeshObserverProfile : BaseMixedRealitySpatialMeshObserv
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -176,24 +194,6 @@ public class LuminSpatialMeshObserverProfile : BaseMixedRealitySpatialMeshObserv
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Nreal.Editor.NrealPathFinder.html
+++ b/docs/api/XRTK.Nreal.Editor.NrealPathFinder.html
@@ -155,24 +155,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -189,6 +171,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Nreal.Profiles.NrealControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Nreal.Profiles.NrealControllerDataProviderProfile.html
@@ -159,6 +159,24 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,24 +199,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Oculus.Editor.OculusHandControllerDataProviderProfileInspector.html
+++ b/docs/api/XRTK.Oculus.Editor.OculusHandControllerDataProviderProfileInspector.html
@@ -171,6 +171,15 @@ public class OculusHandControllerDataProviderProfileInspector : BaseMixedReality
   <div><a class="xref" href="XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityHandControllerDataProviderProfileInspector.html#XRTK_Editor_Profiles_InputSystem_Controllers_BaseMixedRealityHandControllerDataProviderProfileInspector_OnInspectorGUI">BaseMixedRealityHandControllerDataProviderProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -187,15 +196,6 @@ public class OculusHandControllerDataProviderProfileInspector : BaseMixedReality
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Oculus.Editor.OculusPathFinder.html
+++ b/docs/api/XRTK.Oculus.Editor.OculusPathFinder.html
@@ -159,24 +159,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -193,6 +175,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Oculus.Plugins.OculusApi.Controller.html
+++ b/docs/api/XRTK.Oculus.Plugins.OculusApi.Controller.html
@@ -144,6 +144,9 @@ public enum Controller</code></pre>
   </thead></thead></table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.ControllerExtensions.html#XRTK_Oculus_Extensions_ControllerExtensions_ToHandedness_XRTK_Oculus_Plugins_OculusApi_Controller_">ControllerExtensions.ToHandedness()</a>
+  </div>
+  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(String)</a>
   </div>
   <div>
@@ -166,9 +169,6 @@ public enum Controller</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;OculusApi.Controller&gt;(Func&lt;OculusApi.Controller, Boolean&gt;, Int32)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.ControllerExtensions.html#XRTK_Oculus_Extensions_ControllerExtensions_ToHandedness_XRTK_Oculus_Plugins_OculusApi_Controller_">ControllerExtensions.ToHandedness()</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Oculus.Plugins.OculusApi.Posef.html
+++ b/docs/api/XRTK.Oculus.Plugins.OculusApi.Posef.html
@@ -225,6 +225,12 @@
   <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.MixedRealityPoseExtensions.html#XRTK_Oculus_Extensions_MixedRealityPoseExtensions_ToMixedRealityPose_XRTK_Oculus_Plugins_OculusApi_Posef_System_Boolean_">MixedRealityPoseExtensions.ToMixedRealityPose(OculusApi.Posef, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.Vector3Extensions.html#XRTK_Oculus_Extensions_Vector3Extensions_GetPosePosition_XRTK_Oculus_Plugins_OculusApi_Posef_">Vector3Extensions.GetPosePosition(OculusApi.Posef)</a>
+  </div>
+  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -232,12 +238,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.MixedRealityPoseExtensions.html#XRTK_Oculus_Extensions_MixedRealityPoseExtensions_ToMixedRealityPose_XRTK_Oculus_Plugins_OculusApi_Posef_System_Boolean_">MixedRealityPoseExtensions.ToMixedRealityPose(OculusApi.Posef, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.Vector3Extensions.html#XRTK_Oculus_Extensions_Vector3Extensions_GetPosePosition_XRTK_Oculus_Plugins_OculusApi_Posef_">Vector3Extensions.GetPosePosition(OculusApi.Posef)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Oculus.Plugins.OculusApi.Quatf.html
+++ b/docs/api/XRTK.Oculus.Plugins.OculusApi.Quatf.html
@@ -283,6 +283,9 @@
   <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.QuaternionExtensions.html#XRTK_Oculus_Extensions_QuaternionExtensions_FromFlippedZQuatf_XRTK_Oculus_Plugins_OculusApi_Quatf_">QuaternionExtensions.FromFlippedZQuatf(OculusApi.Quatf)</a>
+  </div>
+  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -290,9 +293,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.QuaternionExtensions.html#XRTK_Oculus_Extensions_QuaternionExtensions_FromFlippedZQuatf_XRTK_Oculus_Plugins_OculusApi_Quatf_">QuaternionExtensions.FromFlippedZQuatf(OculusApi.Quatf)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Oculus.Plugins.OculusApi.Vector3f.html
+++ b/docs/api/XRTK.Oculus.Plugins.OculusApi.Vector3f.html
@@ -254,6 +254,12 @@
   <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.Vector3Extensions.html#XRTK_Oculus_Extensions_Vector3Extensions_FromFlippedZVector3f_XRTK_Oculus_Plugins_OculusApi_Vector3f_">Vector3Extensions.FromFlippedZVector3f(OculusApi.Vector3f)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Oculus.Extensions.Vector3Extensions.html#XRTK_Oculus_Extensions_Vector3Extensions_ToVector3_XRTK_Oculus_Plugins_OculusApi_Vector3f_">Vector3Extensions.ToVector3(OculusApi.Vector3f)</a>
+  </div>
+  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -261,12 +267,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.Vector3Extensions.html#XRTK_Oculus_Extensions_Vector3Extensions_FromFlippedZVector3f_XRTK_Oculus_Plugins_OculusApi_Vector3f_">Vector3Extensions.FromFlippedZVector3f(OculusApi.Vector3f)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Oculus.Extensions.Vector3Extensions.html#XRTK_Oculus_Extensions_Vector3Extensions_ToVector3_XRTK_Oculus_Plugins_OculusApi_Vector3f_">Vector3Extensions.ToVector3(OculusApi.Vector3f)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Oculus.Profiles.OculusControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Oculus.Profiles.OculusControllerDataProviderProfile.html
@@ -159,6 +159,24 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,24 +199,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Oculus.Profiles.OculusHandControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Oculus.Profiles.OculusHandControllerDataProviderProfile.html
@@ -178,6 +178,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -200,24 +218,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Providers.CameraSystem.BaseCameraDataProvider.html
+++ b/docs/api/XRTK.Providers.CameraSystem.BaseCameraDataProvider.html
@@ -90,6 +90,7 @@
       <div class="level5"><a class="xref" href="XRTK.Oculus.Providers.CameraSystem.OculusCameraDataProvider.html">OculusCameraDataProvider</a></div>
       <div class="level5"><a class="xref" href="XRTK.SteamVR.Providers.CameraSystem.SteamVRCameraDataProvider.html">SteamVRCameraDataProvider</a></div>
       <div class="level5"><a class="xref" href="XRTK.Ultraleap.Providers.CameraSystem.UltraleapCameraDataProvider.html">UltraleapCameraDataProvider</a></div>
+      <div class="level5"><a class="xref" href="XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.html">WebXRCameraDataProvider</a></div>
       <div class="level5"><a class="xref" href="XRTK.WindowsMixedReality.Providers.CameraSystem.WindowsMixedRealityCameraDataProvider.html">WindowsMixedRealityCameraDataProvider</a></div>
   </div>
   <div classs="implements">

--- a/docs/api/XRTK.Providers.Controllers.BaseController.html
+++ b/docs/api/XRTK.Providers.Controllers.BaseController.html
@@ -92,6 +92,7 @@
       <div class="level2"><a class="xref" href="XRTK.Providers.Controllers.UnityInput.UnityTouchController.html">UnityTouchController</a></div>
       <div class="level2"><a class="xref" href="XRTK.SteamVR.Providers.Controllers.SteamVRController.html">SteamVRController</a></div>
       <div class="level2"><a class="xref" href="XRTK.Ultraleap.Providers.Controllers.UltraleapController.html">UltraleapController</a></div>
+      <div class="level2"><a class="xref" href="XRTK.WebXR.Providers.Controllers.WebXRController.html">WebXRController</a></div>
       <div class="level2"><a class="xref" href="XRTK.WindowsMixedReality.Providers.Controllers.WindowsMixedRealityMotionController.html">WindowsMixedRealityMotionController</a></div>
   </div>
   <div classs="implements">

--- a/docs/api/XRTK.Providers.Controllers.BaseControllerDataProvider.html
+++ b/docs/api/XRTK.Providers.Controllers.BaseControllerDataProvider.html
@@ -96,6 +96,7 @@
       <div class="level5"><a class="xref" href="XRTK.Providers.Controllers.UnityInput.UnityTouchDataProvider.html">UnityTouchDataProvider</a></div>
       <div class="level5"><a class="xref" href="XRTK.SteamVR.Providers.Controllers.SteamVRControllerDataProvider.html">SteamVRControllerDataProvider</a></div>
       <div class="level5"><a class="xref" href="XRTK.Ultraleap.Providers.Controllers.UltraleapControllerDataProvider.html">UltraleapControllerDataProvider</a></div>
+      <div class="level5"><a class="xref" href="XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.html">WebXRControllerDataProvider</a></div>
       <div class="level5"><a class="xref" href="XRTK.WindowsMixedReality.Providers.Controllers.WindowsMixedRealityControllerDataProvider.html">WindowsMixedRealityControllerDataProvider</a></div>
   </div>
   <div classs="implements">

--- a/docs/api/XRTK.Providers.Networking.Profiles.BaseMixedRealityNetworkProviderProfile.html
+++ b/docs/api/XRTK.Providers.Networking.Profiles.BaseMixedRealityNetworkProviderProfile.html
@@ -120,6 +120,24 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -142,24 +160,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Providers.Networking.WebRTC.MixedRealityWebRtcNetworkProviderProfile.html
+++ b/docs/api/XRTK.Providers.Networking.WebRTC.MixedRealityWebRtcNetworkProviderProfile.html
@@ -121,6 +121,24 @@ public class MixedRealityWebRtcNetworkProviderProfile : BaseMixedRealityNetworkP
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -143,24 +161,6 @@ public class MixedRealityWebRtcNetworkProviderProfile : BaseMixedRealityNetworkP
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Providers.SpatialObservers.BaseMixedRealitySpatialMeshObserverProfile.html
+++ b/docs/api/XRTK.Providers.SpatialObservers.BaseMixedRealitySpatialMeshObserverProfile.html
@@ -325,6 +325,24 @@ as some platforms may not support returning normal along with the spatial mesh.<
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -347,24 +365,6 @@ as some platforms may not support returning normal along with the spatial mesh.<
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Providers.SpatialObservers.BaseMixedRealitySpatialObserverProfile.html
+++ b/docs/api/XRTK.Providers.SpatialObservers.BaseMixedRealitySpatialObserverProfile.html
@@ -278,6 +278,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -300,24 +318,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Providers.SpatialObservers.BaseMixedRealitySurfaceObserverProfile.html
+++ b/docs/api/XRTK.Providers.SpatialObservers.BaseMixedRealitySurfaceObserverProfile.html
@@ -416,6 +416,24 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -438,24 +456,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Input.Handlers.BaseInputHandlerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.Input.Handlers.BaseInputHandlerInspector.html
@@ -151,24 +151,6 @@
   <div><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEditor.Editor.html#UnityEditor_Editor_OnInspectorGUI">Editor.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -185,6 +167,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Input.Handlers.ControllerPoseSynchronizerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.Input.Handlers.ControllerPoseSynchronizerInspector.html
@@ -183,24 +183,6 @@ public class ControllerPoseSynchronizerInspector : Editor, IPreviewable, IToolMo
   <div><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEditor.Editor.html#UnityEditor_Editor_OnInspectorGUI">Editor.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -217,6 +199,24 @@ public class ControllerPoseSynchronizerInspector : Editor, IPreviewable, IToolMo
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Input.Handlers.DefaultMixedRealityControllerVisualizerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.Input.Handlers.DefaultMixedRealityControllerVisualizerInspector.html
@@ -127,24 +127,6 @@ public class DefaultMixedRealityControllerVisualizerInspector : ControllerPoseSy
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -161,6 +143,24 @@ public class DefaultMixedRealityControllerVisualizerInspector : ControllerPoseSy
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Input.Handlers.PointerClickHandlerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.Input.Handlers.PointerClickHandlerInspector.html
@@ -153,24 +153,6 @@ public class PointerClickHandlerInspector : BaseInputHandlerInspector, IPreviewa
   <div><a class="xref" href="XRTK.SDK.Editor.Input.Handlers.BaseInputHandlerInspector.html#XRTK_SDK_Editor_Input_Handlers_BaseInputHandlerInspector_OnInspectorGUI">BaseInputHandlerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -187,6 +169,24 @@ public class PointerClickHandlerInspector : BaseInputHandlerInspector, IPreviewa
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Input.Handlers.SpeechInputHandlerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.Input.Handlers.SpeechInputHandlerInspector.html
@@ -153,24 +153,6 @@ public class SpeechInputHandlerInspector : BaseInputHandlerInspector, IPreviewab
   <div><a class="xref" href="XRTK.SDK.Editor.Input.Handlers.BaseInputHandlerInspector.html#XRTK_SDK_Editor_Input_Handlers_BaseInputHandlerInspector_OnInspectorGUI">BaseInputHandlerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -187,6 +169,24 @@ public class SpeechInputHandlerInspector : BaseInputHandlerInspector, IPreviewab
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Input.Handlers.WindowsMixedRealityControllerVisualizerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.Input.Handlers.WindowsMixedRealityControllerVisualizerInspector.html
@@ -157,24 +157,6 @@ public class WindowsMixedRealityControllerVisualizerInspector : DefaultMixedReal
   <div><a class="xref" href="XRTK.SDK.Editor.Input.Handlers.ControllerPoseSynchronizerInspector.html#XRTK_SDK_Editor_Input_Handlers_ControllerPoseSynchronizerInspector_OnInspectorGUI">ControllerPoseSynchronizerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -191,6 +173,24 @@ public class WindowsMixedRealityControllerVisualizerInspector : DefaultMixedReal
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.SdkPathFinder.html
+++ b/docs/api/XRTK.SDK.Editor.SdkPathFinder.html
@@ -159,24 +159,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -193,6 +175,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.UX.Collections.BaseCollectionInspector.html
+++ b/docs/api/XRTK.SDK.Editor.UX.Collections.BaseCollectionInspector.html
@@ -116,24 +116,6 @@ public class BaseCollectionInspector : Editor, IPreviewable, IToolModeOwner</cod
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -150,6 +132,24 @@ public class BaseCollectionInspector : Editor, IPreviewable, IToolModeOwner</cod
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.UX.Pointers.BaseControllerPointerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.UX.Pointers.BaseControllerPointerInspector.html
@@ -189,24 +189,6 @@ public class BaseControllerPointerInspector : ControllerPoseSynchronizerInspecto
   <div><a class="xref" href="XRTK.SDK.Editor.Input.Handlers.ControllerPoseSynchronizerInspector.html#XRTK_SDK_Editor_Input_Handlers_ControllerPoseSynchronizerInspector_OnInspectorGUI">ControllerPoseSynchronizerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -223,6 +205,24 @@ public class BaseControllerPointerInspector : ControllerPoseSynchronizerInspecto
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.UX.Pointers.HandSpatialPointerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.UX.Pointers.HandSpatialPointerInspector.html
@@ -161,24 +161,6 @@ public class HandSpatialPointerInspector : LinePointerInspector, IPreviewable, I
   <div><a class="xref" href="XRTK.SDK.Editor.UX.Pointers.LinePointerInspector.html#XRTK_SDK_Editor_UX_Pointers_LinePointerInspector_OnInspectorGUI">LinePointerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -195,6 +177,24 @@ public class HandSpatialPointerInspector : LinePointerInspector, IPreviewable, I
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.UX.Pointers.LinePointerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.UX.Pointers.LinePointerInspector.html
@@ -162,24 +162,6 @@ public class LinePointerInspector : BaseControllerPointerInspector, IPreviewable
   <div><a class="xref" href="XRTK.SDK.Editor.UX.Pointers.BaseControllerPointerInspector.html#XRTK_SDK_Editor_UX_Pointers_BaseControllerPointerInspector_OnInspectorGUI">BaseControllerPointerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -196,6 +178,24 @@ public class LinePointerInspector : BaseControllerPointerInspector, IPreviewable
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.UX.Pointers.MousePointerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.UX.Pointers.MousePointerInspector.html
@@ -160,24 +160,6 @@ public class MousePointerInspector : BaseControllerPointerInspector, IPreviewabl
   <div><a class="xref" href="XRTK.SDK.Editor.UX.Pointers.BaseControllerPointerInspector.html#XRTK_SDK_Editor_UX_Pointers_BaseControllerPointerInspector_OnInspectorGUI">BaseControllerPointerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -194,6 +176,24 @@ public class MousePointerInspector : BaseControllerPointerInspector, IPreviewabl
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.UX.Pointers.ParabolicTeleportPointerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.UX.Pointers.ParabolicTeleportPointerInspector.html
@@ -162,24 +162,6 @@ public class ParabolicTeleportPointerInspector : TeleportPointerInspector, IPrev
   <div><a class="xref" href="XRTK.SDK.Editor.UX.Pointers.TeleportPointerInspector.html#XRTK_SDK_Editor_UX_Pointers_TeleportPointerInspector_OnInspectorGUI">TeleportPointerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -196,6 +178,24 @@ public class ParabolicTeleportPointerInspector : TeleportPointerInspector, IPrev
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.UX.Pointers.TeleportPointerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.UX.Pointers.TeleportPointerInspector.html
@@ -162,24 +162,6 @@ public class TeleportPointerInspector : LinePointerInspector, IPreviewable, IToo
   <div><a class="xref" href="XRTK.SDK.Editor.UX.Pointers.LinePointerInspector.html#XRTK_SDK_Editor_UX_Pointers_LinePointerInspector_OnInspectorGUI">LinePointerInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -196,6 +178,24 @@ public class TeleportPointerInspector : LinePointerInspector, IPreviewable, IToo
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Utilities.Solvers.ControllerFinderInspector.html
+++ b/docs/api/XRTK.SDK.Editor.Utilities.Solvers.ControllerFinderInspector.html
@@ -151,24 +151,6 @@ public abstract class ControllerFinderInspector : Editor, IPreviewable, IToolMod
   <div><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEditor.Editor.html#UnityEditor_Editor_OnInspectorGUI">Editor.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -185,6 +167,24 @@ public abstract class ControllerFinderInspector : Editor, IPreviewable, IToolMod
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Utilities.Solvers.InBetweenEditor.html
+++ b/docs/api/XRTK.SDK.Editor.Utilities.Solvers.InBetweenEditor.html
@@ -135,24 +135,6 @@ public class InBetweenEditor : Editor, IPreviewable, IToolModeOwner</code></pre>
   <div><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEditor.Editor.html#UnityEditor_Editor_OnInspectorGUI">Editor.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -169,6 +151,24 @@ public class InBetweenEditor : Editor, IPreviewable, IToolModeOwner</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SDK.Editor.Utilities.Solvers.SolverHandlerInspector.html
+++ b/docs/api/XRTK.SDK.Editor.Utilities.Solvers.SolverHandlerInspector.html
@@ -154,24 +154,6 @@ public class SolverHandlerInspector : ControllerFinderInspector, IPreviewable, I
   <div><a class="xref" href="XRTK.SDK.Editor.Utilities.Solvers.ControllerFinderInspector.html#XRTK_SDK_Editor_Utilities_Solvers_ControllerFinderInspector_OnInspectorGUI">ControllerFinderInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -188,6 +170,24 @@ public class SolverHandlerInspector : ControllerFinderInspector, IPreviewable, I
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Seed.PackagePickerWindow.html
+++ b/docs/api/XRTK.Seed.PackagePickerWindow.html
@@ -115,6 +115,24 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -134,24 +152,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.MixedRealityInspectorUtility.html#XRTK_Editor_Utilities_MixedRealityInspectorUtility_CenterOnMainWin_UnityEditor_EditorWindow_">MixedRealityInspectorUtility.CenterOnMainWin(EditorWindow)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SteamVR.Editor.SteamVRPathFinder.html
+++ b/docs/api/XRTK.SteamVR.Editor.SteamVRPathFinder.html
@@ -158,24 +158,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -192,6 +174,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.SteamVR.Profiles.SteamVRControllerDataProviderProfile.html
+++ b/docs/api/XRTK.SteamVR.Profiles.SteamVRControllerDataProviderProfile.html
@@ -159,6 +159,24 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,24 +199,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Ultraleap.Editor.UltraleapPathFinder.html
+++ b/docs/api/XRTK.Ultraleap.Editor.UltraleapPathFinder.html
@@ -159,24 +159,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -193,6 +175,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Ultraleap.Profiles.UltraleapControllerDataProviderProfile.html
+++ b/docs/api/XRTK.Ultraleap.Profiles.UltraleapControllerDataProviderProfile.html
@@ -159,6 +159,24 @@
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -181,24 +199,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Utilities.Build.BuildDeployWindow.html
+++ b/docs/api/XRTK.Utilities.Build.BuildDeployWindow.html
@@ -201,6 +201,24 @@ public static void OpenWindow()</code></pre>
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -220,24 +238,6 @@ public static void OpenWindow()</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.MixedRealityInspectorUtility.html#XRTK_Editor_Utilities_MixedRealityInspectorUtility_CenterOnMainWin_UnityEditor_EditorWindow_">MixedRealityInspectorUtility.CenterOnMainWin(EditorWindow)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Utilities.Build.BuildInfo.html
+++ b/docs/api/XRTK.Utilities.Build.BuildInfo.html
@@ -532,15 +532,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
-  </div>
-  <div>
       <a class="xref" href="XRTK.Utilities.Build.BuildInfoExtensions.html#XRTK_Utilities_Build_BuildInfoExtensions_AppendSymbols_XRTK_Utilities_Build_IBuildInfo_System_String___">BuildInfoExtensions.AppendSymbols(IBuildInfo, String[])</a>
   </div>
   <div>
@@ -560,6 +551,15 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Build.BuildInfoExtensions.html#XRTK_Utilities_Build_BuildInfoExtensions_AppendWithoutConfigurationSymbols_XRTK_Utilities_Build_IBuildInfo_System_String_">BuildInfoExtensions.AppendWithoutConfigurationSymbols(IBuildInfo, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Utilities.Build.IBuildInfo.html
+++ b/docs/api/XRTK.Utilities.Build.IBuildInfo.html
@@ -461,15 +461,6 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
-  </div>
-  <div>
       <a class="xref" href="XRTK.Utilities.Build.BuildInfoExtensions.html#XRTK_Utilities_Build_BuildInfoExtensions_AppendSymbols_XRTK_Utilities_Build_IBuildInfo_System_String___">BuildInfoExtensions.AppendSymbols(IBuildInfo, String[])</a>
   </div>
   <div>
@@ -489,6 +480,15 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Build.BuildInfoExtensions.html#XRTK_Utilities_Build_BuildInfoExtensions_AppendWithoutConfigurationSymbols_XRTK_Utilities_Build_IBuildInfo_System_String_">BuildInfoExtensions.AppendWithoutConfigurationSymbols(IBuildInfo, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Utilities.Build.UwpBuildInfo.html
+++ b/docs/api/XRTK.Utilities.Build.UwpBuildInfo.html
@@ -285,15 +285,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
-  </div>
-  <div>
       <a class="xref" href="XRTK.Utilities.Build.BuildInfoExtensions.html#XRTK_Utilities_Build_BuildInfoExtensions_AppendSymbols_XRTK_Utilities_Build_IBuildInfo_System_String___">BuildInfoExtensions.AppendSymbols(IBuildInfo, String[])</a>
   </div>
   <div>
@@ -313,6 +304,15 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Build.BuildInfoExtensions.html#XRTK_Utilities_Build_BuildInfoExtensions_AppendWithoutConfigurationSymbols_XRTK_Utilities_Build_IBuildInfo_System_String_">BuildInfoExtensions.AppendWithoutConfigurationSymbols(IBuildInfo, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Utilities.Editor.CorePathFinder.html
+++ b/docs/api/XRTK.Utilities.Editor.CorePathFinder.html
@@ -159,24 +159,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -193,6 +175,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Utilities.Editor.IconEditor.html
+++ b/docs/api/XRTK.Utilities.Editor.IconEditor.html
@@ -136,24 +136,6 @@ public class IconEditor : Editor, IPreviewable, IToolModeOwner</code></pre>
   <div><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEditor.Editor.html#UnityEditor_Editor_OnInspectorGUI">Editor.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -170,6 +152,24 @@ public class IconEditor : Editor, IPreviewable, IToolModeOwner</code></pre>
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.Utilities.Gltf.GltfAsset.html
+++ b/docs/api/XRTK.Utilities.Gltf.GltfAsset.html
@@ -176,24 +176,6 @@
   </table>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -210,6 +192,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.WebXR.Editor.WebXRPathFinder.html
+++ b/docs/api/XRTK.WebXR.Editor.WebXRPathFinder.html
@@ -1,0 +1,235 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class WebXRPathFinder
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class WebXRPathFinder
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Editor.WebXRPathFinder">
+  
+  
+  <h1 id="XRTK_WebXR_Editor_WebXRPathFinder" data-uid="XRTK.WebXR.Editor.WebXRPathFinder" class="text-break">Class WebXRPathFinder
+  </h1>
+  <div class="markdown level0 summary"><p>Dummy scriptable object used to find the relative path of the com.xrtk.webxr.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEngine.Object.html">Object</a></div>
+    <div class="level2"><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEngine.ScriptableObject.html">ScriptableObject</a></div>
+    <div class="level3"><span class="xref">WebXRPathFinder</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="XRTK.Utilities.Editor.IPathFinder.html">IPathFinder</a></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="XRTK.WebXR.Editor.html">XRTK.WebXR.Editor</a></h6>
+  <h6><strong>Assembly</strong>: XRTK.WebXR.Editor.dll</h6>
+  <h5 id="XRTK_WebXR_Editor_WebXRPathFinder_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class WebXRPathFinder : ScriptableObject, IPathFinder</code></pre>
+  </div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Editor_WebXRPathFinder_Location.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Editor.WebXRPathFinder.Location%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Editor/WebXRPathFinder.cs/#L16">View Source</a>
+  </span>
+  <a id="XRTK_WebXR_Editor_WebXRPathFinder_Location_" data-uid="XRTK.WebXR.Editor.WebXRPathFinder.Location*"></a>
+  <h4 id="XRTK_WebXR_Editor_WebXRPathFinder_Location" data-uid="XRTK.WebXR.Editor.WebXRPathFinder.Location">Location</h4>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string Location { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Editor.IPathFinder.html">IPathFinder</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Editor_WebXRPathFinder.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Editor.WebXRPathFinder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Editor/WebXRPathFinder.cs/#L13" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WebXR.Editor.html
+++ b/docs/api/XRTK.WebXR.Editor.html
@@ -1,0 +1,119 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Namespace XRTK.WebXR.Editor
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Namespace XRTK.WebXR.Editor
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Editor">
+  
+  <h1 id="XRTK_WebXR_Editor" data-uid="XRTK.WebXR.Editor" class="text-break">Namespace XRTK.WebXR.Editor
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="markdown level0 remarks"></div>
+    <h3 id="classes">Classes
+  </h3>
+      <h4><a class="xref" href="XRTK.WebXR.Editor.WebXRPathFinder.html">WebXRPathFinder</a></h4>
+      <section><p>Dummy scriptable object used to find the relative path of the com.xrtk.webxr.</p>
+</section>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.html
+++ b/docs/api/XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.html
@@ -1,0 +1,245 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class WebXRControllerDataProviderProfile
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class WebXRControllerDataProviderProfile
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile">
+  
+  
+  <h1 id="XRTK_WebXR_Profiles_WebXRControllerDataProviderProfile" data-uid="XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile" class="text-break">Class WebXRControllerDataProviderProfile
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEngine.Object.html">Object</a></div>
+    <div class="level2"><a class="xref" href="https://stephenhodgson.github.io/UnityCsReference/api/UnityEngine.ScriptableObject.html">ScriptableObject</a></div>
+    <div class="level3"><a class="xref" href="XRTK.Definitions.BaseMixedRealityProfile.html">BaseMixedRealityProfile</a></div>
+    <div class="level4"><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html">BaseMixedRealityControllerDataProviderProfile</a></div>
+    <div class="level5"><span class="xref">WebXRControllerDataProviderProfile</span></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_HasSetupDefaults">BaseMixedRealityControllerDataProviderProfile.HasSetupDefaults</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_ControllerMappingProfiles">BaseMixedRealityControllerDataProviderProfile.ControllerMappingProfiles</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Definitions.BaseMixedRealityProfile.html#XRTK_Definitions_BaseMixedRealityProfile_ParentProfile">BaseMixedRealityProfile.ParentProfile</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="XRTK.WebXR.Profiles.html">XRTK.WebXR.Profiles</a></h6>
+  <h6><strong>Assembly</strong>: XRTK.WebXR.dll</h6>
+  <h5 id="XRTK_WebXR_Profiles_WebXRControllerDataProviderProfile_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class WebXRControllerDataProviderProfile : BaseMixedRealityControllerDataProviderProfile</code></pre>
+  </div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Profiles_WebXRControllerDataProviderProfile_GetDefaultControllerOptions.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.GetDefaultControllerOptions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/Profiles/WebXRControllerDataProviderProfile.cs/#L12">View Source</a>
+  </span>
+  <a id="XRTK_WebXR_Profiles_WebXRControllerDataProviderProfile_GetDefaultControllerOptions_" data-uid="XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.GetDefaultControllerOptions*"></a>
+  <h4 id="XRTK_WebXR_Profiles_WebXRControllerDataProviderProfile_GetDefaultControllerOptions" data-uid="XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.GetDefaultControllerOptions">GetDefaultControllerOptions()</h4>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override ControllerDefinition[] GetDefaultControllerOptions()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="XRTK.Definitions.Controllers.ControllerDefinition.html">ControllerDefinition</a>[]</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CreateNewProfileInstance_XRTK_Definitions_BaseMixedRealityProfile_UnityEditor_SerializedProperty_System_Type_System_Boolean_">BaseMixedRealityProfileInspectorExtensions.CreateNewProfileInstance(BaseMixedRealityProfile, SerializedProperty, Type, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Profiles_WebXRControllerDataProviderProfile.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/Profiles/WebXRControllerDataProviderProfile.cs/#L10" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WebXR.Profiles.html
+++ b/docs/api/XRTK.WebXR.Profiles.html
@@ -1,0 +1,118 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Namespace XRTK.WebXR.Profiles
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Namespace XRTK.WebXR.Profiles
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Profiles">
+  
+  <h1 id="XRTK_WebXR_Profiles" data-uid="XRTK.WebXR.Profiles" class="text-break">Namespace XRTK.WebXR.Profiles
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="markdown level0 remarks"></div>
+    <h3 id="classes">Classes
+  </h3>
+      <h4><a class="xref" href="XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.html">WebXRControllerDataProviderProfile</a></h4>
+      <section></section>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.html
+++ b/docs/api/XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.html
@@ -1,0 +1,318 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class WebXRCameraDataProvider
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class WebXRCameraDataProvider
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider">
+  
+  
+  <h1 id="XRTK_WebXR_Providers_CameraSystem_WebXRCameraDataProvider" data-uid="XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider" class="text-break">Class WebXRCameraDataProvider
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="XRTK.Services.BaseService.html">BaseService</a></div>
+    <div class="level2"><a class="xref" href="XRTK.Services.BaseServiceWithConstructor.html">BaseServiceWithConstructor</a></div>
+    <div class="level3"><a class="xref" href="XRTK.Services.BaseDataProvider.html">BaseDataProvider</a></div>
+    <div class="level4"><a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html">BaseCameraDataProvider</a></div>
+    <div class="level5"><span class="xref">WebXRCameraDataProvider</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="XRTK.Interfaces.CameraSystem.IMixedRealityCameraDataProvider.html">IMixedRealityCameraDataProvider</a></div>
+    <div><a class="xref" href="XRTK.Interfaces.IMixedRealityDataProvider.html">IMixedRealityDataProvider</a></div>
+    <div><a class="xref" href="XRTK.Interfaces.IMixedRealityService.html">IMixedRealityService</a></div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.idisposable">IDisposable</a></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_IsOpaque">BaseCameraDataProvider.IsOpaque</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_IsStereoscopic">BaseCameraDataProvider.IsStereoscopic</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_HeadHeightIsManagedByDevice">BaseCameraDataProvider.HeadHeightIsManagedByDevice</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_CameraRig">BaseCameraDataProvider.CameraRig</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_DefaultHeadHeight">BaseCameraDataProvider.DefaultHeadHeight</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_HeadHeight">BaseCameraDataProvider.HeadHeight</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_Priority">BaseCameraDataProvider.Priority</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_Initialize">BaseCameraDataProvider.Initialize()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_Enable">BaseCameraDataProvider.Enable()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_Update">BaseCameraDataProvider.Update()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_LateUpdate">BaseCameraDataProvider.LateUpdate()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_Disable">BaseCameraDataProvider.Disable()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_Destroy">BaseCameraDataProvider.Destroy()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_ApplySettingsForDefaultHeadHeight">BaseCameraDataProvider.ApplySettingsForDefaultHeadHeight()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_ApplySettingsForOpaqueDisplay">BaseCameraDataProvider.ApplySettingsForOpaqueDisplay()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_ApplySettingsForTransparentDisplay">BaseCameraDataProvider.ApplySettingsForTransparentDisplay()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_ResetRigTransforms">BaseCameraDataProvider.ResetRigTransforms()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.CameraSystem.BaseCameraDataProvider.html#XRTK_Providers_CameraSystem_BaseCameraDataProvider_SyncRigTransforms">BaseCameraDataProvider.SyncRigTransforms()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseDataProvider.html#XRTK_Services_BaseDataProvider_ParentService">BaseDataProvider.ParentService</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseServiceWithConstructor.html#XRTK_Services_BaseServiceWithConstructor_Name">BaseServiceWithConstructor.Name</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Reset">BaseService.Reset()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_FixedUpdate">BaseService.FixedUpdate()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_OnApplicationFocus_System_Boolean_">BaseService.OnApplicationFocus(Boolean)</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_OnApplicationPause_System_Boolean_">BaseService.OnApplicationPause(Boolean)</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Dispose">BaseService.Dispose()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_OnDispose_System_Boolean_">BaseService.OnDispose(Boolean)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="XRTK.WebXR.Providers.CameraSystem.html">XRTK.WebXR.Providers.CameraSystem</a></h6>
+  <h6><strong>Assembly</strong>: XRTK.WebXR.dll</h6>
+  <h5 id="XRTK_WebXR_Providers_CameraSystem_WebXRCameraDataProvider_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[RuntimePlatform(typeof(WebXRPlatform))]
+[Guid(&quot;ae391bc1-67b5-4074-9972-b401b0b9801c&quot;)]
+public class WebXRCameraDataProvider : BaseCameraDataProvider, IMixedRealityCameraDataProvider, IMixedRealityDataProvider, IMixedRealityService, IDisposable</code></pre>
+  </div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Providers_CameraSystem_WebXRCameraDataProvider__ctor_System_String_System_UInt32_XRTK_Definitions_CameraSystem_BaseMixedRealityCameraDataProviderProfile_XRTK_Interfaces_CameraSystem_IMixedRealityCameraSystem_.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.%23ctor(System.String%2CSystem.UInt32%2CXRTK.Definitions.CameraSystem.BaseMixedRealityCameraDataProviderProfile%2CXRTK.Interfaces.CameraSystem.IMixedRealityCameraSystem)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/Providers/CameraSystem/WebXRCameraDataProvider.cs/#L17">View Source</a>
+  </span>
+  <a id="XRTK_WebXR_Providers_CameraSystem_WebXRCameraDataProvider__ctor_" data-uid="XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.#ctor*"></a>
+  <h4 id="XRTK_WebXR_Providers_CameraSystem_WebXRCameraDataProvider__ctor_System_String_System_UInt32_XRTK_Definitions_CameraSystem_BaseMixedRealityCameraDataProviderProfile_XRTK_Interfaces_CameraSystem_IMixedRealityCameraSystem_" data-uid="XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.#ctor(System.String,System.UInt32,XRTK.Definitions.CameraSystem.BaseMixedRealityCameraDataProviderProfile,XRTK.Interfaces.CameraSystem.IMixedRealityCameraSystem)">WebXRCameraDataProvider(String, UInt32, BaseMixedRealityCameraDataProviderProfile, IMixedRealityCameraSystem)</h4>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public WebXRCameraDataProvider(string name, uint priority, BaseMixedRealityCameraDataProviderProfile profile, IMixedRealityCameraSystem parentService)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">name</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.uint32">UInt32</a></td>
+        <td><span class="parametername">priority</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="XRTK.Definitions.CameraSystem.BaseMixedRealityCameraDataProviderProfile.html">BaseMixedRealityCameraDataProviderProfile</a></td>
+        <td><span class="parametername">profile</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="XRTK.Interfaces.CameraSystem.IMixedRealityCameraSystem.html">IMixedRealityCameraSystem</a></td>
+        <td><span class="parametername">parentService</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.CameraSystem.IMixedRealityCameraDataProvider.html">IMixedRealityCameraDataProvider</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.IMixedRealityDataProvider.html">IMixedRealityDataProvider</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.IMixedRealityService.html">IMixedRealityService</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.idisposable">System.IDisposable</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Providers_CameraSystem_WebXRCameraDataProvider.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/Providers/CameraSystem/WebXRCameraDataProvider.cs/#L12" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WebXR.Providers.CameraSystem.html
+++ b/docs/api/XRTK.WebXR.Providers.CameraSystem.html
@@ -1,0 +1,118 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Namespace XRTK.WebXR.Providers.CameraSystem
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Namespace XRTK.WebXR.Providers.CameraSystem
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Providers.CameraSystem">
+  
+  <h1 id="XRTK_WebXR_Providers_CameraSystem" data-uid="XRTK.WebXR.Providers.CameraSystem" class="text-break">Namespace XRTK.WebXR.Providers.CameraSystem
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="markdown level0 remarks"></div>
+    <h3 id="classes">Classes
+  </h3>
+      <h4><a class="xref" href="XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.html">WebXRCameraDataProvider</a></h4>
+      <section></section>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WebXR.Providers.Controllers.WebXRController.html
+++ b/docs/api/XRTK.WebXR.Providers.Controllers.WebXRController.html
@@ -1,0 +1,238 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class WebXRController
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class WebXRController
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Providers.Controllers.WebXRController">
+  
+  
+  <h1 id="XRTK_WebXR_Providers_Controllers_WebXRController" data-uid="XRTK.WebXR.Providers.Controllers.WebXRController" class="text-break">Class WebXRController
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="XRTK.Providers.Controllers.BaseController.html">BaseController</a></div>
+    <div class="level2"><span class="xref">WebXRController</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="XRTK.Interfaces.Providers.Controllers.IMixedRealityController.html">IMixedRealityController</a></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_DefaultInteractions">BaseController.DefaultInteractions</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_DefaultLeftHandedInteractions">BaseController.DefaultLeftHandedInteractions</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_DefaultRightHandedInteractions">BaseController.DefaultRightHandedInteractions</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_GripPoseOffset">BaseController.GripPoseOffset</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_Name">BaseController.Name</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_Enabled">BaseController.Enabled</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_ControllerDataProvider">BaseController.ControllerDataProvider</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_TrackingState">BaseController.TrackingState</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_ControllerHandedness">BaseController.ControllerHandedness</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_InputSource">BaseController.InputSource</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_Visualizer">BaseController.Visualizer</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_IsPositionAvailable">BaseController.IsPositionAvailable</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_IsPositionApproximate">BaseController.IsPositionApproximate</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_IsRotationAvailable">BaseController.IsRotationAvailable</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_Interactions">BaseController.Interactions</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_AngularVelocity">BaseController.AngularVelocity</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_Velocity">BaseController.Velocity</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_UpdateController">BaseController.UpdateController()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_AssignControllerMappings_XRTK_Definitions_Devices_MixedRealityInteractionMapping___">BaseController.AssignControllerMappings(MixedRealityInteractionMapping[])</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_TryRenderControllerModel_System_Byte___System_Boolean_">BaseController.TryRenderControllerModel(Byte[], Boolean)</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseController.html#XRTK_Providers_Controllers_BaseController_TryRenderControllerModelAsync_System_Byte___System_Boolean_">BaseController.TryRenderControllerModelAsync(Byte[], Boolean)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="XRTK.WebXR.Providers.Controllers.html">XRTK.WebXR.Providers.Controllers</a></h6>
+  <h6><strong>Assembly</strong>: XRTK.WebXR.dll</h6>
+  <h5 id="XRTK_WebXR_Providers_Controllers_WebXRController_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Guid(&quot;6e771251-8fb3-4742-a279-eebf7a25f6dd&quot;)]
+public class WebXRController : BaseController, IMixedRealityController</code></pre>
+  </div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.Providers.Controllers.IMixedRealityController.html">IMixedRealityController</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Providers_Controllers_WebXRController.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Providers.Controllers.WebXRController%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/Providers/Controllers/WebXRController.cs/#L8" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.html
+++ b/docs/api/XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.html
@@ -1,0 +1,301 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class WebXRControllerDataProvider
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class WebXRControllerDataProvider
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider">
+  
+  
+  <h1 id="XRTK_WebXR_Providers_Controllers_WebXRControllerDataProvider" data-uid="XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider" class="text-break">Class WebXRControllerDataProvider
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="XRTK.Services.BaseService.html">BaseService</a></div>
+    <div class="level2"><a class="xref" href="XRTK.Services.BaseServiceWithConstructor.html">BaseServiceWithConstructor</a></div>
+    <div class="level3"><a class="xref" href="XRTK.Services.BaseDataProvider.html">BaseDataProvider</a></div>
+    <div class="level4"><a class="xref" href="XRTK.Providers.Controllers.BaseControllerDataProvider.html">BaseControllerDataProvider</a></div>
+    <div class="level5"><span class="xref">WebXRControllerDataProvider</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="XRTK.Interfaces.Providers.Controllers.IMixedRealityControllerDataProvider.html">IMixedRealityControllerDataProvider</a></div>
+    <div><a class="xref" href="XRTK.Interfaces.Providers.IMixedRealityInputDataProvider.html">IMixedRealityInputDataProvider</a></div>
+    <div><a class="xref" href="XRTK.Interfaces.IMixedRealityDataProvider.html">IMixedRealityDataProvider</a></div>
+    <div><a class="xref" href="XRTK.Interfaces.IMixedRealityService.html">IMixedRealityService</a></div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.idisposable">IDisposable</a></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseControllerDataProvider.html#XRTK_Providers_Controllers_BaseControllerDataProvider_ActiveControllers">BaseControllerDataProvider.ActiveControllers</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseControllerDataProvider.html#XRTK_Providers_Controllers_BaseControllerDataProvider_GetControllerMappingProfile_System_Type_XRTK_Definitions_Utilities_Handedness_">BaseControllerDataProvider.GetControllerMappingProfile(Type, Handedness)</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseControllerDataProvider.html#XRTK_Providers_Controllers_BaseControllerDataProvider_AddController_XRTK_Interfaces_Providers_Controllers_IMixedRealityController_">BaseControllerDataProvider.AddController(IMixedRealityController)</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Providers.Controllers.BaseControllerDataProvider.html#XRTK_Providers_Controllers_BaseControllerDataProvider_RemoveController_XRTK_Interfaces_Providers_Controllers_IMixedRealityController_">BaseControllerDataProvider.RemoveController(IMixedRealityController)</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseDataProvider.html#XRTK_Services_BaseDataProvider_ParentService">BaseDataProvider.ParentService</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseDataProvider.html#XRTK_Services_BaseDataProvider_Priority">BaseDataProvider.Priority</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseServiceWithConstructor.html#XRTK_Services_BaseServiceWithConstructor_Name">BaseServiceWithConstructor.Name</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Initialize">BaseService.Initialize()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Reset">BaseService.Reset()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Enable">BaseService.Enable()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Update">BaseService.Update()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_LateUpdate">BaseService.LateUpdate()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_FixedUpdate">BaseService.FixedUpdate()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Disable">BaseService.Disable()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Destroy">BaseService.Destroy()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_OnApplicationFocus_System_Boolean_">BaseService.OnApplicationFocus(Boolean)</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_OnApplicationPause_System_Boolean_">BaseService.OnApplicationPause(Boolean)</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_Dispose">BaseService.Dispose()</a>
+    </div>
+    <div>
+      <a class="xref" href="XRTK.Services.BaseService.html#XRTK_Services_BaseService_OnDispose_System_Boolean_">BaseService.OnDispose(Boolean)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="XRTK.WebXR.Providers.Controllers.html">XRTK.WebXR.Providers.Controllers</a></h6>
+  <h6><strong>Assembly</strong>: XRTK.WebXR.dll</h6>
+  <h5 id="XRTK_WebXR_Providers_Controllers_WebXRControllerDataProvider_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[RuntimePlatform(typeof(WebXRPlatform))]
+[Guid(&quot;4fc04834-14f0-4dc6-b272-cbc0d1bc8964&quot;)]
+public class WebXRControllerDataProvider : BaseControllerDataProvider, IMixedRealityControllerDataProvider, IMixedRealityInputDataProvider, IMixedRealityDataProvider, IMixedRealityService, IDisposable</code></pre>
+  </div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Providers_Controllers_WebXRControllerDataProvider__ctor_System_String_System_UInt32_XRTK_WebXR_Profiles_WebXRControllerDataProviderProfile_XRTK_Interfaces_InputSystem_IMixedRealityInputSystem_.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.%23ctor(System.String%2CSystem.UInt32%2CXRTK.WebXR.Profiles.WebXRControllerDataProviderProfile%2CXRTK.Interfaces.InputSystem.IMixedRealityInputSystem)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/Providers/Controllers/WebXRControllerDataProvider.cs/#L17">View Source</a>
+  </span>
+  <a id="XRTK_WebXR_Providers_Controllers_WebXRControllerDataProvider__ctor_" data-uid="XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.#ctor*"></a>
+  <h4 id="XRTK_WebXR_Providers_Controllers_WebXRControllerDataProvider__ctor_System_String_System_UInt32_XRTK_WebXR_Profiles_WebXRControllerDataProviderProfile_XRTK_Interfaces_InputSystem_IMixedRealityInputSystem_" data-uid="XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.#ctor(System.String,System.UInt32,XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile,XRTK.Interfaces.InputSystem.IMixedRealityInputSystem)">WebXRControllerDataProvider(String, UInt32, WebXRControllerDataProviderProfile, IMixedRealityInputSystem)</h4>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public WebXRControllerDataProvider(string name, uint priority, WebXRControllerDataProviderProfile profile, IMixedRealityInputSystem parentService)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">name</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.uint32">UInt32</a></td>
+        <td><span class="parametername">priority</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.html">WebXRControllerDataProviderProfile</a></td>
+        <td><span class="parametername">profile</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="XRTK.Interfaces.InputSystem.IMixedRealityInputSystem.html">IMixedRealityInputSystem</a></td>
+        <td><span class="parametername">parentService</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.Providers.Controllers.IMixedRealityControllerDataProvider.html">IMixedRealityControllerDataProvider</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.Providers.IMixedRealityInputDataProvider.html">IMixedRealityInputDataProvider</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.IMixedRealityDataProvider.html">IMixedRealityDataProvider</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Interfaces.IMixedRealityService.html">IMixedRealityService</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.idisposable">System.IDisposable</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/new/development/docs-ref-overwrite/new?filename=XRTK_WebXR_Providers_Controllers_WebXRControllerDataProvider.md&amp;value=---%0Auid%3A%20XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/XRTK/XRTK-Core/blob/merge/XRTK-Core/Packages/com.xrtk.webxr/Runtime/Providers/Controllers/WebXRControllerDataProvider.cs/#L12" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WebXR.Providers.Controllers.html
+++ b/docs/api/XRTK.WebXR.Providers.Controllers.html
@@ -1,0 +1,120 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Namespace XRTK.WebXR.Providers.Controllers
+   | XRTK-Core </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Namespace XRTK.WebXR.Providers.Controllers
+   | XRTK-Core ">
+    <meta name="generator" content="docfx 2.56.6.0">
+    
+    <link rel="shortcut icon" href="../favicon.png">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.png" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="XRTK.WebXR.Providers.Controllers">
+  
+  <h1 id="XRTK_WebXR_Providers_Controllers" data-uid="XRTK.WebXR.Providers.Controllers" class="text-break">Namespace XRTK.WebXR.Providers.Controllers
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="markdown level0 remarks"></div>
+    <h3 id="classes">Classes
+  </h3>
+      <h4><a class="xref" href="XRTK.WebXR.Providers.Controllers.WebXRController.html">WebXRController</a></h4>
+      <section></section>
+      <h4><a class="xref" href="XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.html">WebXRControllerDataProvider</a></h4>
+      <section></section>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+                <h5>In This Article</h5>
+                <div></div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            (c) XRTK
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/XRTK.WindowsMixedReality.Editor.Providers.SpatialAwarenessSystem.SpatialObservers.WindowsMixedRealityControllerDataProviderProfileInspector.html
+++ b/docs/api/XRTK.WindowsMixedReality.Editor.Providers.SpatialAwarenessSystem.SpatialObservers.WindowsMixedRealityControllerDataProviderProfileInspector.html
@@ -170,6 +170,15 @@ public class WindowsMixedRealityControllerDataProviderProfileInspector : BaseMix
   <div><a class="xref" href="XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerDataProviderProfileInspector.html#XRTK_Editor_Profiles_InputSystem_Controllers_BaseMixedRealityControllerDataProviderProfileInspector_OnInspectorGUI">BaseMixedRealityControllerDataProviderProfileInspector.OnInspectorGUI()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -186,15 +195,6 @@ public class WindowsMixedRealityControllerDataProviderProfileInspector : BaseMix
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.WindowsMixedReality.Editor.WindowsMixedRealityPathFinder.html
+++ b/docs/api/XRTK.WindowsMixedReality.Editor.WindowsMixedRealityPathFinder.html
@@ -159,24 +159,6 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
-  </div>
-  <div>
       <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
   </div>
   <div>
@@ -193,6 +175,24 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, String, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, Boolean)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_GetOrCreateAsset_UnityEngine_ScriptableObject_System_String_System_String_System_Boolean_">ScriptableObjectExtensions.GetOrCreateAsset(ScriptableObject, String, String, Boolean)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealityControllerDataProviderProfile.html
+++ b/docs/api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealityControllerDataProviderProfile.html
@@ -315,6 +315,24 @@ public class WindowsMixedRealityControllerDataProviderProfile : BaseMixedReality
   <div><a class="xref" href="XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html#XRTK_Definitions_Controllers_BaseMixedRealityControllerDataProviderProfile_GetDefaultControllerOptions">BaseMixedRealityControllerDataProviderProfile.GetDefaultControllerOptions()</a></div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -337,24 +355,6 @@ public class WindowsMixedRealityControllerDataProviderProfile : BaseMixedReality
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealityHandControllerDataProviderProfile.html
+++ b/docs/api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealityHandControllerDataProviderProfile.html
@@ -144,6 +144,24 @@
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -166,24 +184,6 @@
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealitySpatialMeshObserverProfile.html
+++ b/docs/api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealitySpatialMeshObserverProfile.html
@@ -154,6 +154,24 @@ public class WindowsMixedRealitySpatialMeshObserverProfile : BaseMixedRealitySpa
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
+      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
+  </div>
+  <div>
+      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
+  </div>
+  <div>
       <a class="xref" href="XRTK.Editor.Extensions.ScriptableObjectExtensions.html#XRTK_Editor_Extensions_ScriptableObjectExtensions_CreateAsset_UnityEngine_ScriptableObject_System_Boolean_">ScriptableObjectExtensions.CreateAsset(ScriptableObject, Boolean)</a>
   </div>
   <div>
@@ -176,24 +194,6 @@ public class WindowsMixedRealitySpatialMeshObserverProfile : BaseMixedRealitySpa
   </div>
   <div>
       <a class="xref" href="XRTK.Editor.Utilities.BaseMixedRealityProfileInspectorExtensions.html#XRTK_Editor_Utilities_BaseMixedRealityProfileInspectorExtensions_CopySerializedValues_XRTK_Definitions_BaseMixedRealityProfile_XRTK_Definitions_BaseMixedRealityProfile_">BaseMixedRealityProfileInspectorExtensions.CopySerializedValues(BaseMixedRealityProfile, BaseMixedRealityProfile)</a>
-  </div>
-  <div>
-      <a class="xref" href="Leap.CSharpExtensions.html#Leap_CSharpExtensions_HasMethod_System_Object_System_String_">CSharpExtensions.HasMethod(Object, String)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.ConverterExtensions.html#XRTK_Extensions_ConverterExtensions_GetBuiltInTypeBytes__1___0_">ConverterExtensions.GetBuiltInTypeBytes&lt;T&gt;(T)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_DontDestroyOnLoad_UnityEngine_Object_">UnityObjectExtensions.DontDestroyOnLoad(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_Destroy_UnityEngine_Object_System_Single_">UnityObjectExtensions.Destroy(Object, Single)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Extensions.UnityObjectExtensions.html#XRTK_Extensions_UnityObjectExtensions_IsNull_UnityEngine_Object_">UnityObjectExtensions.IsNull(Object)</a>
-  </div>
-  <div>
-      <a class="xref" href="XRTK.Utilities.Async.Awaiters.html#XRTK_Utilities_Async_Awaiters_WaitUntil__1___0_System_Func___0_System_Boolean__System_Int32_">Awaiters.WaitUntil&lt;T&gt;(T, Func&lt;T, Boolean&gt;, Int32)</a>
   </div>
 </article>
           </div>

--- a/docs/api/toc.html
+++ b/docs/api/toc.html
@@ -1361,6 +1361,9 @@
                               <a href="XRTK.Definitions.Platforms.WebGlPlatform.html" name="" title="WebGlPlatform">WebGlPlatform</a>
                           </li>
                           <li>
+                              <a href="XRTK.Definitions.Platforms.WebXRPlatform.html" name="" title="WebXRPlatform">WebXRPlatform</a>
+                          </li>
+                          <li>
                               <a href="XRTK.Definitions.Platforms.WindowsStandalonePlatform.html" name="" title="WindowsStandalonePlatform">WindowsStandalonePlatform</a>
                           </li>
                     </ul>
@@ -4654,6 +4657,49 @@
                           </li>
                           <li>
                               <a href="XRTK.Utilities.WindowsDevicePortal.DataStructures.WirelessNetworkInfo.html" name="" title="WirelessNetworkInfo">WirelessNetworkInfo</a>
+                          </li>
+                    </ul>
+                </li>
+                <li>
+                    <span class="expand-stub"></span>
+                    <a href="XRTK.WebXR.Editor.html" name="" title="XRTK.WebXR.Editor">XRTK.WebXR.Editor</a>
+                    
+                    <ul class="nav level2">
+                          <li>
+                              <a href="XRTK.WebXR.Editor.WebXRPathFinder.html" name="" title="WebXRPathFinder">WebXRPathFinder</a>
+                          </li>
+                    </ul>
+                </li>
+                <li>
+                    <span class="expand-stub"></span>
+                    <a href="XRTK.WebXR.Profiles.html" name="" title="XRTK.WebXR.Profiles">XRTK.WebXR.Profiles</a>
+                    
+                    <ul class="nav level2">
+                          <li>
+                              <a href="XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.html" name="" title="WebXRControllerDataProviderProfile">WebXRControllerDataProviderProfile</a>
+                          </li>
+                    </ul>
+                </li>
+                <li>
+                    <span class="expand-stub"></span>
+                    <a href="XRTK.WebXR.Providers.CameraSystem.html" name="" title="XRTK.WebXR.Providers.CameraSystem">XRTK.WebXR.Providers.CameraSystem</a>
+                    
+                    <ul class="nav level2">
+                          <li>
+                              <a href="XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.html" name="" title="WebXRCameraDataProvider">WebXRCameraDataProvider</a>
+                          </li>
+                    </ul>
+                </li>
+                <li>
+                    <span class="expand-stub"></span>
+                    <a href="XRTK.WebXR.Providers.Controllers.html" name="" title="XRTK.WebXR.Providers.Controllers">XRTK.WebXR.Providers.Controllers</a>
+                    
+                    <ul class="nav level2">
+                          <li>
+                              <a href="XRTK.WebXR.Providers.Controllers.WebXRController.html" name="" title="WebXRController">WebXRController</a>
+                          </li>
+                          <li>
+                              <a href="XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.html" name="" title="WebXRControllerDataProvider">WebXRControllerDataProvider</a>
                           </li>
                     </ul>
                 </li>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -12,7 +12,7 @@
           "hash": "Zh7riv6tjFTfZ9IIzlBbbg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -24,7 +24,7 @@
           "hash": "ScZE5cPiF0goONo+pGHwPg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -36,7 +36,7 @@
           "hash": "DngB5brI/O6P5LcKNIcvXw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -48,7 +48,7 @@
           "hash": "sbWkI6eA+MkCouOgj/RA0w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -60,7 +60,7 @@
           "hash": "ex7f/zAv70l9gEkYs0xdZw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -72,7 +72,7 @@
           "hash": "I7rRiMq/hN61fkw3odbYDQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -84,7 +84,7 @@
           "hash": "gcr/pAcz/4H570CDUlFP3w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -96,7 +96,7 @@
           "hash": "SMd/274XImHo98wnXRXr2Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -108,7 +108,7 @@
           "hash": "FiKj6Qlaub/hVjYidmWD2A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -120,7 +120,7 @@
           "hash": "IgWwNLNaITYIESSYluEOdA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -132,7 +132,7 @@
           "hash": "ZOZGtpR3G6aFyZxmm+GHyQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -144,7 +144,7 @@
           "hash": "JHV+eES2Xwz/jIwFME7Ghw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -156,7 +156,7 @@
           "hash": "9JIfKgAlqV2vD3lIOzYEeg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -168,7 +168,7 @@
           "hash": "kIfCtmIlVJ1bDv7ORUNAYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -180,7 +180,7 @@
           "hash": "51eh8Q4TeIONYSf1+GJ9Kw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -192,7 +192,7 @@
           "hash": "YeJvajWAWTaDhjapqTb7Cg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -204,7 +204,7 @@
           "hash": "qwTIOabDVWsdzr/TuexwkQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -216,7 +216,7 @@
           "hash": "5XF7482sYUIhsPPR2m1VYA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -228,7 +228,7 @@
           "hash": "f/YrSiTH5v5CRJoXaXz03Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -240,7 +240,7 @@
           "hash": "Ivw+umSrClqt021Ho3sn7w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -252,7 +252,7 @@
           "hash": "xxqqqW12wyaYUe37/v6apg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -264,7 +264,7 @@
           "hash": "GQ8pz1byo5Ul8qf3etCOHg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -276,7 +276,7 @@
           "hash": "us3DXTXDfKIctdeDelowHA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -288,7 +288,7 @@
           "hash": "I+eNHGOCv/tZPmid27lf1Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -300,7 +300,7 @@
           "hash": "a58ldqmD9S/PrU6/bY5xNQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -312,7 +312,7 @@
           "hash": "ciVo/lkSUSiU2h1vQ+NusA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -324,7 +324,7 @@
           "hash": "WXcJAjtTmy62A3avsF4pyQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -336,7 +336,7 @@
           "hash": "sLs2AuArkrk0S0uaHW8JhA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -348,7 +348,7 @@
           "hash": "HLCG12YSkv1khuc4zaI/uQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -360,7 +360,7 @@
           "hash": "eSbhUFXmkkx7r0XZN8tpXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -372,7 +372,7 @@
           "hash": "9yT70RP95UB0LIeT3Hjokw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -384,7 +384,7 @@
           "hash": "1bPfyA9e8smNrz+gLF7YtQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -396,7 +396,7 @@
           "hash": "tXR0igDNmp8QPvRobuqqYw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -408,7 +408,7 @@
           "hash": "HMpW6dPoL+pprcVANQC5yg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -420,7 +420,7 @@
           "hash": "O2dYXtWqJ4fixkbj1j+VdA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -432,7 +432,7 @@
           "hash": "7/nENtkcjwiU+6xvJLjsVQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -444,7 +444,7 @@
           "hash": "yi5uZopMzB4RpeWC+bix+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -456,7 +456,7 @@
           "hash": "09BWCAtkz3nJSkrnoVAM8g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -468,7 +468,7 @@
           "hash": "jRLF6t/yJD7hQiznr1UUUA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -480,7 +480,7 @@
           "hash": "a46hD7BNtnICh7XncPhskw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -492,7 +492,7 @@
           "hash": "W08mUV+BFfB3MycFfj0UBQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -504,7 +504,7 @@
           "hash": "hNBMFRw2FFpdyxICVBg7Rg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -516,7 +516,7 @@
           "hash": "TfZ4jDIfYAUFvMLGN00fVg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -528,7 +528,7 @@
           "hash": "lHklD4+d1tP5GvustrA7mg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -540,7 +540,7 @@
           "hash": "gqM2nQQOSbJVVVxVQ2CYaA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -552,7 +552,7 @@
           "hash": "RQKur9lQ8O7JPEOwq3BU1A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -564,7 +564,7 @@
           "hash": "f+lR0EwUtN+/dXy0/pG/rQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -576,7 +576,7 @@
           "hash": "4EaR/ZctTOqiZw0mkKQ3nQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -588,7 +588,7 @@
           "hash": "MF3NUzScMLE92mQDjD9WfA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -600,7 +600,7 @@
           "hash": "TuoV3mjJ4o0QDSwe6P1vag=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -612,7 +612,7 @@
           "hash": "bHXiS9VUbe5mKiK+IE23vA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -624,7 +624,7 @@
           "hash": "TZTax4vY3nb5QtICdEvi1A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -636,7 +636,7 @@
           "hash": "IsBhbVDR0PH7HCF64096UQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -648,7 +648,7 @@
           "hash": "YuZsU6QBLljve81uSGqOpg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -660,7 +660,7 @@
           "hash": "tJcUAlF8WuAFgE1C5zOXBQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -672,7 +672,7 @@
           "hash": "5cYj3nMPLOPpwtITJ7epVQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -684,7 +684,7 @@
           "hash": "GwgQihNgHQfKI33xNMbmRQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -696,7 +696,7 @@
           "hash": "/3Me73Zj2Tl2mvrPhCnkgQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -708,7 +708,7 @@
           "hash": "x12XOva5vbizeuRqFAnk9Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -720,7 +720,7 @@
           "hash": "PVfV7uGBSlVqy2Gun2KxUQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -732,7 +732,7 @@
           "hash": "EfKFrb8dl8D7BetSskbOUA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -744,7 +744,7 @@
           "hash": "RbWB0iE3tTYg0h4rZhz6UQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -756,7 +756,7 @@
           "hash": "VpMbx87c7RD6G79lG5TRIA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -768,7 +768,7 @@
           "hash": "cZu3SOysqTElbg9G9e4Oyw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -780,7 +780,7 @@
           "hash": "yAuTEO1g5jcLG+drLSsKRA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -792,7 +792,7 @@
           "hash": "l6fZw8zldpl7zyBp5HE1ng=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -804,7 +804,7 @@
           "hash": "TgcXj29OQpeRVbvzWJPfKw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -816,7 +816,7 @@
           "hash": "smuayC4xrIJBP2S7eNAu6A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -828,7 +828,7 @@
           "hash": "Ccjys8Bz1+aZ8kggw8V1AQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -840,7 +840,7 @@
           "hash": "feWpdmXTWhfkLkFlhKIJ0g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -852,7 +852,7 @@
           "hash": "izM/lgMmhv0S5cto8MCZiA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -864,7 +864,7 @@
           "hash": "cWzTfa11ZPbPKCJPhO69kg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -876,7 +876,7 @@
           "hash": "rLn1jfUb/hdhOiCtcc3Frw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -888,7 +888,7 @@
           "hash": "qBsPdovQBiI3OvQUBuE6nQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -900,7 +900,7 @@
           "hash": "4YSm8Z51Gl3XHNtvwm0wxw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -912,7 +912,7 @@
           "hash": "vQTCeVPhDCOf9+W4Q5ICrg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -924,7 +924,7 @@
           "hash": "yKl/6H47brsNQwggRUetAA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -936,7 +936,7 @@
           "hash": "rTlOWKnBo5v/S35FlvUmiQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -948,7 +948,7 @@
           "hash": "x4LmcBZqVH5tJ6kr7Thdsw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -960,7 +960,7 @@
           "hash": "tyg4dz5jAY6ZXy/Ac4AUGw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -972,7 +972,7 @@
           "hash": "1Bw4y0lKP+Wf5mWefSltJA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -984,7 +984,7 @@
           "hash": "H6BgeDjrU8pi+9M/UGtJbA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -996,7 +996,7 @@
           "hash": "sTIuBCWuaNr4LOhM1SecJA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1008,7 +1008,7 @@
           "hash": "MmFLNrHMI9nSKFhfBHD5EA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1020,7 +1020,7 @@
           "hash": "RjXCzoQsyWQBm7j5gzE3pw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1032,7 +1032,7 @@
           "hash": "k4ZWw3/RbuFZct+f5b7KZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1044,7 +1044,7 @@
           "hash": "N3qvx17mKG/mmhM9Vs1ccA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1056,7 +1056,7 @@
           "hash": "DZg7ZD2KCTEyjJACAc6k5g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1068,7 +1068,7 @@
           "hash": "KCnqWkpHraxpxAaNAbYpVw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1080,7 +1080,7 @@
           "hash": "FWSZDYrSaQ0kbHjAhB2RCA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1092,7 +1092,7 @@
           "hash": "Jvd0l+DpqFiXA7Ovt3JsFg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1104,7 +1104,7 @@
           "hash": "UjMHmN/LVpM48qp1zeiAyA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1116,7 +1116,7 @@
           "hash": "1uCUfPRSrePudAyFzlsILw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1128,7 +1128,7 @@
           "hash": "GAzx2lEqIMaDk1btiab7ag=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1140,7 +1140,7 @@
           "hash": "mn+kc7/hS1ZqOdm9yXU/2A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1152,7 +1152,7 @@
           "hash": "BL+/cDC2N6iZTDRwnMHJEQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1164,7 +1164,7 @@
           "hash": "0Duc1camgaSD8BzfGuwVSQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1176,7 +1176,7 @@
           "hash": "I8j72Gn1b/wWJjfC6+u5eg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1188,7 +1188,7 @@
           "hash": "Tg06DNIX2ZxSQtwtRXKBqg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1200,7 +1200,7 @@
           "hash": "wbMiV20Xo876vV3IVZ7RWA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1212,7 +1212,7 @@
           "hash": "xSdgiQr3a71GLcSOxUSuTg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1224,7 +1224,7 @@
           "hash": "juyHm9QHeU8xt/e8Gry4gg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1236,7 +1236,7 @@
           "hash": "Ea+VSxdlALbPlBq8xUl/tw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1248,7 +1248,7 @@
           "hash": "UWc3i8Q2mZ/qrdGKUQEKDg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1260,7 +1260,7 @@
           "hash": "Iodbz0ZynYiTbalSw/UFXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1272,7 +1272,7 @@
           "hash": "wGvPDmDK9KyHWZngwOb2pw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1284,7 +1284,7 @@
           "hash": "cTp38fS+TjxFlyycyU8OsA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1296,7 +1296,7 @@
           "hash": "fqIrX2EnCcttwrkVXntN/g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1308,7 +1308,7 @@
           "hash": "xw/PIBlUW6FycImIfZwMrw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1320,7 +1320,7 @@
           "hash": "YWSmWBJgRFKVmPhoAkVLwA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1332,7 +1332,7 @@
           "hash": "z9s4Gvtb7wbiSMMwYlnV5w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1344,7 +1344,7 @@
           "hash": "3M+cSTauWM4FXq6Q0kaKVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1356,7 +1356,7 @@
           "hash": "x967A6r19hSQTJ2Gr0whdA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1368,7 +1368,7 @@
           "hash": "n2P77LCUCxw7woDh2G0WKA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1380,7 +1380,7 @@
           "hash": "cfKCUjiNcp/iKIvhs9uaMQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1392,7 +1392,7 @@
           "hash": "Wqw9hrYnGuXppWZWF387/A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1404,7 +1404,7 @@
           "hash": "UXztUYUa7T37Ch53X/Aj+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1416,7 +1416,7 @@
           "hash": "+zcRw+Myab/VB7+cc3yMeQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1428,7 +1428,7 @@
           "hash": "vlFpFOSmjUQDd/s53dOkGQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1440,7 +1440,7 @@
           "hash": "isxdMz1fPCGuwk7wjeft5A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1452,7 +1452,7 @@
           "hash": "7ds3/Hsb/m2iLErCcWAJnQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1464,7 +1464,7 @@
           "hash": "D4XR2m2rW985U4G61GZb4w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1476,7 +1476,7 @@
           "hash": "t+PeQ+SIeyJt08ENX4z/rQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1488,7 +1488,7 @@
           "hash": "PUlKF1Ihzsj/khRS40cYQQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1500,7 +1500,7 @@
           "hash": "pnvBjlqBlOuKF8cPcSoDxg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1512,7 +1512,7 @@
           "hash": "AmNlnsZqb2cz7S+pqMZIWw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1524,7 +1524,7 @@
           "hash": "XcPAws8Je+TCgZ8SLy6GeQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1536,7 +1536,7 @@
           "hash": "vMjKc+8/tUAGfwzxTfPSnQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1548,7 +1548,7 @@
           "hash": "4lIbF3HpN2zlgN6oi1eXIQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1560,7 +1560,7 @@
           "hash": "yOWrn4BcxKCqBuMCpkopWQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1572,7 +1572,7 @@
           "hash": "O0R5H10J5Gksir11UNdo+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1584,7 +1584,7 @@
           "hash": "rqhlfFtzq/Z7Ni+cCctEuQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1596,7 +1596,7 @@
           "hash": "Ct/9pK1TnGHPn2qryQeHlw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1608,7 +1608,7 @@
           "hash": "tM/s3obqFUQDbLjSBeZMiw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1620,7 +1620,7 @@
           "hash": "pN+8Vd3hcFV66vsDSCrVnw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1632,7 +1632,7 @@
           "hash": "OgNsz12l0u/N+uht9b7hvw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1644,7 +1644,7 @@
           "hash": "epQimettT0XkqC9kxOZbEg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1656,7 +1656,7 @@
           "hash": "Y3tjgdJl3dHGdTG2gX+4DQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1668,7 +1668,7 @@
           "hash": "xtvj0g1IhCssQv7hlExp6g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1680,7 +1680,7 @@
           "hash": "0gImHcZkt+xofKnarKKrlw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1692,7 +1692,7 @@
           "hash": "sfQ+G/i+EzqmIGYd5NI65w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1704,7 +1704,7 @@
           "hash": "nTHBKkzieLpwijhoFyeYcw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1716,7 +1716,7 @@
           "hash": "pBnkgFfHO19nlVmWheIL3g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1728,7 +1728,7 @@
           "hash": "+oayz0PAoZaOEJgk2u8JMg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1740,7 +1740,7 @@
           "hash": "dDKDTYsP8TgMQAjob+rwAQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1752,7 +1752,7 @@
           "hash": "bRkCfd3ncHPk9MMv/NUwpw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1764,7 +1764,7 @@
           "hash": "6QdAqvb+VcbgP7rsnwsi8g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1776,7 +1776,7 @@
           "hash": "ab8FC6dzU6WbGCHsajZZzw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1788,7 +1788,7 @@
           "hash": "/KnvQ0yn5GeZCu3jxfkGIw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1800,7 +1800,7 @@
           "hash": "OUtGjatf3w/1CI7BnY0cGA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1812,7 +1812,7 @@
           "hash": "5XgZoLIoLiyWfqaa9WONjA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1824,7 +1824,7 @@
           "hash": "0ISaP4vpSKWBTqQaEvDNnw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1836,7 +1836,7 @@
           "hash": "qi9i29dawAV73TDh/00wNA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1848,7 +1848,7 @@
           "hash": "8ohtn8G4VrPBvK5nvYOfcg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1860,7 +1860,7 @@
           "hash": "3XheWyGce3Ra50Tu3GJkLg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1872,7 +1872,7 @@
           "hash": "F5+reU83XYlzRnFbCNM5Bw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1884,7 +1884,7 @@
           "hash": "T100Xo1uGiA8RbtOh1x5NA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1896,7 +1896,7 @@
           "hash": "y3emu19/6g0E+0ffOEAxmQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1908,7 +1908,7 @@
           "hash": "B9U6o0Oos1rm4Xam59sjGQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1920,7 +1920,7 @@
           "hash": "QlJkXm2Tf40X6kYjR8hoVQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1932,7 +1932,7 @@
           "hash": "DPvv9jrdXDDoftzSmw2VXw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1944,7 +1944,7 @@
           "hash": "qegwA+NJUr1Jq2egwvvZjg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1956,7 +1956,7 @@
           "hash": "qXqVf48dhQFqPTa5RyJPCg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1968,7 +1968,7 @@
           "hash": "JDhhL7mTJglg0PQUlvOjJQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1980,7 +1980,7 @@
           "hash": "IcIn2f9kgQkqtNlWHXex1g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1992,7 +1992,7 @@
           "hash": "iX1NgNpyDlw/p/gMBhbklQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2004,7 +2004,7 @@
           "hash": "hfnWqUA3+H4cBGubhtItOw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2016,7 +2016,7 @@
           "hash": "V32a3mb1JgOe+Awfb6/MfA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2028,7 +2028,7 @@
           "hash": "pnJinsfCBxg/J/apLIOKTA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2040,7 +2040,7 @@
           "hash": "fZ4S0Hv9AhpryNsNI6h1Ig=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2052,7 +2052,7 @@
           "hash": "FSQd6k4pOAnJ1TYyxPGLKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2064,7 +2064,7 @@
           "hash": "9J1cMg693HfK0oxNT+sjlA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2076,7 +2076,7 @@
           "hash": "HhLOlPcQraynLiX/faq+Ug=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2088,7 +2088,7 @@
           "hash": "o5HNdYDnIMfB6YZurrz+Ug=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2100,7 +2100,7 @@
           "hash": "qbe973JgtyBS4Ixd0ydBqA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2112,7 +2112,7 @@
           "hash": "4FAWImKw7DxhYgeUz63KEg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2124,7 +2124,7 @@
           "hash": "QVDVZ8UIcf8Y3eJgde4tqA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2136,7 +2136,7 @@
           "hash": "7WuHexnRj61ZmGCGnrtbEw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2148,7 +2148,7 @@
           "hash": "Mr63P1ABlDDcAKqC+vF2Wg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2160,7 +2160,7 @@
           "hash": "YZPlmozeuBupkdkx4asMkw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2172,7 +2172,7 @@
           "hash": "jIgESWH814AnL3M80bwQ1w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2184,7 +2184,7 @@
           "hash": "bbqj4jDJOg5V+ccYCXue3g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2196,7 +2196,7 @@
           "hash": "uK1FaqVaLDATvEhP1YT3JQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2208,7 +2208,7 @@
           "hash": "linvCrpegI6Q8z0Kq+1ItQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2220,7 +2220,7 @@
           "hash": "vH5FrntKETTnxEnxrV6JmQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2232,7 +2232,7 @@
           "hash": "nvlDDnHYh8ZIxEaCM9+gaA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2244,7 +2244,7 @@
           "hash": "+nloDvEe+C7AgFDKM5Xyjg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2256,7 +2256,7 @@
           "hash": "DuDlw0kloYbpGzpbJrr7bg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2268,7 +2268,7 @@
           "hash": "bue03mXtmJ9bikCY6ZrK/A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2280,7 +2280,7 @@
           "hash": "wYq2qoudoHGlcL/jNDIUew=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2292,7 +2292,7 @@
           "hash": "/dybbcGb5m9K+1WXJW3Iag=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2304,7 +2304,7 @@
           "hash": "pUeipuRMuVtyWFAMG0YgwQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2316,7 +2316,7 @@
           "hash": "jAsNTwC3diQe+aViO7Y6pg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2328,7 +2328,7 @@
           "hash": "BEYH7Rc46CiR7DU8MKSaDA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2340,7 +2340,7 @@
           "hash": "wa44YlW2kdxKbYbLku+eMg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2352,7 +2352,7 @@
           "hash": "VreVQiseGhfzM1tPDE/jBw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2364,7 +2364,7 @@
           "hash": "xIlIPms8z+dV4C85wCpIxA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2376,7 +2376,7 @@
           "hash": "2B6/ytaQfG3ItJRrWAl/0w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2388,7 +2388,7 @@
           "hash": "r/Dt5O3CczlJaaX8wOB/VQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2400,7 +2400,7 @@
           "hash": "NkCsSQwmitWGDyYyrG1+Sw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2412,7 +2412,7 @@
           "hash": "1HFLL4AcoJ6g1VevIpod0g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2424,7 +2424,7 @@
           "hash": "UJibfbUxrXnRa6hhb0GoCg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2436,7 +2436,7 @@
           "hash": "L1wUoe34HY4NlcoAergWwA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2448,7 +2448,7 @@
           "hash": "eMmeY/cgNuY1HVsybVPZcg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2460,7 +2460,7 @@
           "hash": "z/HFJhn5UAJ0Y9kvDT0Xsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2472,7 +2472,7 @@
           "hash": "LGFZCju3+4f2AwLrbj1d4g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2484,7 +2484,7 @@
           "hash": "GCuGpNGxe8MdZ2sODumRyg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2496,7 +2496,7 @@
           "hash": "cR99Kt5mRwetjZ84wL3dwA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2508,7 +2508,7 @@
           "hash": "vwwGjaZsfFP/+8gtsWnMzQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2520,7 +2520,7 @@
           "hash": "Q3in/Olt/03Mm0sLjFEcHw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2532,7 +2532,7 @@
           "hash": "3TGspehxEb/Nv5/CP/o1Zg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2544,7 +2544,7 @@
           "hash": "jTY6bu/fX9Le/jfa/6CqGg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2556,7 +2556,7 @@
           "hash": "zyD5Zs4UDHmS9U88fbAdUg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2568,7 +2568,7 @@
           "hash": "b7DQ8l+a+Gx7j8lmy9ol4w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2580,7 +2580,7 @@
           "hash": "tWOGMjb9IRh+beoV1bRkMQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2592,7 +2592,7 @@
           "hash": "tB0XzXd02YPodnMn4+pH2A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2604,7 +2604,7 @@
           "hash": "MloRy7onRRiKK3swHhe+YQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2616,7 +2616,7 @@
           "hash": "M3xo0c5MhmREm7tDPx5DKg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2628,7 +2628,7 @@
           "hash": "Gq5LxX9GqIGg7dSH/akFuw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2640,7 +2640,7 @@
           "hash": "+U/6pDL0MirYjPeRLAjX7Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2652,7 +2652,7 @@
           "hash": "uFwsI/xe8zBywGArRDRspg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2664,7 +2664,7 @@
           "hash": "DEvqr8E+sn4kn8Q+inHG2w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2676,7 +2676,7 @@
           "hash": "9TVdTVZ1SDJqeHtT1yEZeA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2688,7 +2688,7 @@
           "hash": "FX1yD2dRws1wVypypL0TCw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2700,7 +2700,7 @@
           "hash": "z6ySc10ZGgvR6OrdIj0aYA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2712,7 +2712,7 @@
           "hash": "3uKN/+EE7ts1AGSqf8Fdkg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2724,7 +2724,7 @@
           "hash": "x1Q2GUnOnYIWhL/qd9e1jg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2736,7 +2736,7 @@
           "hash": "h24As3tCNohmMHXEMUbTow=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2748,7 +2748,7 @@
           "hash": "kQviS/UNEgbLkE7BEJ2zhQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2760,7 +2760,7 @@
           "hash": "UBx4vE7jLeRhka/JLgjdbA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2772,7 +2772,7 @@
           "hash": "4uUpl4eGN2Nwhb2on/YYZw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2784,7 +2784,7 @@
           "hash": "AbUShT95rDDnj2Yawp+Ghg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2796,7 +2796,7 @@
           "hash": "EdAjalxKYcaS1QC5ZCOx8w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2808,7 +2808,7 @@
           "hash": "DcgJHdLz/W1jJELOAd6HQA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2820,7 +2820,7 @@
           "hash": "94rL2AHP/SSrWE3y923W4g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2832,7 +2832,7 @@
           "hash": "EMoqFL1+k2sjpdniOVisgA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2844,7 +2844,7 @@
           "hash": "/xK/k39yx2S7BPTny62PCA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2856,7 +2856,7 @@
           "hash": "GXz3O+RSvtWEBJK/yHBM+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2868,7 +2868,7 @@
           "hash": "kY6ui8IR1OWySAuK9aTTPg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2880,7 +2880,7 @@
           "hash": "PFdKF1ok1M6QOR+1HEZ+qA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2892,7 +2892,7 @@
           "hash": "C2Y/STLgs9QZarxcPWXENA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2904,7 +2904,7 @@
           "hash": "WieHoxrOecjGcZxO+JPPGA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2916,7 +2916,7 @@
           "hash": "Krq6NiCzsOyw2Bl5Z7m6Cg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2928,7 +2928,7 @@
           "hash": "Pjs6zCBlEr5eOdelnblkBg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2940,7 +2940,7 @@
           "hash": "bjdikKXasvKq2s4HiwoexQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2952,7 +2952,7 @@
           "hash": "jO8eE7rlKpp9VfxnZ9s/YQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2964,7 +2964,7 @@
           "hash": "tAyDZ8fsLeUwEXuK1HOzYw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2976,7 +2976,7 @@
           "hash": "k44do+mxLBOLLh3kgAHGJw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -2988,7 +2988,7 @@
           "hash": "EfHJ8hugOu8ndV/I3bhFVQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3000,7 +3000,7 @@
           "hash": "SaqQZl1Xb+aeJ9brQmYNzg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3012,7 +3012,7 @@
           "hash": "SZDQ6C8XtoUIGUeCiJ8iMQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3024,7 +3024,7 @@
           "hash": "SY0SNimVxxruaB3wzSPksg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3036,7 +3036,7 @@
           "hash": "4Mr3RbuQgaHs9mBDyhXR2A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3048,7 +3048,7 @@
           "hash": "GHchfmX9aZAm/tfIy5JTkg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3060,7 +3060,7 @@
           "hash": "PAma6LxazyrWazgdllCP8Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3072,7 +3072,7 @@
           "hash": "SDyleNa1DVYQMAnAVr9xJQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3084,7 +3084,7 @@
           "hash": "JNtpjHSmbG5ei23dIsXldQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3096,7 +3096,7 @@
           "hash": "rxBXwPs+okCIXcHhM/k2eg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3108,7 +3108,7 @@
           "hash": "fLolMGq15BbsqQq16R98yg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3120,7 +3120,7 @@
           "hash": "LmNDNVZFVge75NWqpU7SVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3132,7 +3132,7 @@
           "hash": "U35L5j9LIGpKG60Otp9bxQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3144,7 +3144,7 @@
           "hash": "6ilaf5kwgDhClkMq/obyyA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3156,7 +3156,7 @@
           "hash": "z0yT284XI6I9xKtAqmhqRw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3168,7 +3168,7 @@
           "hash": "aEZx/tj8xwUyK3UOAYTJAw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3180,7 +3180,7 @@
           "hash": "F3sg+FZWF3Ts194eOM2nUg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3192,7 +3192,7 @@
           "hash": "BXkk5xVExgTzjEdhTt+OvA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3204,7 +3204,7 @@
           "hash": "YWIz8rTLYnGMTnnxt9mrEQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3216,7 +3216,7 @@
           "hash": "M8+f4HlNJdHp5Hh54gmmMg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3228,7 +3228,7 @@
           "hash": "MrkVkJbsPYQhtTVJDXLb5Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3240,7 +3240,7 @@
           "hash": "GP1ZUdl9BcF8oMT0/ErpAA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3252,7 +3252,7 @@
           "hash": "ZzTPMxTAWVPu+y5Icz543w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3264,7 +3264,7 @@
           "hash": "A/tryfKX6omM0MHD7CIMbQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3276,7 +3276,7 @@
           "hash": "ayIVqtvomkQysZh7hXA+Tg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3288,7 +3288,7 @@
           "hash": "NIRHK1qB/QWl2QrBrMuU5g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3300,7 +3300,7 @@
           "hash": "c/hp2kg19YzBG8Tl5289NQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3312,7 +3312,7 @@
           "hash": "yYiQa6Rm+2gSp+AgvUQMoA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3324,7 +3324,7 @@
           "hash": "KNb6DthYh/ODJQmuN8HH6g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3336,7 +3336,7 @@
           "hash": "fUZhatO0WNmR3cunzsuAfQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3348,7 +3348,7 @@
           "hash": "Ck0jpu61ubT37Nezn9m8Dg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3360,7 +3360,7 @@
           "hash": "CibZlE+oEzf7u7qb9BF8gg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3372,7 +3372,7 @@
           "hash": "hPm+XTBB0bafhKmjGtgRXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3384,7 +3384,7 @@
           "hash": "EhmBIlnSaUToziPYNS+WpA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3396,7 +3396,7 @@
           "hash": "EdRSiPPZuQ1grec7Uf4+Nw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3408,7 +3408,7 @@
           "hash": "RzHOFYKa3EDaFroKGPc5VQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3420,7 +3420,7 @@
           "hash": "8nfocgHZKCxeLFo5cpj5KQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3432,7 +3432,7 @@
           "hash": "RdR2mbHEUBMMgGQkVrzTnA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3444,7 +3444,7 @@
           "hash": "XLoiXElmZU7M29sEgb30HA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3456,7 +3456,7 @@
           "hash": "B31jFUbQTUqph835Q3g1Zg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3468,7 +3468,7 @@
           "hash": "/y2/YKitTt26WyJMRhLk4A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3480,7 +3480,7 @@
           "hash": "TM2NRlh4H2ifWVLy5YJHpA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3492,7 +3492,7 @@
           "hash": "lH4kReHypaW/evuyc4pQBw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3501,10 +3501,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.ARCore.Editor.ARCorePathFinder.html",
-          "hash": "5h/710nPCGhsjpKMS6rUqg=="
+          "hash": "H/7tCf1g+cUk9R+ifb0BMA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3516,7 +3516,7 @@
           "hash": "am70nOf/xAl4epwftQgybg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3525,10 +3525,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.ARCore.Profiles.ARCoreControllerDataProviderProfile.html",
-          "hash": "PBxkJ4BnvkkpqGXKeQy0Xg=="
+          "hash": "eu19G1xVEbgHtDx0h5ZI+Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3540,7 +3540,7 @@
           "hash": "K/7ctGqsKKubB1/r/s2Yng=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3552,7 +3552,7 @@
           "hash": "/HGLu5kQex1qlhFnF5KS3A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3564,7 +3564,7 @@
           "hash": "J7dd0cbFi2HkVmUL7WSfIQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3576,7 +3576,7 @@
           "hash": "EvBQ/R6ll/ahDjBiVnDwkw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3588,7 +3588,7 @@
           "hash": "jZvkuOxJNz6XzNNZJNpe9g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3600,7 +3600,7 @@
           "hash": "t1HLGKBZy9N2CtZH8AOPvg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3612,7 +3612,7 @@
           "hash": "lBr2HpbJodccskw+r5RDOQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3624,7 +3624,7 @@
           "hash": "mDBEJmxR1Gtec1NTwy4EXg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3636,7 +3636,7 @@
           "hash": "af8cckp7VwP5YtiBQ+Hk2w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3648,7 +3648,7 @@
           "hash": "XR1PjWGqw60VfXhFmgY6vA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3660,7 +3660,7 @@
           "hash": "OQNFvlOEG2la/h0OLP6EZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3672,7 +3672,7 @@
           "hash": "gktk2OI4ItrL5v5kB2Apog=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3684,7 +3684,7 @@
           "hash": "YPh17n3PmmVBKAbwJPSB9w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3696,7 +3696,7 @@
           "hash": "NG83k1DhIHiRYsLBdzU7XA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3708,7 +3708,7 @@
           "hash": "OWb0ltgUVlwtY0bUNPnu8Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3720,7 +3720,7 @@
           "hash": "ali/opiBOON6U6M309OSIA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3729,10 +3729,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.BaseMixedRealityExtensionDataProviderProfile.html",
-          "hash": "Unb7udFYUNw5F34LHw6V6w=="
+          "hash": "WN98+jYE1liCTBX2OKHJvA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3741,10 +3741,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.BaseMixedRealityExtensionServiceProfile.html",
-          "hash": "xQi8UED9zhGrA1ijo4/V/w=="
+          "hash": "tz5TscHpX7rElS7dmA84mg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3753,10 +3753,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.BaseMixedRealityProfile.html",
-          "hash": "30ssHZ/TqaHUsyPbvQYRlQ=="
+          "hash": "7wdlBgAFQA1iMXHI7KZzQg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3765,10 +3765,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.BaseMixedRealityServiceProfile-1.html",
-          "hash": "2yzhMqeCza2QrqQIwDE5UQ=="
+          "hash": "KL64ZQZTCXI1QX3WMw5TSQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3780,7 +3780,7 @@
           "hash": "+gg91Dgctmb0HoGDClatuw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3792,7 +3792,7 @@
           "hash": "QDhhRogW5qUaeu3thpCv5A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3801,10 +3801,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.BoundarySystem.MixedRealityBoundaryProfile.html",
-          "hash": "O5K79HgU7qDH9bb16VtfEQ=="
+          "hash": "GLrTujq8LWuzovMHUsYWHg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3816,7 +3816,7 @@
           "hash": "ej9lH7UvCJWPGTMDqJ33rg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3828,7 +3828,7 @@
           "hash": "xjFKksCwXtWh3sMvYqX6iA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3837,10 +3837,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.CameraSystem.BaseMixedRealityCameraDataProviderProfile.html",
-          "hash": "54RFGkwcRY6Nsx56RcjhwQ=="
+          "hash": "4r6ILv96+IDInqBcJznlPg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3849,10 +3849,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.CameraSystem.MixedRealityCameraSystemProfile.html",
-          "hash": "v4qrNZAh+6QTDEDGpKlrPw=="
+          "hash": "3F4pl56GZ8N5wTavOrmBeA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3864,7 +3864,7 @@
           "hash": "if1Ie5DDfFjL9wR/86wNBg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3873,10 +3873,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.BaseMixedRealityControllerDataProviderProfile.html",
-          "hash": "ieOuf/yq8t8LTf8NB67xOg=="
+          "hash": "UqDiEXuckDoVu8ogvmP4HQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3888,7 +3888,7 @@
           "hash": "CkVIwN34MtjDToaV3bM30A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3897,10 +3897,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.Hands.BaseHandControllerDataProviderProfile.html",
-          "hash": "0DEOT8iHE2VhwzHhkI60Jg=="
+          "hash": "8yYldYFqQ1/4yjMYNGUZbg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3912,7 +3912,7 @@
           "hash": "F+mPJbyUJc1AbDKIiikBOQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3921,10 +3921,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.Hands.HandControllerPoseProfile.html",
-          "hash": "XcSNI7euzL4vAG2yIchaJA=="
+          "hash": "ejn6d4tjKzEo8Ux34+VioQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3936,7 +3936,7 @@
           "hash": "2rm+MD1AU2fn/EvXWGwBvA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3948,7 +3948,7 @@
           "hash": "A6HkiCYL0kMBvxcDyPUoKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3960,7 +3960,7 @@
           "hash": "ZsOr63jHVq9lXZfdmc673w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3972,7 +3972,7 @@
           "hash": "0nN2sNlW7CKvUWaGbVvJmQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3984,7 +3984,7 @@
           "hash": "4PZR5XR6doo/wO1jWhvKLw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -3996,7 +3996,7 @@
           "hash": "W3djUC5Sd7yw+kYAvEtAnQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4008,7 +4008,7 @@
           "hash": "1/NE7JzU87st61jV8Q/1BQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4020,7 +4020,7 @@
           "hash": "+H8M0ZiooOBCFp9pYgpTgw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4032,7 +4032,7 @@
           "hash": "TLEKJdQYWHb40pmQHuym1w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4041,10 +4041,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.MixedRealityControllerMappingProfile.html",
-          "hash": "B5+wuc+Gud0NNPha2qIS2A=="
+          "hash": "iD/bq17iMN6Z0v/Gx89cbg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4053,10 +4053,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.MixedRealityControllerVisualizationProfile.html",
-          "hash": "Lwm9z2xrjdGdh2FEMnCORw=="
+          "hash": "jgbKBufEIUbJujZunAQ1Qg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4065,10 +4065,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.MixedRealityInteractionMappingProfile.html",
-          "hash": "UMZeFfFv81sRD5b6XGxS6Q=="
+          "hash": "I0vCTQTBKU/z/IXhXC5HKw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4077,10 +4077,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.OpenVR.Profiles.OpenVRControllerDataProviderProfile.html",
-          "hash": "Mf7FZo0BKr7JPpnpHxA+Kw=="
+          "hash": "r+H30nOBCWnq78cWi6b3QQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4092,7 +4092,7 @@
           "hash": "q1rODlXx3uAQ6nnSEzyacg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4101,10 +4101,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.Simulation.Hands.SimulatedHandControllerDataProviderProfile.html",
-          "hash": "pUKT4RcQ90gusb1ta6KGaQ=="
+          "hash": "txASW9HWvZCp5sXSlMhzvA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4116,7 +4116,7 @@
           "hash": "MbeFdgT4pKQQd/KMAUQnXQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4128,7 +4128,7 @@
           "hash": "/up0vIMcDVR3xUzPy3e8eg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4137,10 +4137,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.Simulation.SimulatedControllerDataProviderProfile.html",
-          "hash": "2nD7CiPbrHvqKb8Of+kjYQ=="
+          "hash": "j4tpRUNiBV58/VQyb5+glw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4152,7 +4152,7 @@
           "hash": "g0+vhI1z4h8g2op3cDo+GA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4161,10 +4161,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.UnityInput.Profiles.MouseControllerDataProviderProfile.html",
-          "hash": "r9nqkDJPxtdpXPFMe82Aeg=="
+          "hash": "je4EgjpQrdzODlDMYfKBiw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4173,10 +4173,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.UnityInput.Profiles.TouchScreenControllerDataProviderProfile.html",
-          "hash": "UQ3QwOFy0T6fEAMh4C7oMA=="
+          "hash": "i0Bl0aIe8xdCCPclis8kbg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4185,10 +4185,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Controllers.UnityInput.Profiles.UnityInputControllerDataProfile.html",
-          "hash": "xVdguzw82+JhZH2vyCKUsA=="
+          "hash": "3ubjNZtcs3rdXbZfn69SYQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4200,7 +4200,7 @@
           "hash": "rE/yNdfPQckqDewNPihVow=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4212,7 +4212,7 @@
           "hash": "4CYYy3/r2lXffpkpIn9bsw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4224,7 +4224,7 @@
           "hash": "41lStZvN9/HNFJaNxLuJ2g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4236,7 +4236,7 @@
           "hash": "H+gpRphbf1F3WckdlhX94g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4248,7 +4248,7 @@
           "hash": "BDK0O/QMvtS7iWdbR0mfzA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4260,7 +4260,7 @@
           "hash": "GpeE5ZbWVXE/piXyervcOg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4269,10 +4269,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Devices.InputProcessor-1.html",
-          "hash": "+f63xGZzPEB0kMDcdpGpWQ=="
+          "hash": "VkJ+g32DqVny5MCqQ/4LxA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4281,10 +4281,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Devices.InputProcessor.html",
-          "hash": "/NVixxOiZOOC4PoNX91eRw=="
+          "hash": "ILPKbu+ohaV7wkj+YzdQ3A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4293,10 +4293,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Devices.InvertDualAxisProcessor.html",
-          "hash": "BsUdD++wuUR+HcApweRzWQ=="
+          "hash": "6TiuB3K//dV+hEfF+Ndodw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4305,10 +4305,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Devices.InvertSingleAxisProcessor.html",
-          "hash": "7ynr94lb9nSF4xW2Yd3odQ=="
+          "hash": "VJ/HEeV3vcEauwr3F2X+PA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4320,7 +4320,7 @@
           "hash": "P8NtaCO3PkfeDI6Dw82wdQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4332,7 +4332,7 @@
           "hash": "xnAt98EstIt8+gS0lRkwtA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4344,7 +4344,7 @@
           "hash": "lD6yFk2pFg8+BawCD3MJjQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4356,7 +4356,7 @@
           "hash": "ir23YbfGvPLyCnW+3Ghz7w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4368,7 +4368,7 @@
           "hash": "ZYU0JyBWavO6qB9l9OJT1g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4380,7 +4380,7 @@
           "hash": "9hLe/LHhKOKWr41xsSRpYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4392,7 +4392,7 @@
           "hash": "emRi6MqAvkGlHeNcHGgwjQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4401,10 +4401,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.DiagnosticsSystem.MixedRealityDiagnosticsSystemProfile.html",
-          "hash": "NkoGBN6yQefnqg7OtpaYWA=="
+          "hash": "EkSYv8LdvC3ZgvYkgGahLQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4416,7 +4416,7 @@
           "hash": "BRhtUvlz1vISVfQrYVJVsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4428,7 +4428,7 @@
           "hash": "2QtVSfZqCu3Vxb5k40TQ4g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4440,7 +4440,7 @@
           "hash": "hIUb0h6kTBUCV74qsdVrOA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4452,7 +4452,7 @@
           "hash": "jqZhqt4o8eXhDS74jjS4Dw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4464,7 +4464,7 @@
           "hash": "KeiYZm2+/FW54FczEAhphw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4476,7 +4476,7 @@
           "hash": "8+2S2QSAEaTn6LKF7oSXYA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4488,7 +4488,7 @@
           "hash": "CAAs4k6JtA2ZwJ3ejGhTeQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4497,10 +4497,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.InputSystem.MixedRealityGesturesProfile.html",
-          "hash": "Ymxu51DCNNUubMydcCqbtA=="
+          "hash": "8E3W+bNpgvZfF3yboMpMnw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4512,7 +4512,7 @@
           "hash": "fF5XLTd2N2AeaIVicgHaJw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4521,10 +4521,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.InputSystem.MixedRealityInputActionsProfile.html",
-          "hash": "/vycaxjAq3zkvgb/anBqzQ=="
+          "hash": "SVjZ2PWRJ1XKzlulyJV6ww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4533,10 +4533,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.InputSystem.MixedRealityInputSystemProfile.html",
-          "hash": "o+IepbNDI8nhtdjq2YanQg=="
+          "hash": "FuZ68f2wkynJd8tGaovT0A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4545,10 +4545,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.InputSystem.MixedRealityPointerProfile.html",
-          "hash": "Pv8809lcY/WC79E5o4aK8g=="
+          "hash": "06Cy4021uSaU21OWZx35Lg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4557,10 +4557,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.InputSystem.MixedRealitySpeechCommandsProfile.html",
-          "hash": "XLgTLqyaE8I1/s5zTjrmxw=="
+          "hash": "BmE0F6/uZ1CjnFSW4glwhw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4572,7 +4572,7 @@
           "hash": "5eAvRWrWlIyNUg7c+8G+Wg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4584,7 +4584,7 @@
           "hash": "iZ7x8dJqCd+AntxZowytow=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4596,7 +4596,7 @@
           "hash": "QDDBnFqRpW23Ofc+Pxz0tA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4608,7 +4608,7 @@
           "hash": "HU5o51AUjPO9jbukNLAM+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4620,7 +4620,7 @@
           "hash": "wZt5CQuW5hZoDU2qWy0nDQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4632,7 +4632,7 @@
           "hash": "HtqQQ/h67/auyv1Fox9eIw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4644,7 +4644,7 @@
           "hash": "Ui/XjxsocudyP3Av1PSmjA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4656,7 +4656,7 @@
           "hash": "lX1zAES4iArdX4OlJso5Pg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4668,7 +4668,7 @@
           "hash": "rBGtYTBawPZ9OS9VlfTjYA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4680,7 +4680,7 @@
           "hash": "LybiVWSrMGwU6BmNcqEAsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4692,7 +4692,7 @@
           "hash": "AaCM8SGr7qGRhUCJ3y67AQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4704,7 +4704,7 @@
           "hash": "oel8+rUE/aWNAIGiXguHtw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4713,10 +4713,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.MixedRealityPlatformServiceConfigurationProfile.html",
-          "hash": "vj4eimchjaD+9DWI6K9kYw=="
+          "hash": "EZRNgwAzQyNqEFtiUrIi5w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4725,10 +4725,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.MixedRealityRegisteredServiceProvidersProfile.html",
-          "hash": "UkOKsWHlXYz5gSga5LesDA=="
+          "hash": "RBgk21s25V+Xtn3zSbx2Aw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4740,7 +4740,7 @@
           "hash": "mVkCL/RysujFqkm2tQWOEg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4752,7 +4752,7 @@
           "hash": "SfMbPdaENDev440KjnMi+Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4761,10 +4761,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.MixedRealityToolkitRootProfile.html",
-          "hash": "CfYIdnG2vqbiZnq9kwF+qg=="
+          "hash": "JIAiN1wtuLqGxGk5RPCf6Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4773,10 +4773,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.NetworkingSystem.MixedRealityNetworkSystemProfile.html",
-          "hash": "NQyyUwcAgnFFTESiBZ0ahQ=="
+          "hash": "GXs1xiBy0xadAl0H/MRPFw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4788,7 +4788,7 @@
           "hash": "sYbcLE19KGsQOjhm/6+Dbw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4800,7 +4800,7 @@
           "hash": "mO7Me9+1nnaEG5niz/vNQA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4812,7 +4812,7 @@
           "hash": "Pijes9Zu8BqWsuy1nLH9mA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4824,7 +4824,7 @@
           "hash": "j1D6khDdwJt2RPriXX2ZjQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4836,7 +4836,7 @@
           "hash": "mblh0ZAKU2CcUHgB4kPoHw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4848,7 +4848,7 @@
           "hash": "+rQsTm+rIfd8uTCF7zOh0Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4860,7 +4860,7 @@
           "hash": "Z2bVOwrJzsSio9BfATxFkQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4872,7 +4872,7 @@
           "hash": "lxb2iVLbNlcgfAyZOdV4jg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4884,7 +4884,7 @@
           "hash": "aqwuA2a1OwVNpAiumydYFQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4896,7 +4896,7 @@
           "hash": "fSinXU4KyCO5EWl7pPsJyg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4905,10 +4905,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Platforms.BasePlatform.html",
-          "hash": "MNW8WtsJy4em2M6ZT12AAA=="
+          "hash": "hpC+DgGpvvUEbMM7DyF25A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4920,7 +4920,7 @@
           "hash": "HKoCRb0GQL1bPcYTbDefVg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4932,7 +4932,7 @@
           "hash": "RWjc0ilgeDiG+iekTy2mDg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4944,7 +4944,7 @@
           "hash": "wwneBd0fGLXe/+p5DccjQw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4956,7 +4956,7 @@
           "hash": "C6BK/G7ks6ucMO2zXZ1gug=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4968,7 +4968,7 @@
           "hash": "qQdrYOTzF0Fzo0oAWdOxAg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4980,7 +4980,7 @@
           "hash": "FMnvbwAFnrqfkzk2/RD6kg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -4992,7 +4992,7 @@
           "hash": "lnZunkZtHBVXJ5HtJUMlIA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5004,7 +5004,7 @@
           "hash": "S9HF938Brz73ILv3Fo29aw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5016,7 +5016,7 @@
           "hash": "KnyB3rsOLE7O76dDW4bDCQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5028,7 +5028,19 @@
           "hash": "rBQl5XLBOV4zKitPtzl52Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.Definitions.Platforms.WebXRPlatform.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.Definitions.Platforms.WebXRPlatform.html",
+          "hash": "CRtcXPMCczFARGPOo1v5Zg=="
+        }
+      },
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5040,7 +5052,7 @@
           "hash": "i0hWgp4uZcNLn5Y2lI43MA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5049,10 +5061,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Platforms.html",
-          "hash": "FVgHD4E4EI+wVRJg2hvCKg=="
+          "hash": "xuLolfABCxM7Ksce1KNnaQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5064,7 +5076,7 @@
           "hash": "gLK5Ik1AWaiFcUNkmiObdw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5073,10 +5085,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.SpatialAwarenessSystem.MixedRealitySpatialAwarenessSystemProfile.html",
-          "hash": "h5ibB3TA1wB8pI+sKhVC0g=="
+          "hash": "wazi8xsx9Xtc3ppq+ovw8g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5088,7 +5100,7 @@
           "hash": "UtFDBunF52k59ZbHuPOQDg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5100,7 +5112,7 @@
           "hash": "MwK2MyzCj8+FdEIv1+sFhw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5112,7 +5124,7 @@
           "hash": "9SP1OTkgmgEm+jiT1rqSnw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5124,7 +5136,7 @@
           "hash": "74k1hr/s2K+HdrH8+5PYVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5136,7 +5148,7 @@
           "hash": "2Ddi3HI/4/HzFKghASs8Yw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5145,10 +5157,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.TeleportSystem.MixedRealityTeleportSystemProfile.html",
-          "hash": "gEQ57mxb+7gFIVbCHGiYew=="
+          "hash": "1QpOWnn2QWTh9PgFD/1wCQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5157,10 +5169,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.TeleportSystem.MixedRealityTeleportValidationDataProviderProfile.html",
-          "hash": "LIpA92HMJqYYIeTttzRpGg=="
+          "hash": "m/Q6UdPZ42As7jsY3UFuWg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5172,7 +5184,7 @@
           "hash": "152MHw/xM18+NBHworfVKA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5184,7 +5196,7 @@
           "hash": "bo2WgzvtPKZTADBymJSKDA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5196,7 +5208,7 @@
           "hash": "GEny1UsSDnMAgGNwuy2e1g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5208,7 +5220,7 @@
           "hash": "mlMgzaJi/wiRuuLi8jzBrQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5220,7 +5232,7 @@
           "hash": "4l0ZE2M0lXgmnEQ2oKOkAw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5232,7 +5244,7 @@
           "hash": "NK59rvCgvRcMwumo9b0Aww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5244,7 +5256,7 @@
           "hash": "/tRWgS09R5C6G7NEPzYS7Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5256,7 +5268,7 @@
           "hash": "2RM7brtOnWtswjgt48lZgw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5265,10 +5277,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Definitions.Utilities.Handedness.html",
-          "hash": "05ECLmp0hbDj7XWcim0suA=="
+          "hash": "tsWJbFt3v+cL+1Ez1JWBmA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5280,7 +5292,7 @@
           "hash": "kpRqAO1m2vufVGJKLC3NuQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5292,7 +5304,7 @@
           "hash": "y6VCWgzK/GNBDR8MMMzlEw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5304,7 +5316,7 @@
           "hash": "2b3/f7+sxxCV51xj9K07CQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5316,7 +5328,7 @@
           "hash": "0qp5dF2aXK9d2coKWaVoMA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5328,7 +5340,7 @@
           "hash": "vFU1XQo+PEYP8LENYQ7kgg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5340,7 +5352,7 @@
           "hash": "j3ZWvWANZ2rPyC7tkCdNww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5352,7 +5364,7 @@
           "hash": "OXwLJ9o6VSwz0W7xA9TAfA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5364,7 +5376,7 @@
           "hash": "tGdAP7ZDFdG4sNZkr0f2YA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5376,7 +5388,7 @@
           "hash": "TuuWlfzJlXGnjs8AJylk8g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5388,7 +5400,7 @@
           "hash": "SWoBU0kC6vh2TTBbw+Y5tQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5400,7 +5412,7 @@
           "hash": "F2oFCuCi6i/XTTlc6sLzLA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5412,7 +5424,7 @@
           "hash": "WOL21HpKycVet9Uo4v0o7A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5424,7 +5436,7 @@
           "hash": "IB/6Ys3MmQvt9YCNPWCEbQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5436,7 +5448,7 @@
           "hash": "m0v+lZrsb+PW+Qr3q52Jvw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5448,7 +5460,7 @@
           "hash": "0XQo7TmFnh/BNXuBl/b1bQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5460,7 +5472,7 @@
           "hash": "FnJ7XfQ9/Ikl0Jj3/veqdg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5469,10 +5481,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.DemoCustomExtensionServiceProfileInspector.html",
-          "hash": "DZ275Ad79Zyf47dCS9o9vg=="
+          "hash": "SlHLmJLKpmMqEiQu3uDFcA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5481,10 +5493,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.ChannelPackerWindow.html",
-          "hash": "E00VJL8UhRKrapehxGHKfA=="
+          "hash": "u3TWoUYPaS5qDiLSGJIjmg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5493,10 +5505,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.ClippingBoxEditor.html",
-          "hash": "QrQ9GCDANuEXfjPh/Qb+Qw=="
+          "hash": "qfrX3mi+PJvuOVnWnd9byg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5505,10 +5517,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.ClippingPlaneEditor.html",
-          "hash": "gNKLgswxVOqXUDFL+cPFqQ=="
+          "hash": "pK439d6USg1u/MWxV4vVCA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5517,10 +5529,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.ClippingSphereEditor.html",
-          "hash": "eCb+WZfuvnQx5+oROd8Ojg=="
+          "hash": "+5yNaVrQGZszv0OBW8wtAQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5529,10 +5541,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.ControllerPopupWindow.html",
-          "hash": "BefQVIbrY5Yyx0MMv75JpA=="
+          "hash": "hXWqZK62wjDsikR0ryC9hw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5544,7 +5556,7 @@
           "hash": "fe22Ya94DzhAeF3OYrgwBQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5556,7 +5568,7 @@
           "hash": "Ub+OoPeQwrD8JgYVudv7tw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5565,10 +5577,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Data.Controllers.Hands.HandControllerPoseProfileInspector.html",
-          "hash": "Qdr2bA0yUkaz6pOXOB/hQw=="
+          "hash": "4DEtkcSuntbrgil1Typ4gw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5580,7 +5592,7 @@
           "hash": "9/xTXgf6bNPismfrRsJrXQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5592,7 +5604,7 @@
           "hash": "f0kzWiEyQUvSTt9Tv6+O5g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5604,7 +5616,7 @@
           "hash": "FZx+mPyDga4Uo7jeWc/quw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5616,7 +5628,7 @@
           "hash": "UvRi0y9CI1eHdIuBXi5uYA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5628,7 +5640,7 @@
           "hash": "OUDIXAYYif/4W2xSKqd35A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5640,7 +5652,7 @@
           "hash": "qRZzsngYRkBXSsF1zmkpgA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5652,7 +5664,7 @@
           "hash": "MKpHHWezNqnhZsAapIqDZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5661,10 +5673,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.HoverLightInspector.html",
-          "hash": "VYiL4YvtnpA8fmO3kzTiEw=="
+          "hash": "Wfc4brCIbrwQ5P+dBzFXSQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5676,7 +5688,7 @@
           "hash": "aH1J9UA/u8o/nq3cljt2oA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5688,7 +5700,7 @@
           "hash": "x4ni+mxz2G3EoRYdnkSv6A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5700,7 +5712,7 @@
           "hash": "joIgYwMucT905LfnKaYY3w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5712,7 +5724,7 @@
           "hash": "HLW1SE39C3r4uNVnFRIcng=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5724,7 +5736,7 @@
           "hash": "b5QrTrQDNLlLZf5RFtQ88g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5736,7 +5748,7 @@
           "hash": "CNfCgpdRRAjMPRBSw0WXgg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5748,7 +5760,7 @@
           "hash": "FTp0sxGmqkNNp9RgB35axQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5757,10 +5769,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.MixedRealityToolkitInspector.html",
-          "hash": "60t9eRNKnIhCTZ+xsF8WyQ=="
+          "hash": "KUySH40fgPXtuL4G6uK72w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5772,7 +5784,7 @@
           "hash": "G2hxp82oZeBsa1gDf+sGnA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5781,10 +5793,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.BaseMixedRealityProfileInspector.html",
-          "hash": "WfI6+Q9I4hGYXE5oGyEDlA=="
+          "hash": "wEMrJMkLC/pRfDEwbvVm5w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5793,10 +5805,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.CameraSystem.BaseMixedRealityCameraDataProviderProfileInspector.html",
-          "hash": "5ux7c8mKJUoUCVvGf+7+rQ=="
+          "hash": "GhmmoBTXP+499KQpUwnZLA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5805,10 +5817,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.CameraSystem.MixedRealityCameraSystemProfileInspector.html",
-          "hash": "3bRolEAjOBISoWYCISG+og=="
+          "hash": "CgJHxbk8wwV07GLPpH35ig=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5820,7 +5832,7 @@
           "hash": "aU6UJF1izPo8N5ICZJtwVg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5829,10 +5841,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.DiagnosticsSystem.MixedRealityDiagnosticsSystemProfileInspector.html",
-          "hash": "gdG1J8Dr55IJRv9Qd4idxg=="
+          "hash": "kpXRvH4ipRfytv+Xsx6BSg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5844,7 +5856,7 @@
           "hash": "tfXdaLcYe5XdIh0rq8hDhQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5853,10 +5865,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerDataProviderProfileInspector.html",
-          "hash": "VP6dqf9zsXn2B0HOkxMyOw=="
+          "hash": "QauPVbxzIHrFetsH3nxQcg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5865,10 +5877,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityControllerMappingProfileInspector.html",
-          "hash": "ScxN92qF99/h6/5gSHvlSw=="
+          "hash": "sqSk/7lYd5Gmh6+AP0wQAQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5877,10 +5889,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.Controllers.BaseMixedRealityHandControllerDataProviderProfileInspector.html",
-          "hash": "f1VKIB2iqX5XeikRtXFjKA=="
+          "hash": "+qfuMikYhZcIhTBqVldHKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5889,10 +5901,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.Controllers.MixedRealityControllerVisualizationProfileInspector.html",
-          "hash": "Ilc2SqQ7p6kHChSj3gKUXg=="
+          "hash": "DLBXKdH5Js12NOIXhmGXTQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5901,10 +5913,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.Controllers.MixedRealityInteractionMappingProfileInspector.html",
-          "hash": "AuUtMkVJXBE7KKRwBAp2qw=="
+          "hash": "gPYlP9s4M/oSGHli4Uok9Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5913,10 +5925,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.Controllers.Simulation.SimulatedControllerDataProviderProfileInspector.html",
-          "hash": "08jiHrrpnDYe90SvJpCzyQ=="
+          "hash": "TQC4VVht6gkDVmsH4889JQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5925,10 +5937,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.Controllers.Simulation.SimulatedHandControllerDataProviderProfileInspector.html",
-          "hash": "06t5es1GgY0HDFkKH/5ECw=="
+          "hash": "L7Ak1M/sCI/YHcVccMRtvw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5940,7 +5952,7 @@
           "hash": "bsaeLVkDP72xU88sjP3GGg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5952,7 +5964,7 @@
           "hash": "ZW6qWOPE7EiAJL1PP1risA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5961,10 +5973,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.MixedRealityGesturesProfileInspector.html",
-          "hash": "VO1m4+Wcohc1VqOJpXu8yQ=="
+          "hash": "WTQNVUYOjHVqwepLRlpwTQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5973,10 +5985,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.MixedRealityInputActionsProfileInspector.html",
-          "hash": "bTXPKIcgLRSYYToASmgecg=="
+          "hash": "VdGP6kbPSRWtYmGzMVAUdw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5985,10 +5997,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.MixedRealityInputSystemProfileInspector.html",
-          "hash": "6uM6lWXqZ1oMTY+zbRDahQ=="
+          "hash": "aQMCI9R4ltUi97zzmVOJYw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -5997,10 +6009,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.MixedRealityPointerProfileInspector.html",
-          "hash": "aUqipjvJ3xCr/SdjBf9F2g=="
+          "hash": "QivAjaY7jTT0R0cb7QyHgA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6009,10 +6021,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.InputSystem.MixedRealitySpeechCommandsProfileInspector.html",
-          "hash": "88af2Ax4k5f611qLe7s2dw=="
+          "hash": "t/tVWj6DYqQha4H/c+41HA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6024,7 +6036,7 @@
           "hash": "ooavjbIPHvIG16MxYvhM/g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6033,10 +6045,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.MixedRealityBoundaryVisualizationProfileInspector.html",
-          "hash": "9MfWR33RL9KQ6HRDNmVGIQ=="
+          "hash": "8eW5y6KIFE1t0KAYoCKAsQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6045,10 +6057,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.MixedRealityNetworkSystemProfileInspector.html",
-          "hash": "wDB4F5GqsX3eVxe0ZSqcqg=="
+          "hash": "4KknykdFdq7YhRn57LMqnw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6057,10 +6069,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.MixedRealityPlatformServiceConfigurationProfileInspector.html",
-          "hash": "iLeG0e1HCe4Ni9AWluYmUA=="
+          "hash": "9QKpC6lhKV26uJgLUWvmfg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6069,10 +6081,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.MixedRealityRegisteredServiceProvidersProfileInspector.html",
-          "hash": "OlzndO+x7GjqjlPoEVzsaA=="
+          "hash": "cUiEE2d6GZH6GbxEVucv0g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6081,10 +6093,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.MixedRealityServiceProfileInspector.html",
-          "hash": "sBupfqMuIj10AD5hE55VBA=="
+          "hash": "U7WpNV2BlldJtIlWYW0yLg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6093,10 +6105,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.MixedRealityToolkitRootProfileInspector.html",
-          "hash": "nclF1vxt4FauWoGQltDZRw=="
+          "hash": "jXylkYx31NkomBgC4XmenA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6105,10 +6117,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySpatialMeshObserverProfileInspector.html",
-          "hash": "p1glBqgYpaoVhdGKbcCn5Q=="
+          "hash": "690da4PYH76kyTGVmSFhNQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6117,10 +6129,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySpatialObserverProfileInspector.html",
-          "hash": "fKOprowA4LHDPlD3bvXQuQ=="
+          "hash": "YW/lZCaOYjT07wUpdW96Sg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6129,10 +6141,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.SpatialAwareness.BaseMixedRealitySurfaceObserverProfileInspector.html",
-          "hash": "LKe1T8ZJI8IeHEIfkzHbQw=="
+          "hash": "V/1304mm5b1Lul0XRsBaJg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6141,10 +6153,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.SpatialAwareness.MixedRealitySpatialAwarenessSystemProfileInspector.html",
-          "hash": "6+Wq3YuT6MeH74XQwK3xoQ=="
+          "hash": "T9VU7LSCj91H4/CuQzwcfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6156,7 +6168,7 @@
           "hash": "YuAGusuG+WMKBxfA+YEioQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6165,10 +6177,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.TeleportSystem.MixedRealityTeleportSystemProfileInspector.html",
-          "hash": "h+oZjzz4k9f2GKqwh8LA3Q=="
+          "hash": "LjjPspuIN6SehNT3EfBxvg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6177,10 +6189,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Profiles.TeleportSystem.MixedRealityTeleportValidationDataProviderProfileInspector.html",
-          "hash": "hV1hFWRPj3z2Zm0IVIgKNQ=="
+          "hash": "dNBf7G4y8dkjN0RjbWJN1Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6192,7 +6204,7 @@
           "hash": "ETqwhpLFZa6qnrYsIN2rMg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6204,7 +6216,7 @@
           "hash": "XEmJEB7g8MmNK1UGGmYOBA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6216,7 +6228,7 @@
           "hash": "ICKBEkn4r220yOweg04cWQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6228,7 +6240,7 @@
           "hash": "rfse7P6p7xEmvYvhIw3i3Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6240,7 +6252,7 @@
           "hash": "bVlUO0DfASO9RQAZBz2XDg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6252,7 +6264,7 @@
           "hash": "Bt1TOn45LYV62j25iZjofQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6264,7 +6276,7 @@
           "hash": "l3/V0TacJ5ajFWLllrAywA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6276,7 +6288,7 @@
           "hash": "t5PwvjndNMDrMcVRK6aO6A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6288,7 +6300,7 @@
           "hash": "oQK2ctedwsE5ZjDT5mAZFA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6300,7 +6312,7 @@
           "hash": "02Ep+A7mg7OSlMfJlG1cQQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6312,7 +6324,7 @@
           "hash": "+EYm9+3jY4tVKWA9C/UD/Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6324,7 +6336,7 @@
           "hash": "Z1vH/WhY0hXQxMtcbXVT7g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6336,7 +6348,7 @@
           "hash": "sp0dsGJ9l8TPKA+ReAvSlQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6348,7 +6360,7 @@
           "hash": "oNjg1++TDxjzzLkvX/ifTw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6360,7 +6372,7 @@
           "hash": "sl/S0aUVaqkLUYTAKxyyQA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6372,7 +6384,7 @@
           "hash": "CsBxo4JAdYOnwLAdGiRIJQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6381,10 +6393,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.SystemTypeRepairWindow.html",
-          "hash": "TNXlBXPBrFboUfloUP2nuw=="
+          "hash": "AIKkssIaC1sdZhqeJ5mZkQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6396,7 +6408,7 @@
           "hash": "EtOncuPFKyZbTtTBWxBnbw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6408,7 +6420,7 @@
           "hash": "UW+UgG2Q669tp2rIAm1d2g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6420,7 +6432,7 @@
           "hash": "Uw3BbQtkf7efZ3JE3pGsBA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6429,7 +6441,7 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.AutoSceneSwitcher.html",
-          "hash": "lFx8MMQ6vWbKiaHbn0cy0A=="
+          "hash": "gFkdxuEGKvK/zrMBnZbOVA=="
         }
       },
       "is_incremental": false,
@@ -6444,7 +6456,7 @@
           "hash": "zD9JKdkIYv5rd8LBZM70Og=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6453,10 +6465,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.CanvasEditorExtension.html",
-          "hash": "3u18xOkcP+tBxovbDgrySA=="
+          "hash": "GTxep/FqZlkb62BWuRv8/Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6468,7 +6480,7 @@
           "hash": "70zrryVJRZhTqVVq1G/USg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6480,7 +6492,7 @@
           "hash": "w1d04MSVNCmgiVCNBApeog=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6492,7 +6504,7 @@
           "hash": "s2utqN59fnldO4rUoht8Sw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6501,10 +6513,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.Lines.DataProviders.BaseMixedRealityLineDataProviderInspector.html",
-          "hash": "dVNj4N07UA57dcSZLoreCA=="
+          "hash": "c2/Zb69LuPlPTKIFVhu80w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6513,10 +6525,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.Lines.DataProviders.BezierDataProviderInspector.html",
-          "hash": "edI/qjg137tgpnBt2l++HQ=="
+          "hash": "3RAY1DERhW3lE8u1ANYHeQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6525,10 +6537,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.Lines.DataProviders.EllipseLineDataProviderInspector.html",
-          "hash": "JGMtIGv0wEd5Soz7MPnKxg=="
+          "hash": "kyu9zVFi0AjrWM5ikU2QUQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6537,10 +6549,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.Lines.DataProviders.ParabolaPhysicalLineDataProviderInspector.html",
-          "hash": "r/10nICWbV2xP5m7W/4dSw=="
+          "hash": "57juO1NykdC8iF46XGPNvw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6549,10 +6561,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.Lines.DataProviders.ParabolicConstrainedLineDataProviderInspector.html",
-          "hash": "eH5+VOQ3N2HIXD+H34LPgA=="
+          "hash": "BISMCZ6B9Z7T/1Dhb2VvXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6561,10 +6573,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.Lines.DataProviders.RectangleLineDataProviderInspector.html",
-          "hash": "sEcLcOkyz1YqBQipHgQ49Q=="
+          "hash": "yXbR4R7fP+ePI8de0pnvyQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6573,10 +6585,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.Lines.DataProviders.SimpleLineDataProviderInspector.html",
-          "hash": "EcgXuLFntlmPF8b6oxlfCA=="
+          "hash": "C7FIjH2i0YYGnmdauVfzOA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6585,10 +6597,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.Lines.DataProviders.SplineDataProviderInspector.html",
-          "hash": "UudUbZPL0+4rk9DAUdZG2Q=="
+          "hash": "0lVY/o8T95tFQ9t3dscL8A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6600,7 +6612,7 @@
           "hash": "7oPd7pU9lwWqGosBbNTrVw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6612,7 +6624,7 @@
           "hash": "yRldjTXtjsA4cxJiGvl7mg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6621,10 +6633,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.MixedRealityServiceWizard.html",
-          "hash": "4JNpaJwJpiXzXGefP2TWEA=="
+          "hash": "FIWsHqDOc9Irb9rGn4UdYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6636,7 +6648,7 @@
           "hash": "AHATB1wnmUWao9b1K5m/HA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6645,10 +6657,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkSettings.html",
-          "hash": "zcx4drZ8HQ67K7abIf729w=="
+          "hash": "p0tXSJoCiRCmFF59wZEqCA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6657,10 +6669,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkSettingsInspector.html",
-          "hash": "jWKOHz/eCSHnmHaUmwcjNA=="
+          "hash": "douNAa13i4tjhetqQQWOMA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6672,7 +6684,7 @@
           "hash": "9bqQb33zJjWh5dr922+ukg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6681,10 +6693,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Editor.Utilities.SymbolicLinks.SymbolicLinkerWindow.html",
-          "hash": "FZYKA+ww4R3aiQqTI+eZJw=="
+          "hash": "bjM7SBFscjUj96EwYin1Wg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6696,7 +6708,7 @@
           "hash": "BNlS8HdjgP/D04O35aMkvA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6708,7 +6720,7 @@
           "hash": "t6p1IUT46NUanImJRwFrUw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6732,7 +6744,7 @@
           "hash": "vMJwqTXYkq4xAh9XZPdvWA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6741,10 +6753,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Etee.Editor.EteePathFinder.html",
-          "hash": "ps3Y/pAVcxUwW4vcyL5BWg=="
+          "hash": "hm2y7HMj7n45pSk/IO4muQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6756,7 +6768,7 @@
           "hash": "RTsFN8QmZ6FKRMmQxONhfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6765,10 +6777,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Etee.Profiles.EteeControllerDataProviderProfile.html",
-          "hash": "NAoQEh0Jtzi+rD6o1O6wsg=="
+          "hash": "47SM3etDe0IuRXR85VQegQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6780,7 +6792,7 @@
           "hash": "Imyn7lkLfv2916o5IS036A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6792,7 +6804,7 @@
           "hash": "NZCelTdstmR8e1DpCRu9Gw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6804,7 +6816,7 @@
           "hash": "BMMDSNsWtKj16wlWGjaSgA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6816,7 +6828,7 @@
           "hash": "OaHlzZnRMUB/FGfkh6Qd5g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6828,7 +6840,7 @@
           "hash": "BadasJhvWNuexphx7kNBwA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6840,7 +6852,7 @@
           "hash": "No9BDO5RQofIXsu0oQPZdg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6852,7 +6864,7 @@
           "hash": "AsLFOIqLe8swDbG713Q6iQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6864,7 +6876,7 @@
           "hash": "GyqWTGYmMiTeXC3DE9G6VA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6876,7 +6888,7 @@
           "hash": "viw2k1ZAjzHGDC8Do/9jAA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6888,7 +6900,7 @@
           "hash": "MOLqrdwxmtCDcCQJSMgRYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6900,7 +6912,7 @@
           "hash": "hkHDOJimAdx+kd0rAIHMVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6912,7 +6924,7 @@
           "hash": "VTizy3iH48qLFHntazs4YQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6924,7 +6936,7 @@
           "hash": "MbtswNCKbGJYY+9Q4x0v/A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6936,7 +6948,7 @@
           "hash": "0A+TZr2ErgNQJwYE4cou6w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6948,7 +6960,7 @@
           "hash": "1qml48BtcuDKEaIUwY6fuA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6960,7 +6972,7 @@
           "hash": "gVFmxkaMubHihx2neHgdsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6972,7 +6984,7 @@
           "hash": "rnOhJZdtVxuywpEM4l5MFA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6984,7 +6996,7 @@
           "hash": "u3zheYVxfhiADYFTzWEEIA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6996,7 +7008,7 @@
           "hash": "71jDcmDIH3Z58jkAgWzqEQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7008,7 +7020,7 @@
           "hash": "ALd4VZ9DUEPl6Hdpqmd13Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7020,7 +7032,7 @@
           "hash": "J4uc85mQ1uDqg261/d7wDg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7032,7 +7044,7 @@
           "hash": "Yn+Vk0a8Nb5u2MYUvE7T7w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7044,7 +7056,7 @@
           "hash": "7FM+MtAq1iCVNzFgXfzfJQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7056,7 +7068,7 @@
           "hash": "y58h3ZmTbOAMCum8MHGugA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7068,7 +7080,7 @@
           "hash": "PPUkzMoHbTJmQKbze+CdSw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7080,7 +7092,7 @@
           "hash": "HB/1HxnhREQyVBbD+v/gqA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7092,7 +7104,7 @@
           "hash": "RAGUyVhSruiOTPTuhi2rng=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7104,7 +7116,7 @@
           "hash": "44OxTf+SqHNBUAIt2tJwTw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7116,7 +7128,7 @@
           "hash": "GyTsTDeZBigpQpUlQoLlgA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7128,7 +7140,7 @@
           "hash": "KcoJU6LsExOpd8+xnlcOHA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7140,7 +7152,7 @@
           "hash": "tpvEjKjitt1z1QFmilF+OQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7152,7 +7164,7 @@
           "hash": "LkatvB/PhxIFxbPNc7Kh1Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7164,7 +7176,7 @@
           "hash": "9q8rElN6AxUeYk47rJXqww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7176,7 +7188,7 @@
           "hash": "f5Z5TtY6735Gr7aqegZAKg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7185,10 +7197,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Examples.Demos.CustomExtensionServices.DemoCustomExtensionServiceProfile.html",
-          "hash": "17nVjOnEJFGdKvZ1XPT6Kg=="
+          "hash": "PS1OMpTRYfTuSFfOhHG9pA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7200,7 +7212,7 @@
           "hash": "KYU2Sm1S/7r58sHE6nllvw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7212,7 +7224,7 @@
           "hash": "4tnghKDbxAvRPwNYCAfI6A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7224,7 +7236,7 @@
           "hash": "CkxUOkaDbIfAy+bKnflKZQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7236,7 +7248,7 @@
           "hash": "5CMFqMyKhn/vay7uYgbn5Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7248,7 +7260,7 @@
           "hash": "g6xjgov1Vk+G4SABM9W4wQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7260,7 +7272,7 @@
           "hash": "2Sk+5cj6b1XtTe1GYbIShA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7272,7 +7284,7 @@
           "hash": "tJRw8VWmdhQiJxnt5sTXIw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7284,7 +7296,7 @@
           "hash": "D347Sfmg9GcapfFAq6YGAw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7296,7 +7308,7 @@
           "hash": "W8Lfp4s2Lz3nyJ6zfdsxPA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7308,7 +7320,7 @@
           "hash": "42bRRSdRfT9fWw3MxsybzA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7320,7 +7332,7 @@
           "hash": "xhXwwJMQHoPZju5lopiIQw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7332,7 +7344,7 @@
           "hash": "qQyrNEjtatr8L+ZUz0OyNg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7344,7 +7356,7 @@
           "hash": "QbNAI9+GXZSE5lWtseFM0g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7356,7 +7368,7 @@
           "hash": "Ss/0w+GxDPzSPETG+WNDNg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7368,7 +7380,7 @@
           "hash": "0AG1gHbkar2oOuFVDAdgRA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7380,7 +7392,7 @@
           "hash": "F0B3iKi3PjpQrqNjywixFw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7392,7 +7404,7 @@
           "hash": "QXk+NNZUAwwIypBKGmstVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7404,7 +7416,7 @@
           "hash": "mIlbltNahvMoxGPVJ/GC5g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7416,7 +7428,7 @@
           "hash": "ZhJ+MR+WGpi5WFZkAMhOGQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7428,7 +7440,7 @@
           "hash": "lasf1QbQq6pLAUfZ0Er3Yg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7440,7 +7452,7 @@
           "hash": "Xoi67kERM49MwNUnrnF9KA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7452,7 +7464,7 @@
           "hash": "79oIx8HphSk2BjOyrmqHpA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7464,7 +7476,7 @@
           "hash": "bdKO5yUcxH0LieQLLQIi0w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7476,7 +7488,7 @@
           "hash": "aoJ57yKjJtGyO1mjq++M6w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7488,7 +7500,7 @@
           "hash": "8B1Y9lWJB2DPpCyBso9ebg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7500,7 +7512,7 @@
           "hash": "IXSDkb5gaL7BbTmPadpIzw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7512,7 +7524,7 @@
           "hash": "NLm6X8PkrqyJ5E90IZNo7A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7524,7 +7536,7 @@
           "hash": "aij2ir6Za0gC1LOOZeHMbQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7536,7 +7548,7 @@
           "hash": "exBvH7DrOIWvTB6oRQjBkw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7548,7 +7560,7 @@
           "hash": "1d/HlfLi9kB2LJWfHaTBlw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7560,7 +7572,7 @@
           "hash": "6WGTrLtET9DIEFDz082ShA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7572,7 +7584,7 @@
           "hash": "FUHaiKMhp491HwkcSnYmHg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7584,7 +7596,7 @@
           "hash": "gSDFFwWGth+mYyOmwYcHDQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7596,7 +7608,7 @@
           "hash": "Uhtp3C20dct/Jpx2hEf5Bw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7608,7 +7620,7 @@
           "hash": "ilguGNzIAtD5mw8y4gNtMA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7620,7 +7632,7 @@
           "hash": "Z1TDOJo8HGjTphInEgeZYQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7632,7 +7644,7 @@
           "hash": "aju3MojL1nSnIMelU7sXzA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7644,7 +7656,7 @@
           "hash": "LsJklAJwIrVVRIl4gLOwyw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7656,7 +7668,7 @@
           "hash": "4r6tR95kM2I2lMx9XqqveQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7668,7 +7680,7 @@
           "hash": "EdMLpe3SmTO1yUBurgr2ew=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7680,7 +7692,7 @@
           "hash": "T1ZP+eXTF0HW5EColPXChA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7692,7 +7704,7 @@
           "hash": "HsBqK4OLm/yJB1VHyo0gxQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7704,7 +7716,7 @@
           "hash": "uY582SUYTA4cxGZU8yxEDw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7716,7 +7728,7 @@
           "hash": "AWiAfhqTWpEDuFMAX4qAEQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7728,7 +7740,7 @@
           "hash": "aFQupYDcGc7fkOXKYgzHuw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7740,7 +7752,7 @@
           "hash": "9Sc1+5pS3mZNHsHZAhpxIQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7752,7 +7764,7 @@
           "hash": "BUJC0Vs8bcXxT8D160nl+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7764,7 +7776,7 @@
           "hash": "d1cq72wTUSgNloMmsZKlLg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7776,7 +7788,7 @@
           "hash": "wZ+XfVMJmY1gU7ssE6R5pw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7788,7 +7800,7 @@
           "hash": "DuPDDs1epVT96VLeJBeKyQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7800,7 +7812,7 @@
           "hash": "YEH2MWYGRYApUjXuJM3uAw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7812,7 +7824,7 @@
           "hash": "DEKAJJwKBv+3WogFISQC1Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7824,7 +7836,7 @@
           "hash": "27gFrycKabZ1e8Bs+o5jBA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7836,7 +7848,7 @@
           "hash": "hYM5ao1k/Tl6OayekUyXZQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7848,7 +7860,7 @@
           "hash": "3OZQzMGWN584QAJu42mYSw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7860,7 +7872,7 @@
           "hash": "bY/nmwybi9tH0rynr92ddA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7872,7 +7884,7 @@
           "hash": "x85GUgcFtZjnqDHhPZ4h7g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7884,7 +7896,7 @@
           "hash": "Q40oXueQZi/VA4Y8l9r6hQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7896,7 +7908,7 @@
           "hash": "PoqP6MJVY+safN6+PNuqRg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7908,7 +7920,7 @@
           "hash": "iS37OSiImEMj/qIlcG/DSg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7920,7 +7932,7 @@
           "hash": "zZS2JI3DRC9JpkqaCPzGxg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7932,7 +7944,7 @@
           "hash": "rVW2R+PdVmmLBR9mkqvotQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7944,7 +7956,7 @@
           "hash": "awZaBxiD1GOGSpOFc+DxEA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7956,7 +7968,7 @@
           "hash": "5+ut7mfwsBVbykqL4+HZxA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7968,7 +7980,7 @@
           "hash": "fknkoAgkBo80rWkog8d76w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7980,7 +7992,7 @@
           "hash": "+TN8EF8aFkGB5ljdqAwjvg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -7992,7 +8004,7 @@
           "hash": "7pgvuDQFcwHVJrJ9ESdV5w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8004,7 +8016,7 @@
           "hash": "PlV3gL/nqDF0ya0pCksUfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8016,7 +8028,7 @@
           "hash": "K8vSeSOU3iwAo8nYiYF3CQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8028,7 +8040,7 @@
           "hash": "49aH8xSP7y6iWU4CoIcUrQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8040,7 +8052,7 @@
           "hash": "TkDkKY2ecRSS4MeqHyg4IQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8052,7 +8064,7 @@
           "hash": "gCInoW2XWxk02ewNLuHtxg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8064,7 +8076,7 @@
           "hash": "Y/IpISDR1KOIk5y3w4PtSA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8076,7 +8088,7 @@
           "hash": "izYz8F675s52H94DyvwzSQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8088,7 +8100,7 @@
           "hash": "ZyXIjZZmfFrTyD8nnwfo+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8100,7 +8112,7 @@
           "hash": "HzAamL7aeZDiqeFzhmlHBQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8112,7 +8124,7 @@
           "hash": "/MwlokRwQCM40SaP0Dobyw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8124,7 +8136,7 @@
           "hash": "K7x88hZq/WXcQSWqAVlhXQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8136,7 +8148,7 @@
           "hash": "u+rQlTj8FYyEeT+2yNCWEA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8148,7 +8160,7 @@
           "hash": "8912rTgyQ2HtRp7MRspyCQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8160,7 +8172,7 @@
           "hash": "DfDwgkTvkDWI2N79BtZP4w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8172,7 +8184,7 @@
           "hash": "geiEMPwcT3A4mwgKfrNpXg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8184,7 +8196,7 @@
           "hash": "RZxd9g3L4fhO2aLfllsqvA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8196,7 +8208,7 @@
           "hash": "4KU+8haZwQuLji8kZ3nPLw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8208,7 +8220,7 @@
           "hash": "5UiIpLeHDNVL/GhekUzvsA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8220,7 +8232,7 @@
           "hash": "18ou3FOgVv+3VeOO3BWJUQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8232,7 +8244,7 @@
           "hash": "H/Tvzp/RfSHYUq/hjFo8iA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8244,7 +8256,7 @@
           "hash": "AMAJwsm7aQ1a4r9d4nZb/w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8256,7 +8268,7 @@
           "hash": "1whKGaCUoPgHSa3oGoOPoQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8268,7 +8280,7 @@
           "hash": "EtU2lmLnyk2nTLeKZH1vOQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8280,7 +8292,7 @@
           "hash": "9xPs5b8JgacIUU1f6YM5ZQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8292,7 +8304,7 @@
           "hash": "H28sHnjrHyYORT7JdOYbkw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8304,7 +8316,7 @@
           "hash": "p1fnOLB+q+OQLgEhcpOliw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8316,7 +8328,7 @@
           "hash": "C2DFNvnEaMU6LKAnZ+C2mQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8328,7 +8340,7 @@
           "hash": "fCLEMjMrgTs+dw0GnQEWSQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8340,7 +8352,7 @@
           "hash": "neUxSE5md2BOStBLikcsAQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8352,7 +8364,7 @@
           "hash": "TD1/XmlkGqqFZZC06IzVvA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8364,7 +8376,7 @@
           "hash": "N9ud226COECsXFqYSFpnjg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8376,7 +8388,7 @@
           "hash": "NIdQRpgS+hcx2XRq0OAU/w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8388,7 +8400,7 @@
           "hash": "YZ9g+zA+a+wvoVEmqRyyNw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8400,7 +8412,7 @@
           "hash": "hfG/Ua3ewzfXvO6ujcmopg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8412,7 +8424,7 @@
           "hash": "5AvcPDQ9yQIQ2NEMEXSf4A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8424,7 +8436,7 @@
           "hash": "o/z48PtlNeGWD7P3SupCsA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8436,7 +8448,7 @@
           "hash": "Su71/b8ITBe9FyV47Otq8A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8448,7 +8460,7 @@
           "hash": "1LbqnjMtfvBZukZ+/XDlfg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8460,7 +8472,7 @@
           "hash": "vJ2Jxl2Xkmdv6thdcAPfLQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8472,7 +8484,7 @@
           "hash": "vWRcvKeLWt5eh2C1bBNZog=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8484,7 +8496,7 @@
           "hash": "x324f4w87RfQ0rMWOOvGgQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8496,7 +8508,7 @@
           "hash": "JM35ac7eqZVZpmJitRovMg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8508,7 +8520,7 @@
           "hash": "SvnXbbDDWrHmLgLVeWziVg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8520,7 +8532,7 @@
           "hash": "wcbqWEXfXlHdojBQFAISZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8532,7 +8544,7 @@
           "hash": "B3MetSJMR8KaTIO/Rz67JA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8544,7 +8556,7 @@
           "hash": "CBkmAJ/NW4YfmOPXbIhlSw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8556,7 +8568,7 @@
           "hash": "fumeO3W5HKxSJ1pkoniSbg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8568,7 +8580,7 @@
           "hash": "ihLW/p6+orvvqSceQ+/atw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8580,7 +8592,7 @@
           "hash": "dUJ/CMLv7kHmXYb14AT6SA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8592,7 +8604,7 @@
           "hash": "coFYeqwx6yt2HtwOy7SVyA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8604,7 +8616,7 @@
           "hash": "V30pERAwmpcYH2e60QAUQQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8616,7 +8628,7 @@
           "hash": "1Q7CyIgq/swlRGMNfdrSMQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8628,7 +8640,7 @@
           "hash": "k/ozpxIj4e5CoNpW8IsCzA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8640,7 +8652,7 @@
           "hash": "moEx94Kq7kJ9PCI/UwauAg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8652,7 +8664,7 @@
           "hash": "xcrgzwAukkfco4Gk2npeDA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8664,7 +8676,7 @@
           "hash": "hBr6xrbivjpZogxxIC87Hg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8676,7 +8688,7 @@
           "hash": "2vHD0X4GgUteKKrmbQpdPQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8688,7 +8700,7 @@
           "hash": "UzcfZtSl3+F3oLn09MFLQw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8700,7 +8712,7 @@
           "hash": "fqumbenuZCEc33ZydJ7ocg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8712,7 +8724,7 @@
           "hash": "aRIvVq65JyuLWtpXRPs/oA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8724,7 +8736,7 @@
           "hash": "uatbumCdEwpAwcoTP+JYxg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8736,7 +8748,7 @@
           "hash": "qor9hdpL7Vd1PfZs5Rg1qg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8748,7 +8760,7 @@
           "hash": "zsPXX6rCWTgM/OSFy6k4Ig=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8760,7 +8772,7 @@
           "hash": "uq3lxymQzv2bUgi6OtdYIw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8772,7 +8784,7 @@
           "hash": "NoWFa+IcIrnAWHKag7wwUw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8784,7 +8796,7 @@
           "hash": "sN5VEYdw26DgaXQUeGZ/Xw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8796,7 +8808,7 @@
           "hash": "hAiyLq1RQK0R69C8Vw287g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8808,7 +8820,7 @@
           "hash": "RnUzGcXiohtbMnrm57cW9Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8820,7 +8832,7 @@
           "hash": "QYZtU6fkT7ttlPHAGBwQ0w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8832,7 +8844,7 @@
           "hash": "G3tCuqlJ98BR3pNUxCbsHw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8844,7 +8856,7 @@
           "hash": "bEExgyT//hFt2pZhbWFCfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8856,7 +8868,7 @@
           "hash": "h+h7iVXhYxN6Yyn7h7rC4Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8868,7 +8880,7 @@
           "hash": "iwFOrmjCusuXg/+d3WK/ZQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8880,7 +8892,7 @@
           "hash": "lbklyxA9svSbvx9cAjKldQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8892,7 +8904,7 @@
           "hash": "kDbu6AsKrbwD0MlFU+RtFA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8904,7 +8916,7 @@
           "hash": "fTp2XxJ9izxVmmm+Cbj8Pg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8916,7 +8928,7 @@
           "hash": "2M3zRw2PJEA3VEkLuzSoPw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8928,7 +8940,7 @@
           "hash": "YJHZTjclI+aOQPY39O6aAg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8940,7 +8952,7 @@
           "hash": "ZNUobvcwC1cjusUcV62J9g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8952,7 +8964,7 @@
           "hash": "EBg8Nh5hBSpgHQ3k3wHzUQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8964,7 +8976,7 @@
           "hash": "eoM+elbY11Vk0TWE/t490A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8976,7 +8988,7 @@
           "hash": "hQatlX3HXIF+kdF0NGFp5A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -8988,7 +9000,7 @@
           "hash": "8WCP3WlUe9W5ISk+1kNVVQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9000,7 +9012,7 @@
           "hash": "loTkb+irx9PV0C1KdFd6lQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9012,7 +9024,7 @@
           "hash": "CsunB0PrhgTZzEOBZyMW+w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9024,7 +9036,7 @@
           "hash": "62jJJ1JI5ps/rbb3dWKI7g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9036,7 +9048,7 @@
           "hash": "lXKFV0bUNYnOoA82furXLA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9045,10 +9057,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Lenovo.A6.Profiles.A6ControllerDataProviderProfile.html",
-          "hash": "94bR86h8V3UT2fFbkglJcQ=="
+          "hash": "OyjRbBq5cHWQHv+svxI+Ow=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9060,7 +9072,7 @@
           "hash": "Zzk4ts2aFDhnlPG7Q4MSmw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9072,7 +9084,7 @@
           "hash": "2FX7csQhAb47tF02Mt0HPA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9084,7 +9096,7 @@
           "hash": "6bPJdkO0iO/5LRfkH4skbg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9096,7 +9108,7 @@
           "hash": "DlaXeAhEJgadkNEYbEyJiw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9108,7 +9120,7 @@
           "hash": "iAjdtnQJJcmRPM6Uqa6wIw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9120,7 +9132,7 @@
           "hash": "uOVwWISDNue5iOkAYIrcRw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9129,10 +9141,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Lenovo.Editor.LenovoPathFinder.html",
-          "hash": "8ZgJFABxVoFjE96mTw8TQQ=="
+          "hash": "4tFXSYA5s2cQnBSNXjPmKA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9144,7 +9156,7 @@
           "hash": "pjbfyQmhQmpYil/fUyGPAA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9156,7 +9168,7 @@
           "hash": "zmYD/Ruh7f1Y+wy6M56CwA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9168,7 +9180,7 @@
           "hash": "0ViF+lbKoKICx7VRqsCOhg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9180,7 +9192,7 @@
           "hash": "PgFf4bpxR9QZqIvTLSB6Aw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9189,10 +9201,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Lumin.Editor.LuminHandControllerDataProviderProfileInspector.html",
-          "hash": "FWpFy6obfe5U31oXZhzbOw=="
+          "hash": "FBKSSirONF+weFLTK3NOfA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9201,10 +9213,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Lumin.Editor.LuminPathFinder.html",
-          "hash": "e9oz/UuvYdkB10zJRvzX6Q=="
+          "hash": "ul7uQX2loHvIT3rkOlz6Pg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9216,7 +9228,7 @@
           "hash": "PwJNHRae5A9Bsdz8UkJcow=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9228,7 +9240,7 @@
           "hash": "9wPYax9fUrngI1KJ81TLvQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9240,7 +9252,7 @@
           "hash": "x5yvE4cLg6r2Tdj8rCJzdA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9252,7 +9264,7 @@
           "hash": "4fxM+GJsvROwyVgS3zpgNA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9261,10 +9273,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Lumin.Profiles.LuminControllerDataProviderProfile.html",
-          "hash": "fiMlOO6ipKsbglc9NDwJ8g=="
+          "hash": "15DtoJUPj0jfbszuJCBknA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9273,10 +9285,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Lumin.Profiles.LuminHandControllerDataProviderProfile.html",
-          "hash": "dP8aGMj0R9cHaV6467PnQw=="
+          "hash": "WiEJGWFXZs+RHkfbqXLIsA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9285,10 +9297,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Lumin.Profiles.LuminSpatialMeshObserverProfile.html",
-          "hash": "2J/P6VwdTsdmvuOsejT36A=="
+          "hash": "2gwcFQ7XNPdT3Om0/38OEA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9300,7 +9312,7 @@
           "hash": "QNPnHagQnmQV3JUbMbyKsQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9312,7 +9324,7 @@
           "hash": "SVnZckG1nYPymOlQ2MVdZw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9324,7 +9336,7 @@
           "hash": "LQvrYawO8+T0iSz7u+uDIQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9336,7 +9348,7 @@
           "hash": "k4gFcdHjeSO/9KPW9Ktu+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9348,7 +9360,7 @@
           "hash": "7GUSzU+F8+aOC1+n2/P64A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9360,7 +9372,7 @@
           "hash": "vu2O6eOUcAIJwDY2tHtdcg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9372,7 +9384,7 @@
           "hash": "zetMsngQJub4ZDyhSo+xVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9384,7 +9396,7 @@
           "hash": "34efLrv495ilg60sgg0IZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9396,7 +9408,7 @@
           "hash": "EUS0nVerNHV4UkQHs2IY3Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9408,7 +9420,7 @@
           "hash": "9Ewd71rcIP3gMGiSAHir9Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9417,10 +9429,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Nreal.Editor.NrealPathFinder.html",
-          "hash": "KyXhG11GsPReCgeUFxOvQA=="
+          "hash": "AhjlC36Dv+lONGjRYFNyZg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9432,7 +9444,7 @@
           "hash": "bNI6K/TJ8Re0UEVYrvL5lg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9441,10 +9453,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Nreal.Profiles.NrealControllerDataProviderProfile.html",
-          "hash": "+WhQNKAEeNE4IZXfVC0+aA=="
+          "hash": "PLofXHIDvjdu5ZT4Enl9+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9456,7 +9468,7 @@
           "hash": "Oz+uVwsaQUFWiI8VeIQcdw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9468,7 +9480,7 @@
           "hash": "bH8vHrEKlu+Bo7ltzq46xg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9480,7 +9492,7 @@
           "hash": "wbizoefrS3R4eKeip8+Ruw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9492,7 +9504,7 @@
           "hash": "QBa2U07Zk+PY7+jHBbLRHA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9504,7 +9516,7 @@
           "hash": "T6ztOVgMdJ4g/Co23U6++A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9516,7 +9528,7 @@
           "hash": "yQdT96y6Vseqz7TAUaDfcw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9528,7 +9540,7 @@
           "hash": "sPMFnXiSnimym6mGIfpMeg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9540,7 +9552,7 @@
           "hash": "5bM7byueTbfnQWRiGyDCiA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9549,10 +9561,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Oculus.Editor.OculusHandControllerDataProviderProfileInspector.html",
-          "hash": "NC0gCWZ3/fZ/Opl5yQZv8A=="
+          "hash": "VWkUA65z/HoFzx0jK44iJA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9561,10 +9573,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Oculus.Editor.OculusPathFinder.html",
-          "hash": "1kuO4rB8a9jhwYvpbQcNSw=="
+          "hash": "r4YD3lAnvnQTw4C2qX5Anw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9576,7 +9588,7 @@
           "hash": "PP54UjseXsu8rFm4ANZzeQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9588,7 +9600,7 @@
           "hash": "g7LY/rTxRYV+b3My0ARE0A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9600,7 +9612,7 @@
           "hash": "oiRU/3oG4aWz8c0kyL/ykQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9612,7 +9624,7 @@
           "hash": "a7M9l+zh048f4toibt1xAg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9624,7 +9636,7 @@
           "hash": "O/cZc8CmyV7c/QuFF6AHFg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9636,7 +9648,7 @@
           "hash": "2kKWHXxMxTjp317xWmywgQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9648,7 +9660,7 @@
           "hash": "5ut9ptRLg0wac+N/yUP/zA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9660,7 +9672,7 @@
           "hash": "TvFNJKFfn1Rxo+Ej63hrWg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9672,7 +9684,7 @@
           "hash": "7Utty9RASXD1ZbIYGGzRUA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9684,7 +9696,7 @@
           "hash": "MG+6vZg5ECyrJKNMAjhyfg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9696,7 +9708,7 @@
           "hash": "u/bqYOU07hga/ntIi9hzFQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9708,7 +9720,7 @@
           "hash": "9dkWuyPS7Ol55CZpPgkToQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9720,7 +9732,7 @@
           "hash": "qvfkxZvuqFHU76/L5MaUxg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9732,7 +9744,7 @@
           "hash": "FCJBvy7xEY2HjnHRqdEFtQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9744,7 +9756,7 @@
           "hash": "vMrAoB6WY2yvHlymxus/Cw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9756,7 +9768,7 @@
           "hash": "Qc7ko9MGTLdN8CXyxonokw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9768,7 +9780,7 @@
           "hash": "+86rpwM0gaIwhbtXeyrlJw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9780,7 +9792,7 @@
           "hash": "idAsBLEujdl1mzExfwP89A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9792,7 +9804,7 @@
           "hash": "pRDkRVqHbraVm8GDK3VvbQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9804,7 +9816,7 @@
           "hash": "Xz5TZXnTW03uV/30FiF+vg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9816,7 +9828,7 @@
           "hash": "yvzFcSsPtxte9zmQGahs1w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9828,7 +9840,7 @@
           "hash": "OgTbH1Lb9KDTEQZSBOst5Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9837,10 +9849,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Oculus.Plugins.OculusApi.Controller.html",
-          "hash": "i096XyYp5i3606I2sap73Q=="
+          "hash": "sDy/iZHkRVOsjupaKV632A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9852,7 +9864,7 @@
           "hash": "skI8V+zwH+e3Diua1XJGbA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9864,7 +9876,7 @@
           "hash": "j75cEGtOF83vo2Ca1p4ylg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9876,7 +9888,7 @@
           "hash": "PbvX3BYm0UR9OrVJkMoT7g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9888,7 +9900,7 @@
           "hash": "NKNMZUQEidWQND7OoVYPqw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9900,7 +9912,7 @@
           "hash": "ekwcoYNbfzhrb9jeLRX+Ew=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9912,7 +9924,7 @@
           "hash": "nIOGr0bWt11+Pg3n7wapww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9924,7 +9936,7 @@
           "hash": "E6z5dwtgOQDpKzdL8JHOpQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9936,7 +9948,7 @@
           "hash": "KC97FqgpGIKBYAMehb1OgQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9948,7 +9960,7 @@
           "hash": "5hZNSNKe32O1FwdhJNtoAQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9960,7 +9972,7 @@
           "hash": "5Dn84PPQQEPwByHQzt7LyA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9972,7 +9984,7 @@
           "hash": "XvKxSwVOcCPtZESkNy9rPQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9984,7 +9996,7 @@
           "hash": "XPoY2Lm5PFCBNeKXwhpjLg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -9996,7 +10008,7 @@
           "hash": "LVAtMKBz2Mxau9Ggp8C/PA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10008,7 +10020,7 @@
           "hash": "hmZDgwPxiAmEFVlKAy6jsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10020,7 +10032,7 @@
           "hash": "88BH40PVg7IMt472FA9s7g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10032,7 +10044,7 @@
           "hash": "LWt5pt+U2xBXtbh7Qw5gsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10044,7 +10056,7 @@
           "hash": "ygeuvf/xd3DHk2khbgD/qQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10056,7 +10068,7 @@
           "hash": "yYkEX90dVeHqOJEJO1hZhQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10068,7 +10080,7 @@
           "hash": "n1bgS/v8bcFLQplNTYsshw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10080,7 +10092,7 @@
           "hash": "pGzl/aW+wL3f4+5deiUbGQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10092,7 +10104,7 @@
           "hash": "rvRDb0jKoR2ep6oV8RjepQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10101,10 +10113,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Oculus.Plugins.OculusApi.Posef.html",
-          "hash": "eF8NhWDWayJ5rTGGj/7xlQ=="
+          "hash": "I/Y0XeQZZiNlxRm6neSHdQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10113,10 +10125,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Oculus.Plugins.OculusApi.Quatf.html",
-          "hash": "NHi0hFNrbmwiFUfpbm04Gw=="
+          "hash": "E8n/gz4hXptRTPgHH6L9Tw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10128,7 +10140,7 @@
           "hash": "8VXMRod0NL0xdK4XwuEbaw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10140,7 +10152,7 @@
           "hash": "ge4Wiuz8h0P/ff4S7bbcTg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10152,7 +10164,7 @@
           "hash": "K5XiBal8RsZgRlgti0rlyQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10164,7 +10176,7 @@
           "hash": "rOEuotbwA/s41BDmiYYkEQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10176,7 +10188,7 @@
           "hash": "ThXjYGtZivgyiHknEWq4sQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10188,7 +10200,7 @@
           "hash": "fYP7LOWYhpzmW69LcRQ9lw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10200,7 +10212,7 @@
           "hash": "5HDdSodplJZw9eayUcjTCA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10212,7 +10224,7 @@
           "hash": "2ncJ1YXNIuUJHiHmpddIQQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10224,7 +10236,7 @@
           "hash": "Tzwo0UyNtUDGiwpEhlTo2Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10236,7 +10248,7 @@
           "hash": "fe8WV6x6JTHX2Rie+m9SVw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10248,7 +10260,7 @@
           "hash": "8Og0A6j30gbbRnGSWFi8Qg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10260,7 +10272,7 @@
           "hash": "aBPK9mGQeQIHUuJXHVlEwQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10272,7 +10284,7 @@
           "hash": "MV1/d8lHI7uHeNPMyIJFZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10284,7 +10296,7 @@
           "hash": "Y4QsTC/TMdJTwGMv6qWJSw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10296,7 +10308,7 @@
           "hash": "xzJ0dYT4prahnTMuAxN7+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10308,7 +10320,7 @@
           "hash": "XuXnZbvX5BvZEPHpBIumyQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10320,7 +10332,7 @@
           "hash": "VNjw4YhKJfMSVBSvZaLDrQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10332,7 +10344,7 @@
           "hash": "ncGwdZR/uz5tmz0HklFF3A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10344,7 +10356,7 @@
           "hash": "lM/yeR5FtsXRaSK2Qr+ZXg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10356,7 +10368,7 @@
           "hash": "YZNMkNniB+IO2EicOrxsrA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10368,7 +10380,7 @@
           "hash": "Jb6Z9vAN7FL65gPgMHSsiQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10377,10 +10389,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Oculus.Plugins.OculusApi.Vector3f.html",
-          "hash": "4aHn1BEwe/5YBk6XtUZE5A=="
+          "hash": "5DL23hzjUEBY26HAxdyfvg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10392,7 +10404,7 @@
           "hash": "B2xHoRTFLAVBggbks0g6WQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10404,7 +10416,7 @@
           "hash": "e4sa0ApzZTsEH198nKcY6w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10416,7 +10428,7 @@
           "hash": "dQB9ALLCPs5qootJAjNVxw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10428,7 +10440,7 @@
           "hash": "s9xvIDg/NSqCQv9uBBPG+Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10440,7 +10452,7 @@
           "hash": "HddzPx2CVLdo6aRzVHXpKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10449,10 +10461,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Oculus.Profiles.OculusControllerDataProviderProfile.html",
-          "hash": "lifoTsy/0kAmvjK5SguGGw=="
+          "hash": "qLXxDypwmOy39+H+HKDO5Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10461,10 +10473,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Oculus.Profiles.OculusHandControllerDataProviderProfile.html",
-          "hash": "N3M14Crs4T1ZQmcF95Dzxw=="
+          "hash": "zqpbt19/MkrWNM7du9H+Dw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10476,7 +10488,7 @@
           "hash": "hZBz4px4Had9C/bVih91zg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10488,7 +10500,7 @@
           "hash": "4SQ9EZKCR6MYTFTf7ZGlNg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10500,7 +10512,7 @@
           "hash": "yDINS3D2lyUWyzZmm9tbCQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10512,7 +10524,7 @@
           "hash": "h1bz0xCrDqrcF/d7CYZsaw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10524,7 +10536,7 @@
           "hash": "hVxmqicwxh0iohSakFEg7A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10536,7 +10548,7 @@
           "hash": "/1n63pSC9LvQv0XudJeAlQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10548,7 +10560,7 @@
           "hash": "B4cCA4hd8NDkHSiqRCuwwQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10560,7 +10572,7 @@
           "hash": "iTi/8Gm5WLaC22gg7Cxgaw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10572,7 +10584,7 @@
           "hash": "MwsvsRkMRmuKBGeRZt3Gyw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10584,7 +10596,7 @@
           "hash": "UwZIgU0YjvcT+Hm0g42Urg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10596,7 +10608,7 @@
           "hash": "RKvgKTsbrpZYC4+Y812QhQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10608,7 +10620,7 @@
           "hash": "0WWnymA/3vd0ptvC/GOkVQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10617,10 +10629,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Providers.CameraSystem.BaseCameraDataProvider.html",
-          "hash": "45Sq/h3h73XZc+ht6gtcmw=="
+          "hash": "Tk3UPS90Cjgg1vr4zGzM+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10632,7 +10644,7 @@
           "hash": "XBRG8qAIe5dVSrkBIS6Sow=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10641,10 +10653,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Providers.Controllers.BaseController.html",
-          "hash": "7+Dyo63rLOh2R1G6Dmh4nw=="
+          "hash": "uqmUafXenwJlUwIdAL89+w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10653,10 +10665,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Providers.Controllers.BaseControllerDataProvider.html",
-          "hash": "4LyM0iZoekfFMLqXGPAhhA=="
+          "hash": "CfXTtpAy73lQHVpNnArGyw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10668,7 +10680,7 @@
           "hash": "LCOWU6ixmhzRkTAW2m6nyA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10680,7 +10692,7 @@
           "hash": "mTNPMhbiOkjysCmh5OX36Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10692,7 +10704,7 @@
           "hash": "t+/WI2m9aVR44GEwrduDnQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10704,7 +10716,7 @@
           "hash": "Y0wPmH9IPsUZtYLVhSZ+AA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10716,7 +10728,7 @@
           "hash": "Ra4/vWLUo0RlFTXgcXrkdw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10728,7 +10740,7 @@
           "hash": "EI1vbruVxNoOwXzc65tMxw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10740,7 +10752,7 @@
           "hash": "1PW1bAh1LvIV6+HAbmvl9w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10752,7 +10764,7 @@
           "hash": "JFrKlkWZ18CK2awd55AS6Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10764,7 +10776,7 @@
           "hash": "FOJT8P7FdnoaKTFUDxfSzA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10776,7 +10788,7 @@
           "hash": "Zo9w8LycZPTQFGQUa5HsJw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10788,7 +10800,7 @@
           "hash": "++cPwDQY/S2aKrbDac8qNQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10800,7 +10812,7 @@
           "hash": "qCznDkuw8g3hC0WSAQp1Ww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10812,7 +10824,7 @@
           "hash": "YwcW7kaHKEQuvU+QC/GHag=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10824,7 +10836,7 @@
           "hash": "RrP8uBHCT04edAprM1AZyA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10836,7 +10848,7 @@
           "hash": "7TI/xkWY0bC0fJq8ejXQSw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10848,7 +10860,7 @@
           "hash": "JzjHGPOoR1BPgzr04sqFVw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10860,7 +10872,7 @@
           "hash": "ZiPWi8shKfUjokktFJq2aw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10872,7 +10884,7 @@
           "hash": "5HdCx5XbI6Aqq/29O+gJ6Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10884,7 +10896,7 @@
           "hash": "TxwyyJIIGLbwOtUKyXRPww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10896,7 +10908,7 @@
           "hash": "EgPnSSJIwy7cpnEb5DadMA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10908,7 +10920,7 @@
           "hash": "M9BqHIPcI6WXY1OrEJVxjw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10920,7 +10932,7 @@
           "hash": "1lwOPuXEIjvCg36nGCGmBw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10932,7 +10944,7 @@
           "hash": "iKxR5iXHxxhaJfnSQzTo4A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10944,7 +10956,7 @@
           "hash": "zmnJ8PksUKP71RUp9l7jpQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10956,7 +10968,7 @@
           "hash": "wk4lsbfWeUiWpzFtSi423g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10968,7 +10980,7 @@
           "hash": "VFeLANWFKwjIY0uPbTjLNQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10980,7 +10992,7 @@
           "hash": "9QQk4yNSgfS4ExLkTUFJfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -10992,7 +11004,7 @@
           "hash": "y9oanz2dM2+AThYyWAzSfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11004,7 +11016,7 @@
           "hash": "DoPugSv0wj01kwqlz/OIYA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11016,7 +11028,7 @@
           "hash": "kVv36OQrjPYu4cWXWZelDg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11025,10 +11037,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Providers.Networking.Profiles.BaseMixedRealityNetworkProviderProfile.html",
-          "hash": "iMc8MSAKfP5xiJnRACj2Gw=="
+          "hash": "eO5OZsr9u46F7pmMURcueg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11040,7 +11052,7 @@
           "hash": "vsISIbAnUJzOjxZCpL030A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11052,7 +11064,7 @@
           "hash": "CSOXVHrE+q1RFHlWvVhXmg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11061,10 +11073,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Providers.Networking.WebRTC.MixedRealityWebRtcNetworkProviderProfile.html",
-          "hash": "pJfWTjXWzV+CUf+D3UXAoQ=="
+          "hash": "bBh8H9JvAc0emYCPn8kdTw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11076,7 +11088,7 @@
           "hash": "5qy/iw50xPjnoVHYtcmkKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11088,7 +11100,7 @@
           "hash": "BZXBPLIPqSEhAjIVZpMX2g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11100,7 +11112,7 @@
           "hash": "if5LPrjU+X1Kq63bGEoqnA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11109,10 +11121,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Providers.SpatialObservers.BaseMixedRealitySpatialMeshObserverProfile.html",
-          "hash": "sdgE3ds93TgB0p6mI1zV/g=="
+          "hash": "zW6W0Dwom/PI/Eeu99GhYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11124,7 +11136,7 @@
           "hash": "lpok+kuB6IlVx6YwLctq6Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11133,10 +11145,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Providers.SpatialObservers.BaseMixedRealitySpatialObserverProfile.html",
-          "hash": "+rcCMG6Q1N9SATj4iSymgw=="
+          "hash": "6CtwSHZ2SqRrvbbW0Ue0+Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11148,7 +11160,7 @@
           "hash": "S7dQvvz2MQsaYsA8Anb2kA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11157,10 +11169,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Providers.SpatialObservers.BaseMixedRealitySurfaceObserverProfile.html",
-          "hash": "q2loN334HY2UN710lKGHWw=="
+          "hash": "jNfRozpBUfo2iBhcFwZ/NA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11172,7 +11184,7 @@
           "hash": "S61YsJrWlOJ0cpMd0xer2Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11184,7 +11196,7 @@
           "hash": "buyDDm5e9Cbe9F8mkhhxUg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11196,7 +11208,7 @@
           "hash": "vFCCrtK0cZQdF98qn2Qjjg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11208,7 +11220,7 @@
           "hash": "pkhAwlHyOrHGsqz33DQKxQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11220,7 +11232,7 @@
           "hash": "xtt+Psdwl2fBDGBy/bB6Pw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11232,7 +11244,7 @@
           "hash": "aWKKICNd1JZT/djyI/ZAfg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11244,7 +11256,7 @@
           "hash": "S9shMwj8vNVWNk9/QpLohg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11256,7 +11268,7 @@
           "hash": "wIcNvL+OWwfVODq5GXOYtw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11268,7 +11280,7 @@
           "hash": "hlkPl9Wt5C4fF09DaxhOVw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11280,7 +11292,7 @@
           "hash": "PJm7b/yv6qUTq9Sc7H8hKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11292,7 +11304,7 @@
           "hash": "gOAWvfG/WObCg7mDF3PkVg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11304,7 +11316,7 @@
           "hash": "umh9JPeMlINRLoGcmGlXAw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11316,7 +11328,7 @@
           "hash": "c2oo+rtBG+by6UiEAKo9QA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11328,7 +11340,7 @@
           "hash": "Vfh5wQ44OH5ytCfmSMgPag=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11340,7 +11352,7 @@
           "hash": "aSCx6bVKUY4dtH3TndUGlQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11352,7 +11364,7 @@
           "hash": "YC5qppxnRwShRhUWMsH3BA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11361,10 +11373,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Input.Handlers.BaseInputHandlerInspector.html",
-          "hash": "z6W6HQvD2bBkR0HD/tuu4A=="
+          "hash": "rtpX3MBFTsw0tr1HnmDbGw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11373,10 +11385,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Input.Handlers.ControllerPoseSynchronizerInspector.html",
-          "hash": "eKFu4S8OMNNQqmMcJLeFNg=="
+          "hash": "Td7vpMdbnLWHdJYbXUyaKw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11385,10 +11397,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Input.Handlers.DefaultMixedRealityControllerVisualizerInspector.html",
-          "hash": "4bMPdnabFds1bEVyA0ieOw=="
+          "hash": "+5UHjity/WbgLTmCgzBHUQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11397,10 +11409,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Input.Handlers.PointerClickHandlerInspector.html",
-          "hash": "1WlMGw+rqS49wXcHuu2K0w=="
+          "hash": "Dpj0nr/K02n9skxxNnpyPw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11409,10 +11421,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Input.Handlers.SpeechInputHandlerInspector.html",
-          "hash": "0uLfwyAzRDKtHNfPmjPmNA=="
+          "hash": "Au8S2S1Qr6UEEueAIjaenA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11421,10 +11433,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Input.Handlers.WindowsMixedRealityControllerVisualizerInspector.html",
-          "hash": "Zz0aVcPlGQXQDJbSmCsocQ=="
+          "hash": "mdrXQHr37ZjHgyfKLrqznA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11436,7 +11448,7 @@
           "hash": "VESG/IRzFjp+SEheEv6eVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11445,10 +11457,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.SdkPathFinder.html",
-          "hash": "vN3UEBJfGeTG0WFMGYsx5g=="
+          "hash": "kQu+y8+739CmqlKehsUsCQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11457,10 +11469,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.UX.Collections.BaseCollectionInspector.html",
-          "hash": "L9uECfk2SBIFYF/MICnL4Q=="
+          "hash": "JkGy8Lu35XfdHsnT2uEFsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11472,7 +11484,7 @@
           "hash": "F6+T8DXNlXrH/8KtXWuilg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11481,10 +11493,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.UX.Pointers.BaseControllerPointerInspector.html",
-          "hash": "SaPf8BWALJGa22g8/YVYxQ=="
+          "hash": "VJSyqWN56f4xqGRUC/ZuEg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11493,10 +11505,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.UX.Pointers.HandSpatialPointerInspector.html",
-          "hash": "vzCtvxFZmoueny+uIPoARg=="
+          "hash": "UCPuMTBVSxvHLB+CqgIRmw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11505,10 +11517,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.UX.Pointers.LinePointerInspector.html",
-          "hash": "HKhyob6peX9abmAuiKSOiw=="
+          "hash": "0Mh/32U4N4cXMVrUOl1zvg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11517,10 +11529,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.UX.Pointers.MousePointerInspector.html",
-          "hash": "VHDRnO3bUfzDLlvFnsdJag=="
+          "hash": "MRmYU6YLpbrCT6UqreHdlA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11529,10 +11541,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.UX.Pointers.ParabolicTeleportPointerInspector.html",
-          "hash": "Y6jld6Q3hIEjB8u63VvwYg=="
+          "hash": "A544JbIPWKePhRHCc4MELQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11541,10 +11553,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.UX.Pointers.TeleportPointerInspector.html",
-          "hash": "cHpnusfR1IWK/cfqKKTvlw=="
+          "hash": "yH+mEWKXwybnMhYtI1OaSw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11556,7 +11568,7 @@
           "hash": "kRBmY2SApHFKoccKSEJDGQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11565,10 +11577,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Utilities.Solvers.ControllerFinderInspector.html",
-          "hash": "V8bA2bMoKaTFvEBcG34O+w=="
+          "hash": "MkqXoDOBvxWhK1iexoh7pg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11577,10 +11589,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Utilities.Solvers.InBetweenEditor.html",
-          "hash": "dPT/gkr6DsSZ9p7l2uNK/g=="
+          "hash": "BEk8G+oLhkturvB7Oa/DAQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11589,10 +11601,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SDK.Editor.Utilities.Solvers.SolverHandlerInspector.html",
-          "hash": "EzKs7DwSWZX/ML36sc1ahg=="
+          "hash": "5cWiQhMzluEDA7jHyoXUWQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11604,7 +11616,7 @@
           "hash": "kCnxPoSjcoyqbVRrbic9yw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11616,7 +11628,7 @@
           "hash": "btJTNWKjVqyyMR4HsjhnXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11628,7 +11640,7 @@
           "hash": "U5zmBFiaGFbQzPLTnWPv/w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11640,7 +11652,7 @@
           "hash": "Oer7ij7mEoBOdFr8JrM+Zg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11652,7 +11664,7 @@
           "hash": "PxSI2w1WUjEymV9Tcf5H5Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11664,7 +11676,7 @@
           "hash": "F5pfREbKKQJfOxZ86XNOkg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11676,7 +11688,7 @@
           "hash": "o9v+Hm78i/nSW0bmHLyR6g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11688,7 +11700,7 @@
           "hash": "B4JFvUGR6dahajvMMvHi6A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11700,7 +11712,7 @@
           "hash": "S2g40NqfLndG8uqfE6U2xA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11712,7 +11724,7 @@
           "hash": "+Vg8ds9uAqP0FBPgXtmELA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11724,7 +11736,7 @@
           "hash": "7PpkEgtKttCh0V8rmKXl3w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11736,7 +11748,7 @@
           "hash": "0oC7MPx4TIKrZvHibFnu4A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11748,7 +11760,7 @@
           "hash": "dppXQRCn2koPy4VdaRVuMg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11760,7 +11772,7 @@
           "hash": "CJgzKm7H4lx8InRRb5mClg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11772,7 +11784,7 @@
           "hash": "XKrsooFUQU75GonyG9Fkhw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11784,7 +11796,7 @@
           "hash": "6JEOdWiM7F+PJasHYu5LYQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11796,7 +11808,7 @@
           "hash": "au767vB66Xw7jfh40iHwrw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11808,7 +11820,7 @@
           "hash": "rGq3+wAWOrd2tj13N0GcKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11820,7 +11832,7 @@
           "hash": "/wGYYHkkDMbp7eoNZbfjFA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11832,7 +11844,7 @@
           "hash": "YAmNf9Fs4TP10/lClLvlGw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11844,7 +11856,7 @@
           "hash": "GVJEzUHvfT/qDnB+RcnUAw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11856,7 +11868,7 @@
           "hash": "4K5Ek7XVIbE/CvfVgLno1g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11868,7 +11880,7 @@
           "hash": "K1W2GsLKSlAaqtll/l918w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11880,7 +11892,7 @@
           "hash": "Sbq9a1AGSqXUyp92jXjxbQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11892,7 +11904,7 @@
           "hash": "h7WFzbUrDJLYNJ30mPqNzg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11904,7 +11916,7 @@
           "hash": "mq43S8Z5jWyKyYbjrp1tCA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11916,7 +11928,7 @@
           "hash": "m+SjmIyS2EKOq933NZG89Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11928,7 +11940,7 @@
           "hash": "ka4d+swZetYW8dyl0xOpww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11940,7 +11952,7 @@
           "hash": "KR1eHiVZNa+5WMTAJSQfEQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11952,7 +11964,7 @@
           "hash": "xAfAuafF3RGQ0zqH0H7zEw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11964,7 +11976,7 @@
           "hash": "3MJE5d3FSCgS/yaDCwk1pw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11976,7 +11988,7 @@
           "hash": "NxFzDsHLjspA7Y3/oyG3jA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -11988,7 +12000,7 @@
           "hash": "cmIhOgLKTaxcwUu3Y3nRVw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12000,7 +12012,7 @@
           "hash": "KVaqPahM9SBLyADaqk8OEQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12012,7 +12024,7 @@
           "hash": "6OFqjj8aoIyBRJaLNugJiw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12024,7 +12036,7 @@
           "hash": "35Ch1hu6Tkm7Dk74IUuIMg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12036,7 +12048,7 @@
           "hash": "wOX2r4zDxAstT9GjCDNoHA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12048,7 +12060,7 @@
           "hash": "tlNKFe3mGsu8eWLFEZmofw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12060,7 +12072,7 @@
           "hash": "QQumFiPGeKTTbf0Nz2+6vA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12072,7 +12084,7 @@
           "hash": "3oJ6Mxk/6R+e6Jc8DjYBeA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12084,7 +12096,7 @@
           "hash": "6gXU0nFSnxSoMoA57M72xA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12096,7 +12108,7 @@
           "hash": "hBiBLGULg2Na6cUJCjbp4w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12108,7 +12120,7 @@
           "hash": "etdkNpmAAGJDovQ31a1k8g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12120,7 +12132,7 @@
           "hash": "wTQYnqNAN4+z1mxt3hgfxQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12132,7 +12144,7 @@
           "hash": "v1/xVNKbFe+N6VnqMQpGuw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12144,7 +12156,7 @@
           "hash": "9Kt5Bub6F+Ed9LgKMw/gVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12156,7 +12168,7 @@
           "hash": "vb2WCrimc7SlJwcnzbqJCQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12168,7 +12180,7 @@
           "hash": "ja1Da35taYpdUds34PF24g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12180,7 +12192,7 @@
           "hash": "bTnE/zEoCny0cEyePso95w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12192,7 +12204,7 @@
           "hash": "KZYqaWd4QnKEAQEqzZLo5g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12204,7 +12216,7 @@
           "hash": "5nkx57udFqVAUm5g6IJbNQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12216,7 +12228,7 @@
           "hash": "T/EQY9xKfrbiVD215AP2bw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12228,7 +12240,7 @@
           "hash": "GsDyke8jd3srlf0+MjgK2Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12240,7 +12252,7 @@
           "hash": "m/by8GfZCLmAE9EnJXT4YQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12252,7 +12264,7 @@
           "hash": "fXGhUba0uBSO6aH8ftP8TA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12264,7 +12276,7 @@
           "hash": "XB5wOUqAyFC4CFT4df1jZQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12276,7 +12288,7 @@
           "hash": "JU8mdW9PpuYqwNVvWbBjkA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12288,7 +12300,7 @@
           "hash": "0DI4zSKd2EJ0nQekxWf/1g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12300,7 +12312,7 @@
           "hash": "DR4no7UK94oc12I1HQrhmQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12312,7 +12324,7 @@
           "hash": "oTfgpgo1p4L3XkIAkp/9UQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12324,7 +12336,7 @@
           "hash": "sDl0wLTFRgwnMiPIaZGUaw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12336,7 +12348,7 @@
           "hash": "ORTMXxrHCojqsTGTfoJTZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12348,7 +12360,7 @@
           "hash": "QGcSGy99tO1ShoQ+MsWxvA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12360,7 +12372,7 @@
           "hash": "O7a8umByphlzdPn9jUNsTg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12372,7 +12384,7 @@
           "hash": "oqpobbeKcj8cA/RHT3HEog=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12384,7 +12396,7 @@
           "hash": "x2oEJ0UREx1diHwbBY4PxA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12396,7 +12408,7 @@
           "hash": "8bF3iClSWBM8lazBJnKpOQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12408,7 +12420,7 @@
           "hash": "OqyStwIahAI+7WYEPmY/cA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12420,7 +12432,7 @@
           "hash": "3ZsL6gvY6oAX/c51ltCGcw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12432,7 +12444,7 @@
           "hash": "c0lscCJFok79N4KErjJF+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12444,7 +12456,7 @@
           "hash": "QVFZFl3pXLFl5Jj5oS3BVg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12456,7 +12468,7 @@
           "hash": "QBR3P7klTtxvIvQ4ovD3Cw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12468,7 +12480,7 @@
           "hash": "9jvK6yeUERzPRXmtQDgP6Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12480,7 +12492,7 @@
           "hash": "0DCVIVu8LpJSPzm/V1gvJA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12492,7 +12504,7 @@
           "hash": "cJlpOq+fAoM7l79t9CyYLA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12504,7 +12516,7 @@
           "hash": "vr28tZ6Bw0NwkpCj8k3tEw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12516,7 +12528,7 @@
           "hash": "S7qwsc/prcZcAzDEjgDN3Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12528,7 +12540,7 @@
           "hash": "nMvGibRUSNPD4CTvvMbyKw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12540,7 +12552,7 @@
           "hash": "qEAqnlNb2WRfbKDu7Qpa/Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12552,7 +12564,7 @@
           "hash": "oY3v1pEte31gAsdL671Inw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12564,7 +12576,7 @@
           "hash": "zYWklgzf+H2UH9x11fUBew=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12576,7 +12588,7 @@
           "hash": "VYlXlrWGIhJP1n7imEcaYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12588,7 +12600,7 @@
           "hash": "KWJU7COF5C5MSnAC5IVT8w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12600,7 +12612,7 @@
           "hash": "hUtEMlJ2YmGef2UZ8598mQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12612,7 +12624,7 @@
           "hash": "gKtbTnY8E+9fjust0d8OuA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12624,7 +12636,7 @@
           "hash": "yhN4uO9U48RnG6Qa1LGKmw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12636,7 +12648,7 @@
           "hash": "uVu6O8jyTCb6/5n5G7gQ2g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12648,7 +12660,7 @@
           "hash": "q4UxoYeYAYVXlHiWaIkIZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12660,7 +12672,7 @@
           "hash": "5FDlx+z5zRr1OrQfTi+Tfg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12669,10 +12681,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Seed.PackagePickerWindow.html",
-          "hash": "WJ/3mJRFsiUab1sWEDhVDA=="
+          "hash": "j01qo1HmRvaHr5q3sikRGA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12684,7 +12696,7 @@
           "hash": "SiONDVaVdFEAfz+6gzjxpA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12696,7 +12708,7 @@
           "hash": "c60hv4OFTiuGknhVeowYMw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12708,7 +12720,7 @@
           "hash": "xyNbtPpCJb1wN4FG7J6e/w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12720,7 +12732,7 @@
           "hash": "PAtdZqa5UrFXTYO5u8cKhA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12732,7 +12744,7 @@
           "hash": "67la4Zn+mWOHYMaiBoYw9Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12744,7 +12756,7 @@
           "hash": "N8YpwiWjI60TcJxGZqasJA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12756,7 +12768,7 @@
           "hash": "UlKqG1+XnDBaw0/lCo5Dkg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12768,7 +12780,7 @@
           "hash": "qjsWRhyXG+sXoCH5bjExyw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12780,7 +12792,7 @@
           "hash": "ERK8BPJy+y3z33lD+/4pJQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12792,7 +12804,7 @@
           "hash": "c7sgR1ZokHg4v/ABjo8j+w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12804,7 +12816,7 @@
           "hash": "yfF6OFTJwkoQzt8Awr7KuA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12816,7 +12828,7 @@
           "hash": "itdUounGgttQ/U8bF7up2A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12828,7 +12840,7 @@
           "hash": "N3Yo5QhIYe7yUbnc/qwOfA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12840,7 +12852,7 @@
           "hash": "Zu9DLERGV35wJTjEciGNzg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12852,7 +12864,7 @@
           "hash": "AJBCDFLma42aUM77dufciQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12864,7 +12876,7 @@
           "hash": "zdBBZWfvw92tttITgrmQNw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12876,7 +12888,7 @@
           "hash": "f7paqsiGG3gKtVtlrca4kA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12888,7 +12900,7 @@
           "hash": "dMxRRn8MRhi+0AiW3cGU1g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12900,7 +12912,7 @@
           "hash": "0Pkngz3ODbUxVXX3wBDcRg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12912,7 +12924,7 @@
           "hash": "dFyUEMubHVf0TnVOUqtHbA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12924,7 +12936,7 @@
           "hash": "ch/A2uY7V6+ulkNtLoknBg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12936,7 +12948,7 @@
           "hash": "WoTGtH1iUxDwlhcwmUrbpg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12948,7 +12960,7 @@
           "hash": "87zgtkR5hyQjTvU+GQgFWA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12960,7 +12972,7 @@
           "hash": "EV4e5DnYHCoMKYc/2S5ehg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12972,7 +12984,7 @@
           "hash": "O/FT/BeXke3ymcdO3f+mGw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12984,7 +12996,7 @@
           "hash": "OdiqRekK0uULzindQC3FLg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -12996,7 +13008,7 @@
           "hash": "XoAs9KFL6b8VSfXQme8qtA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13008,7 +13020,7 @@
           "hash": "u856bA5O+SrdMy6vRMY8Dw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13020,7 +13032,7 @@
           "hash": "fx0bot53jx3FFp/JyTd8TQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13032,7 +13044,7 @@
           "hash": "7qvYn1FNRa6hWolgqESJZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13044,7 +13056,7 @@
           "hash": "RWNUN1kIckGvle0Nv4+Bjg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13056,7 +13068,7 @@
           "hash": "2W+L6u2MWbvwMH8guDcMUQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13068,7 +13080,7 @@
           "hash": "5RudMXSRMHyOelDUl0qVeQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13080,7 +13092,7 @@
           "hash": "V1rrxODF9VZLe+5eVDwWcA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13092,7 +13104,7 @@
           "hash": "zo8AW4I+j8PCF2eMAFr/EA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13104,7 +13116,7 @@
           "hash": "fRq0szRjQYwEPpst8q5Nbg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13116,7 +13128,7 @@
           "hash": "zJ3Jg3iTFu3rAaKyImibog=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13128,7 +13140,7 @@
           "hash": "Qy/2KkYb6k8Rz7nrTLrmuA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13137,10 +13149,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SteamVR.Editor.SteamVRPathFinder.html",
-          "hash": "/OUf4qhIQWH9y1CnBaW9Ug=="
+          "hash": "cclf7XhVlXYg1JLbtAYBNQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13152,7 +13164,7 @@
           "hash": "YlHXCaWboo9fa0C1G6lYBg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13164,7 +13176,7 @@
           "hash": "sd2lhruSez15+rijsxU4Ig=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13173,10 +13185,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.SteamVR.Profiles.SteamVRControllerDataProviderProfile.html",
-          "hash": "hnSZusRGIWZLVN/F9SGK2g=="
+          "hash": "y2cnMiP6iYcrFm7AQTFHHw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13188,7 +13200,7 @@
           "hash": "uAxehefq+P5v/n3ckXVzNw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13200,7 +13212,7 @@
           "hash": "FCM5FPDkpHcd7dl1ME51aA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13212,7 +13224,7 @@
           "hash": "QLgxrfKZcNiv+BX4Ctbhfg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13224,7 +13236,7 @@
           "hash": "MLx6yfwktXg+VStzhWl7Hg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13236,7 +13248,7 @@
           "hash": "BOCsQMpRcM/yW69xhGXejw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13248,7 +13260,7 @@
           "hash": "rNzCiusZ+Pm80nPqIdgIYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13260,7 +13272,7 @@
           "hash": "PmKiXgiOAxMKKvsHD/DMCQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13272,7 +13284,7 @@
           "hash": "es4WezQBAHveYaZcHGCcww=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13284,7 +13296,7 @@
           "hash": "NRWmLdFI53T4Oh8djETOzQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13296,7 +13308,7 @@
           "hash": "ntqM3hFlxN+Glk8jVRTwBg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13308,7 +13320,7 @@
           "hash": "UAm3KsVDz/INOTRdJEKc0A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13320,7 +13332,7 @@
           "hash": "x2wv2DcJUIqpOi8NXOAL0w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13332,7 +13344,7 @@
           "hash": "8P23ZlkPabH4OiRZeSOqtg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13344,7 +13356,7 @@
           "hash": "R4VVwsuTztm+4PIM1kZ4Vw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13356,7 +13368,7 @@
           "hash": "hW3qxojFP/riIg8FMc/sFg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13368,7 +13380,7 @@
           "hash": "bH/O7zg6R5JIQHokVDe8/w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13380,7 +13392,7 @@
           "hash": "a3f0annUUbdevfblPPqVEw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13392,7 +13404,7 @@
           "hash": "YfLSOAzjHM/iVcZK+yaRrg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13404,7 +13416,7 @@
           "hash": "7RewY7OrZ44/tKLxkK/j/A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13416,7 +13428,7 @@
           "hash": "fJiLJPPoU3BSvwZROielpw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13425,10 +13437,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Ultraleap.Editor.UltraleapPathFinder.html",
-          "hash": "lzdGUcuLgmL3J/ZXhL0g2A=="
+          "hash": "S0m7Nb0+/bJh6dqus3vqPg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13440,7 +13452,7 @@
           "hash": "ZjbA6MlUunf3C2gi1fGZxA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13452,7 +13464,7 @@
           "hash": "WHmda1pLrIhJZb6h9JrjEg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13461,10 +13473,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Ultraleap.Profiles.UltraleapControllerDataProviderProfile.html",
-          "hash": "u3kZ7HHYGa1LzzL4hQ/vng=="
+          "hash": "M02oZQv1SPN4MYi2gM1aIQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13476,7 +13488,7 @@
           "hash": "1SL4Jdjnr/DA10B/qJd7uA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13488,7 +13500,7 @@
           "hash": "Y5Wjn/mKj+QiyxCe11sUpw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13500,7 +13512,7 @@
           "hash": "AwYZnhgB9jimUFud5v5lkA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13512,7 +13524,7 @@
           "hash": "r+Jxq3JJFZ611Sd6Kzb1pQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13524,7 +13536,7 @@
           "hash": "ZZnkFhFRIvpMwTqYy9w/6w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13536,7 +13548,7 @@
           "hash": "K+IfYq9kJKcX3Qdy+IrZ+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13548,7 +13560,7 @@
           "hash": "6uysAbOnM/B1siIETSFxxw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13560,7 +13572,7 @@
           "hash": "8gfeTSM3pVunlL4WeHkXmg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13572,7 +13584,7 @@
           "hash": "yOfF4fHa5mAzldopuzTziQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13584,7 +13596,7 @@
           "hash": "lJntwAU84xe4Gwmn6f617Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13596,7 +13608,7 @@
           "hash": "YTGTKIvJmXhBIyBBRmec/g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13608,7 +13620,7 @@
           "hash": "DdGD3Z8hzBdiOFASqvPIYw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13620,7 +13632,7 @@
           "hash": "DvKA8grdWFAvsFwR62lzYw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13632,7 +13644,7 @@
           "hash": "m35ka/dA64wonllI2hRNVw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13644,7 +13656,7 @@
           "hash": "5yXee7oIBDNZVPBKdUdlug=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13656,7 +13668,7 @@
           "hash": "C6adox8u1jPZCCEsfZPLSA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13668,7 +13680,7 @@
           "hash": "cSZIfPPL15rg9pyo9es1lA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13680,7 +13692,7 @@
           "hash": "CGdma7RhA+PIZ6RY16tqiw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13689,10 +13701,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Utilities.Build.BuildDeployWindow.html",
-          "hash": "rPH8DUBtRBRN4/Af1ivpVA=="
+          "hash": "R4H0HKSOJY9eT8F8HCkVeQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13701,10 +13713,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Utilities.Build.BuildInfo.html",
-          "hash": "w8GLhaiVBI1cNBPXRlM0Ew=="
+          "hash": "ld6B4dwIdcioHgOsmJuogw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13716,7 +13728,7 @@
           "hash": "E5yXonP12zQWm5Ch5IUAUQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13725,10 +13737,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Utilities.Build.IBuildInfo.html",
-          "hash": "hipNC4jZhX9UiHG+QJLqcA=="
+          "hash": "dHn2dL0OjJkvUnGRCPR1Uw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13740,7 +13752,7 @@
           "hash": "SlksLDmYSLvK8Vb3l5+FJg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13752,7 +13764,7 @@
           "hash": "uCIAPb8sflJoIqQHbHsJoA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13764,7 +13776,7 @@
           "hash": "rgq2UtwHB7KAPMOvU+IEqA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13776,7 +13788,7 @@
           "hash": "qlSyu0QsBpkjc+455srZFA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13785,10 +13797,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Utilities.Build.UwpBuildInfo.html",
-          "hash": "ZHa82sbao4iTTTKLkkASmA=="
+          "hash": "5SrSo66qzH6oX/k8wkOi6A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13800,7 +13812,7 @@
           "hash": "KgO5w8OLC8MQtUz73J3RKg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13812,7 +13824,7 @@
           "hash": "G0DTj3D1j7Tmw7sxBPUNxg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13824,7 +13836,7 @@
           "hash": "twUxeMhaOrHkb2PjV3opuA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13836,7 +13848,7 @@
           "hash": "hNYlSjL4QvUFRUQls+vI6g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13848,7 +13860,7 @@
           "hash": "oL4ny8uXHEnVmjR5k81xkg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13860,7 +13872,7 @@
           "hash": "7hHcHDK/658ud7NLBdKCUw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13872,7 +13884,7 @@
           "hash": "bGRtaKiseacev94iecbBfg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13881,10 +13893,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Utilities.Editor.CorePathFinder.html",
-          "hash": "+Sdy3ngvxTgqoWeilxYSjA=="
+          "hash": "35jrsnceFmeRYLuieMlKug=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13896,7 +13908,7 @@
           "hash": "CZR3izGFPtBZbd2lGI4Aaw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13908,7 +13920,7 @@
           "hash": "ZF3Mexp8nm4yGOvW1/OpPw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13920,7 +13932,7 @@
           "hash": "Z1dgVMeCyl/yOTTLrL0UdA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13929,10 +13941,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Utilities.Editor.IconEditor.html",
-          "hash": "rnCiMJtEKUIVEbLdUtm3Mw=="
+          "hash": "9JHByIo7tirsTjxxZzGWzw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13944,7 +13956,7 @@
           "hash": "GJnFyOPIGZBY6eAg4bGrDA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13956,7 +13968,7 @@
           "hash": "O/Pc4KGEqEDfvbPtTsHk7w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13968,7 +13980,7 @@
           "hash": "nVdkh6fjWfQeW6s4pax2Ew=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13980,7 +13992,7 @@
           "hash": "X2qsCYnxm9Kfo2ZQUz5FXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -13992,7 +14004,7 @@
           "hash": "m9N/RAAkvwJ/+4MeNGPofw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14004,7 +14016,7 @@
           "hash": "JschRVukt9XsJHC1p0PPCg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14016,7 +14028,7 @@
           "hash": "ckekSO14PoEXO9nCQ8C+sA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14028,7 +14040,7 @@
           "hash": "3MPGIvOROjdfYOmlDcf5PQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14040,7 +14052,7 @@
           "hash": "78+doR1B1NkKa7Ezvfo+GA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14052,7 +14064,7 @@
           "hash": "wcfumpOY9sgIalXLfUBfBw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14064,7 +14076,7 @@
           "hash": "lgZCNl/JPQ9ItaIxbK/rtg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14076,7 +14088,7 @@
           "hash": "0VDOjBEK1WAtCFw6W+H9GA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14085,10 +14097,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.Utilities.Gltf.GltfAsset.html",
-          "hash": "i3Rv9w9rCGeBbANSI12qVw=="
+          "hash": "Jt5manokUhJ8/KK+VVpDOw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14100,7 +14112,7 @@
           "hash": "NItiD0EpJ6KCq+CeZCGDTQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14112,7 +14124,7 @@
           "hash": "LryQdJVNORZvZ8KAKPogOA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14124,7 +14136,7 @@
           "hash": "hPIm/kIPWwkQzPkndPJkBA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14136,7 +14148,7 @@
           "hash": "XQUM96nNfBx0HfjA0XrAKA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14148,7 +14160,7 @@
           "hash": "PbrfY1yw1TPa2fohOj7VaQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14160,7 +14172,7 @@
           "hash": "jtv2vGIJrZWYwn2Gpgozkw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14172,7 +14184,7 @@
           "hash": "QF4qlrFJlwL+tvXfeoVkQw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14184,7 +14196,7 @@
           "hash": "G9+AEPjobgmJuwvdwcK28w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14196,7 +14208,7 @@
           "hash": "a2ufAaeiLld9SW7L21y03A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14208,7 +14220,7 @@
           "hash": "Y5vnvK5R++eJAnYA0hOf1w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14220,7 +14232,7 @@
           "hash": "uaIlRj/c+QrsdLhTrjOE0Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14232,7 +14244,7 @@
           "hash": "hZIvtCgCja6UmaUXwIlaXg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14244,7 +14256,7 @@
           "hash": "2D87BJDPVcg8bPiZnie7WA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14256,7 +14268,7 @@
           "hash": "M27FBTWxTPoX23GBT1GR4w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14268,7 +14280,7 @@
           "hash": "GiDLefiAke0rLgwN+BApIA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14280,7 +14292,7 @@
           "hash": "OpcQ8kueVToNxpXo+2Sd+Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14292,7 +14304,7 @@
           "hash": "q6V7k6HshXUTrsUy3WUaNQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14304,7 +14316,7 @@
           "hash": "dwMxOChLHhYlMXXMPJB12Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14316,7 +14328,7 @@
           "hash": "fiQk6MROismezWUnBaSJgg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14328,7 +14340,7 @@
           "hash": "r9sMKSqry9SpAnDDC3Qxfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14340,7 +14352,7 @@
           "hash": "vUexDYOF8UDgzzGqM8pnJQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14352,7 +14364,7 @@
           "hash": "b0fNxXvE0NojQzBt5JLPhw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14364,7 +14376,7 @@
           "hash": "64ewDdCBzCieYHJo8+xpcA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14376,7 +14388,7 @@
           "hash": "qF/8f793+4QxEkxYw9eexA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14388,7 +14400,7 @@
           "hash": "Zfo4HjjEys6rVSvZILl6wA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14400,7 +14412,7 @@
           "hash": "u3Z+X4ckFZ5qCKwvQMKGHg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14412,7 +14424,7 @@
           "hash": "6RPkKtwoCPYbbutilb49yg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14424,7 +14436,7 @@
           "hash": "uO8ADbiM9rcBXJ0PRv4EtQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14436,7 +14448,7 @@
           "hash": "iAwCxP6Jog7MnFxBGwcFQg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14448,7 +14460,7 @@
           "hash": "zuiFEspKHtgJ7IVdhIFDjA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14460,7 +14472,7 @@
           "hash": "UtoFmy5j1B2iy/9ME/YNvw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14472,7 +14484,7 @@
           "hash": "0jf/kMgQsNiEEsSSPX0yeg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14484,7 +14496,7 @@
           "hash": "6CcqjiWcIYIvJRX4eJ23xg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14496,7 +14508,7 @@
           "hash": "1o/Hvm4m3SeRc42k/rZ83Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14508,7 +14520,7 @@
           "hash": "LmWuwYOHMkPogpa8EKobTQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14520,7 +14532,7 @@
           "hash": "j0q4hzDrfBpcowYFayikGQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14532,7 +14544,7 @@
           "hash": "rkjLJnfvQYtaTX3SPkkWJg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14544,7 +14556,7 @@
           "hash": "F03l5jZDrmsRWM4AiBayLA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14556,7 +14568,7 @@
           "hash": "fnbMYn5HzUw7KIytIkCiAg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14568,7 +14580,7 @@
           "hash": "kC37m3r/F33TsU33Z1rW1w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14580,7 +14592,7 @@
           "hash": "ioIhU5FkdsoVmAJuEYkQVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14592,7 +14604,7 @@
           "hash": "qXEynlBaMgg0AcfK9Z12Yw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14604,7 +14616,7 @@
           "hash": "+CzYTz5c1t6o1yTPL09veg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14616,7 +14628,7 @@
           "hash": "GA2wVbHP3EdVdICjuvFJ+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14628,7 +14640,7 @@
           "hash": "U1/Q95KlC7orjkTGAXWMzA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14640,7 +14652,7 @@
           "hash": "xx2i2uVN+zxozntNICE5mA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14652,7 +14664,7 @@
           "hash": "YQv/0YM7vX+2hUwWJlxJUA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14664,7 +14676,7 @@
           "hash": "WPg0QWx/4msaWfPSP5S2IA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14676,7 +14688,7 @@
           "hash": "s1nx3TFyD5rGOt2NLAiT2g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14688,7 +14700,7 @@
           "hash": "bj+m1BPXshvc2g6ui/zVtQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14700,7 +14712,7 @@
           "hash": "qb6edrWfWguudMVNcfa/lg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14712,7 +14724,7 @@
           "hash": "2iZVvJitcj2RygqD9um9Hg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14724,7 +14736,7 @@
           "hash": "9ECmbNSyeoV2i7m9Rm123w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14736,7 +14748,7 @@
           "hash": "CgRGdPc449xW78eZAiP6/Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14748,7 +14760,7 @@
           "hash": "Ir2zvKeH//bveEWNcW2Dzg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14760,7 +14772,7 @@
           "hash": "cB5QgJwzsWo0o7j/aBF6NA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14772,7 +14784,7 @@
           "hash": "z28GXiUgdcKNVkIFuaa1Ug=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14784,7 +14796,7 @@
           "hash": "qM6gpcdddWn6pGNhjrOszw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14796,7 +14808,7 @@
           "hash": "wr2O1++HdAbZIFqE19uAfA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14808,7 +14820,7 @@
           "hash": "JQv0aJOPo+iWsp959FiRtg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14820,7 +14832,7 @@
           "hash": "O23VcnLi3+ejPkD9B+z09w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14832,7 +14844,7 @@
           "hash": "MR0ZiKjfxxT3C4T38qpibQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14844,7 +14856,7 @@
           "hash": "mOnN6QsiYwFshJrwwCcmzw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14856,7 +14868,7 @@
           "hash": "0rutaTm3xlDeo9CQbTNWNg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14868,7 +14880,7 @@
           "hash": "CR/duhuRtbi1Lj0AOJ4Rag=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14880,7 +14892,7 @@
           "hash": "0IMxrh1YUEz1E2fYUUnHaA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14892,7 +14904,7 @@
           "hash": "A+aq6SB2qDiGP3uR0xmWeg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14904,7 +14916,7 @@
           "hash": "vwmCQk6r3rE6t/m7/yWWAA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14916,7 +14928,7 @@
           "hash": "IEDkYfXHYFym9zhlVfAOgQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14928,7 +14940,7 @@
           "hash": "krtx5SphKI9qMfUv+4xSug=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14940,7 +14952,7 @@
           "hash": "vzjwWUcgsrgO4kqBaaCiSw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14952,7 +14964,7 @@
           "hash": "AU6VUXDGYzOkL9jVE8kxKA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14964,7 +14976,7 @@
           "hash": "q4Z3L50FDKxZFvnAsLvX7g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14976,7 +14988,7 @@
           "hash": "cPiyFCcjbwJyKnQDSI0VhQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -14988,7 +15000,7 @@
           "hash": "OfW5cjyIScg4Z7f4fjsTow=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15000,7 +15012,7 @@
           "hash": "lqI9863GCBaf7Cpsktsslg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15012,7 +15024,7 @@
           "hash": "WX0BvgIa6vQiJbktdaTa/Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15024,7 +15036,7 @@
           "hash": "yVF8/mOahOUV9N2JqBVPjA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15036,7 +15048,7 @@
           "hash": "VMDDbL37PzKRUVYdFW4J+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15048,7 +15060,7 @@
           "hash": "2Q1pdrD8msEWRNB4eGgytw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15060,7 +15072,7 @@
           "hash": "F0SwIldFJYR0nLOMPMoivQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15072,7 +15084,7 @@
           "hash": "NTnLDJ7YhYKYp9MbEKCggA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15084,7 +15096,7 @@
           "hash": "eZNdKk9jDRLOcnrsQJFZEA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15096,7 +15108,7 @@
           "hash": "I2czJRolSaa+eS0KaA4n4Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15108,7 +15120,7 @@
           "hash": "oM107Zk47x9bTLkAaCWvVQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15120,7 +15132,7 @@
           "hash": "dkWWj/htyQkBhceVLkqh4g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15132,7 +15144,7 @@
           "hash": "76FW6vAXAljc1H3a4JP3Tw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15144,7 +15156,7 @@
           "hash": "jeyEl1P7ooXXB0Fe/8Z3Cg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15156,7 +15168,7 @@
           "hash": "fk3J97lr0ZruF2O4rpQUKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15168,7 +15180,7 @@
           "hash": "QarDE0F/4dytnAcxY1DZpA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15180,7 +15192,7 @@
           "hash": "gvBw8k1XTNw3DFNcPKGyZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15192,7 +15204,7 @@
           "hash": "7A2zblCk+6HJrii1KKpYAQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15204,7 +15216,7 @@
           "hash": "bZiCnTFkfMU+BBbmRC9KFg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15216,7 +15228,7 @@
           "hash": "GblepmrrBRfI2cNH36CXBw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15228,7 +15240,7 @@
           "hash": "Wn0PNeClRySOsN/z/KqYnw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15240,7 +15252,7 @@
           "hash": "4/FZrFxrBQ0BYetKKfNWTg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15252,7 +15264,7 @@
           "hash": "Uqw8g7i9WKvpLXW7sSOwXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15264,7 +15276,7 @@
           "hash": "64e8YfrgAmiWuGA7lbxWxg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15276,7 +15288,7 @@
           "hash": "90NNq6Gfuf63PBiRz5x0XA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15288,7 +15300,7 @@
           "hash": "Ho+O18NRYI1Qm7XvJZ7KQQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15300,7 +15312,7 @@
           "hash": "nk4rArzSLSrFH/Znesr2ng=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15312,7 +15324,7 @@
           "hash": "AELirwd9VEp/M6UI6LYgQw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15324,7 +15336,7 @@
           "hash": "avOJAacMdAaoWz4dv0XJlw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15336,7 +15348,7 @@
           "hash": "IDyUHrsAXWxNEFRfgOONEA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15348,7 +15360,7 @@
           "hash": "PSTXXReHEYZnpq0GPcsmtQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15360,7 +15372,7 @@
           "hash": "/swCAdADmSZDgOkaVMe/4g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15372,7 +15384,7 @@
           "hash": "xOUSHqib7MZeXPCQv5vWHA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15384,7 +15396,7 @@
           "hash": "lf+NlbcZe2x+1uUYE5k6sg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15396,7 +15408,7 @@
           "hash": "fwu77SEi3bY/wZU27c+aZw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15408,7 +15420,7 @@
           "hash": "TXWgBMtNWRfzbzEbEP7A0g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15420,7 +15432,7 @@
           "hash": "fEsisuac/F923pXnno0j6w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15432,7 +15444,7 @@
           "hash": "uolJjsBEdgrtLptA2Rsq6g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15444,7 +15456,7 @@
           "hash": "FHOUa/ZbHQ/kEctrab5eSQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15456,7 +15468,7 @@
           "hash": "jg0TGYSlF1MdOZ+jKNG2wA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15468,7 +15480,7 @@
           "hash": "9fMJSIcE/ixtJHOcu3bHhw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15480,7 +15492,7 @@
           "hash": "zdSWqa8jox7uANoooZv2Kw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15492,7 +15504,7 @@
           "hash": "etTNI41sxU7yq8V9fi9S2A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15504,7 +15516,7 @@
           "hash": "DEXJtPeIm/+OAqk8TpRxqw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15516,7 +15528,7 @@
           "hash": "DbCkJYXWjAAcEv8SsLubeA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15528,7 +15540,7 @@
           "hash": "HpbBon0xpEC6hY15TBiMXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15540,7 +15552,7 @@
           "hash": "pGsXXVV+oewgpLex3auK9w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15552,7 +15564,7 @@
           "hash": "GL1a6VZ02n42HKW6kzm8VA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15564,7 +15576,7 @@
           "hash": "zoFdis5IResznkTkKG3SZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15576,7 +15588,7 @@
           "hash": "+KzEulP5UleBVXL4LxncXg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15588,7 +15600,7 @@
           "hash": "HRSBDw1Syrcy4TxPGKQGfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15600,7 +15612,7 @@
           "hash": "hOWxarm5q9r7WTFedoqAYA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15612,7 +15624,7 @@
           "hash": "Yo+eOoudgtkycg473t/8yg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15624,7 +15636,7 @@
           "hash": "qOT1iBWgiTcMUnUYolJj6Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15636,7 +15648,7 @@
           "hash": "mCA/TnWInSZ8i3GD6ajQZw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15648,7 +15660,7 @@
           "hash": "vGhg5J+mhOS9NkWB7VkoPQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15660,7 +15672,7 @@
           "hash": "r+yNFKwQ3Zqob3+1Ho9UFw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15672,7 +15684,7 @@
           "hash": "wb76zBqKaG8RHVpL5EsJgg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15684,7 +15696,7 @@
           "hash": "EUgrh8N3BR3YVJmJJlu4wA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15696,7 +15708,7 @@
           "hash": "5fKCRmPLnzU2cN/6THkAUA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15708,7 +15720,7 @@
           "hash": "WUZ+KdAAo2PEau8X51DUsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15720,7 +15732,7 @@
           "hash": "N3LLLjzYY5MUtaZQ7Qu/Pw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15732,7 +15744,7 @@
           "hash": "3uKnb3Wj1hQ5lRe1SbjqxA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15744,7 +15756,115 @@
           "hash": "HBNTlnMYXPuISOuchMweIQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Editor.WebXRPathFinder.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Editor.WebXRPathFinder.html",
+          "hash": "do8y+EMDyD1MoZsjZYSZtQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Editor.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Editor.html",
+          "hash": "IOwcEPR5OzpTWB9CzVN+/Q=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Profiles.WebXRControllerDataProviderProfile.html",
+          "hash": "sTGonhI1G/GTbk9vPIEaqQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Profiles.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Profiles.html",
+          "hash": "Y87fu0JyoREq6adIAyPkMg=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Providers.CameraSystem.WebXRCameraDataProvider.html",
+          "hash": "PiXrSKtF5cBQwpLLuCGxzg=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Providers.CameraSystem.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Providers.CameraSystem.html",
+          "hash": "q/DRl8kDJMwYyMkW+BeLlA=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Providers.Controllers.WebXRController.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Providers.Controllers.WebXRController.html",
+          "hash": "nxdoniO2jKvqwCX4ECRf4w=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Providers.Controllers.WebXRControllerDataProvider.html",
+          "hash": "8//0cYeqeoDy44ge/z0XWg=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "../api/XRTK.WebXR.Providers.Controllers.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/XRTK.WebXR.Providers.Controllers.html",
+          "hash": "uvkEn3sq/jmjvEYkQogmEA=="
+        }
+      },
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15753,10 +15873,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.WindowsMixedReality.Editor.Providers.SpatialAwarenessSystem.SpatialObservers.WindowsMixedRealityControllerDataProviderProfileInspector.html",
-          "hash": "rVWgHPe0Jr2yfAQM3oXciQ=="
+          "hash": "nuA4Xr2e+TPaadLiaK5M5w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15768,7 +15888,7 @@
           "hash": "8HRBusRlsxOaRTYlvK/mHA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15777,10 +15897,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.WindowsMixedReality.Editor.WindowsMixedRealityPathFinder.html",
-          "hash": "5wt3/Rpuyx+m75EIIr+Ckg=="
+          "hash": "cqr6EtDXhe9MPcmSjQgZcA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15792,7 +15912,7 @@
           "hash": "oimPq3Hlsyr5BpG2m2O7Tw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15804,7 +15924,7 @@
           "hash": "Bnak/QPhd4hL/36XTKVhxg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15816,7 +15936,7 @@
           "hash": "laTV299EvctHP1FlAwXn6w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15825,10 +15945,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealityControllerDataProviderProfile.html",
-          "hash": "5F/srbC0jxWyPtdUtHYraA=="
+          "hash": "PRxt12kkNuharo5bkHSOdQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15837,10 +15957,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealityHandControllerDataProviderProfile.html",
-          "hash": "ui+JF4a85hGmHJbOQvQ0fg=="
+          "hash": "KzixXk3t1tyjoCkn58XQ+A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15849,10 +15969,10 @@
       "output": {
         ".html": {
           "relative_path": "api/XRTK.WindowsMixedReality.Profiles.WindowsMixedRealitySpatialMeshObserverProfile.html",
-          "hash": "vM7qRM8a3d6LUR5dyiCGbA=="
+          "hash": "ZrxNfZCXEIwozWvA0XDhqg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15864,7 +15984,7 @@
           "hash": "PYFbstHc+w4wGekcYQJlKA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15876,7 +15996,7 @@
           "hash": "/ov81tPzmq8nZaXcEIrsrw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15888,7 +16008,7 @@
           "hash": "OcfsX/Q8AsMsWaFgGyD6Xg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15900,7 +16020,7 @@
           "hash": "KOA21bwwkdvXWCwFlol0Jw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15912,7 +16032,7 @@
           "hash": "9M6i0kr0n/MVtsaaSWwNdQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15924,7 +16044,7 @@
           "hash": "OR5fmu151XP+zIXnwKuI1Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15936,7 +16056,7 @@
           "hash": "h17v15lD5XDZWqRAwbvaaA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15948,7 +16068,7 @@
           "hash": "B9jLSgOd8OHhb/m/cgxjqw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15960,7 +16080,7 @@
           "hash": "ye6OpJ4wiBSeyGXwIBaSIw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15972,7 +16092,7 @@
           "hash": "9NxTmRbgJTFOE15yPBLzcg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15984,7 +16104,7 @@
           "hash": "Lg1vIoC1/xIcMmMkR6yIaQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -15996,7 +16116,7 @@
           "hash": "L5GomMChP1qSEX04zyENWA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16008,7 +16128,7 @@
           "hash": "uPBN2WP322F7IxRdxxhU4Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16020,7 +16140,7 @@
           "hash": "acdpjwP/WZg25RjaoY2enA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16032,7 +16152,7 @@
           "hash": "5bb7oYMNaxFGVg/WxtlogQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16041,7 +16161,7 @@
       "output": {
         ".html": {
           "relative_path": "api/toc.html",
-          "hash": "Z/5NuKvm5KJEcmbSclg0yw=="
+          "hash": "cNA9OSvzpq4a6ueIJ+tvgw=="
         }
       },
       "is_incremental": false,
@@ -16056,7 +16176,7 @@
           "hash": "eODPjuKhYpU0WzEIvNod4A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16068,7 +16188,7 @@
           "hash": "sV4E+ZXo3xA3GQC23ty5dg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16080,7 +16200,7 @@
           "hash": "mRFS3Qx3wcudRSt9Fc37VQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16092,7 +16212,7 @@
           "hash": "BX8NEBOZvsGL8XiXlyGE3w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16104,7 +16224,7 @@
           "hash": "BIAHn/GzYTosbNVwyHO44Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16116,7 +16236,7 @@
           "hash": "/336VfqyzqMcBWphLngToQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16128,7 +16248,7 @@
           "hash": "LYNxpuJ9Rn/T7ZVwxg+lmA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16140,7 +16260,7 @@
           "hash": "DGgqtEb9Rr8Km8EXLNyHxw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16152,7 +16272,7 @@
           "hash": "/68gPCR1+M4OR6z9aySZIA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16164,7 +16284,7 @@
           "hash": "KrmTLcosvEEaQvyT8B/xuQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16176,7 +16296,7 @@
           "hash": "lUhej8ocMC6j3ic1tEGDgQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16188,7 +16308,7 @@
           "hash": "ysEw33u7UUVF/zpAKxJ7QQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16200,7 +16320,7 @@
           "hash": "RdPtvp9PcXQXnnA/WVRUtA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16212,7 +16332,7 @@
           "hash": "5dZRHkUjm2pHLElJj/2nuA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16224,7 +16344,7 @@
           "hash": "ug+EFHiClw46qjS1b5eDXA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16236,7 +16356,7 @@
           "hash": "Q49jrikN7rXefX4Hk/yZ/A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16248,7 +16368,7 @@
           "hash": "VOUyLbVPuuqG4FfKAwJ2HA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16260,7 +16380,7 @@
           "hash": "1tsBwqYjFAyEhPcS/nMhgg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16272,7 +16392,7 @@
           "hash": "jd4C90ibf3Np9COH76koeQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16284,7 +16404,7 @@
           "hash": "z5lmXyQY9iWG3Nx6+iSjmA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16296,7 +16416,7 @@
           "hash": "IJld/KUB2vaVt7uQn9CwfQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16308,7 +16428,7 @@
           "hash": "UEgmIKg+J2/gtrMBKK/FrA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16320,7 +16440,7 @@
           "hash": "piN6omQ/3N/5I+hTGRjiXw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16332,7 +16452,7 @@
           "hash": "N7k+eXI8PRdgPLfSjHC5Dg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16344,7 +16464,7 @@
           "hash": "6Z0G1iBla4Dp1Mq84h0vCQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16356,7 +16476,7 @@
           "hash": "duwaH2PZLl//37UWRKLJYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16368,7 +16488,7 @@
           "hash": "onj7gHpbiyzXF6bp8JpwXQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16380,7 +16500,7 @@
           "hash": "NX7O1EcWcfaMbGdpnFVGnw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16392,7 +16512,7 @@
           "hash": "gQHST/YGD5YlcqmoXeDw1g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -16404,7 +16524,7 @@
           "hash": "XxVE2zZFZxONOhoraBVmwg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -17458,25 +17578,23 @@
   "incremental_info": [
     {
       "status": {
-        "can_incremental": false,
-        "details": "Cannot build incrementally because last build info is missing.",
+        "can_incremental": true,
         "incrementalPhase": "build",
         "total_file_count": 0,
-        "skipped_file_count": 0,
-        "full_build_reason_code": "NoAvailableBuildCache"
+        "skipped_file_count": 0
       },
       "processors": {
         "ConceptualDocumentProcessor": {
-          "can_incremental": false,
+          "can_incremental": true,
           "incrementalPhase": "build",
           "total_file_count": 37,
-          "skipped_file_count": 0
+          "skipped_file_count": 37
         },
         "ManagedReferenceDocumentProcessor": {
-          "can_incremental": false,
+          "can_incremental": true,
           "incrementalPhase": "build",
-          "total_file_count": 1329,
-          "skipped_file_count": 0
+          "total_file_count": 1339,
+          "skipped_file_count": 1338
         },
         "ResourceDocumentProcessor": {
           "can_incremental": false,
@@ -17496,8 +17614,8 @@
     },
     {
       "status": {
-        "can_incremental": false,
-        "details": "Cannot support incremental post processing, the reason is: last post processor info is null.",
+        "can_incremental": true,
+        "details": "Can support incremental post processing.",
         "incrementalPhase": "postProcessing",
         "total_file_count": 0,
         "skipped_file_count": 0

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6444,7 +6444,7 @@
           "hash": "gFkdxuEGKvK/zrMBnZbOVA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -6732,7 +6732,7 @@
           "hash": "+5+d1V9Wv2VjX0pzUiJ4xA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -17594,7 +17594,7 @@
           "can_incremental": true,
           "incrementalPhase": "build",
           "total_file_count": 1339,
-          "skipped_file_count": 1338
+          "skipped_file_count": 1339
         },
         "ResourceDocumentProcessor": {
           "can_incremental": false,


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

This PR fixes the `AutoSceneSwitcher` showing up when the toolkit is actually already configured in the scene(s).
Also this fixes the `AutoSceneSwitcher` forcing the XRTK base scene to be the active scene. This breaks multi-scene editing behaviour expected from the editor. As only the active scene's lightmaps will be used and people might want another scene to be the active scene in editor. The XRTK does not require the base scene to be the active scene, it just needs to be loaded.