### PR TITLE
Fix NRE in EditorActiveProfileChangeHandler

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/EditorActiveProfileChangeHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/EditorActiveProfileChangeHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) XRTK. All rights reserved.
+// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using UnityEditor;
@@ -18,7 +18,7 @@ namespace XRTK.Editor
 
         private static void EditorApplication_hierarchyChanged()
         {
-            if (!MixedRealityToolkit.Instance.IsNull())
+            if (!(MixedRealityToolkit.Instance.IsNull() || MixedRealityToolkit.Instance.ActiveProfile.IsNull()))
             {
                 if (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
                     Utilities.InputMappingAxisUtility.CheckUnityInputManagerMappings(Utilities.ControllerMappingUtilities.UnityInputManagerAxes))


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Fixes the NREs thrown in the build's test steps when no active profile was configured for the toolkit.
NREs were thrown in the handler if no active profile was set.