### PR TITLE
Fixed auto-configuration without user input

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/EditorActiveProfileChangeHandler.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/EditorActiveProfileChangeHandler.cs
@@ -3,7 +3,6 @@
 
 using UnityEditor;
 using UnityEngine;
-using XRTK.Extensions;
 using XRTK.Services;
 
 namespace XRTK.Editor
@@ -18,7 +17,7 @@ namespace XRTK.Editor
 
         private static void EditorApplication_hierarchyChanged()
         {
-            if (!(MixedRealityToolkit.Instance.IsNull() || MixedRealityToolkit.Instance.ActiveProfile.IsNull()))
+            if (MixedRealityToolkit.HasActiveProfile)
             {
                 if (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
                     Utilities.InputMappingAxisUtility.CheckUnityInputManagerMappings(Utilities.ControllerMappingUtilities.UnityInputManagerAxes))


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

<!-- Please provide a clear and concise description of the pull request. -->
fixed a bug where the xrtk would auto-configure itself bc the Instance was called

## Changes

<!-- Brief list of the targeted features that are being changed. -->

- Fixes: #758 