### PR TITLE
Updated Controller Mapping Data Provider Profile Inspector

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/ControllerPopupWindow.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/ControllerPopupWindow.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using XRTK.Definitions.Controllers;
-using XRTK.Definitions.Devices;
 using XRTK.Definitions.Utilities;
 using XRTK.Editor.Data;
 using XRTK.Editor.PropertyDrawers;
@@ -343,35 +342,9 @@ namespace XRTK.Editor
                 if (useCustomInteractionMapping ||
                     currentControllerTexture.IsNull())
                 {
-                    bool skip = false;
-
-                    if (ControllerType.Name == "WindowsMixedRealityMotionController" && Handedness == Handedness.None)
-                    {
-                        switch (description)
-                        {
-                            case "Grip Press":
-                            case "Trigger Position":
-                            case "Trigger Touched":
-                            case "Touchpad Position":
-                            case "Touchpad Touch":
-                            case "Touchpad Press":
-                            case "Menu Press":
-                            case "Thumbstick Position":
-                            case "Thumbstick Press":
-                                skip = true;
-                                break;
-                            case "Trigger Press (Select)":
-                                description = "Air Tap (Select)";
-                                break;
-                        }
-                    }
-
-                    if (!skip)
-                    {
-                        inputActionDropdown.OnGui(GUIContent.none, action, axisConstraint, GUILayout.Width(INPUT_ACTION_LABEL_WIDTH));
-                        EditorGUILayout.LabelField(description, GUILayout.ExpandWidth(true));
-                        GUILayout.FlexibleSpace();
-                    }
+                    inputActionDropdown.OnGui(GUIContent.none, action, axisConstraint, GUILayout.Width(INPUT_ACTION_LABEL_WIDTH));
+                    EditorGUILayout.LabelField(description, GUILayout.ExpandWidth(true));
+                    GUILayout.FlexibleSpace();
                 }
                 else
                 {

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/Controllers/BaseMixedRealityControllerDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/Controllers/BaseMixedRealityControllerDataProviderProfileInspector.cs
@@ -2,20 +2,20 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
 using XRTK.Definitions.Controllers;
 using XRTK.Definitions.Devices;
 using XRTK.Definitions.Utilities;
-using XRTK.Providers.Controllers;
-using XRTK.Extensions;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using XRTK.Editor.Extensions;
 using XRTK.Editor.PropertyDrawers;
 using XRTK.Editor.Utilities;
+using XRTK.Extensions;
+using XRTK.Providers.Controllers;
 
 namespace XRTK.Editor.Profiles.InputSystem.Controllers
 {
@@ -266,32 +266,41 @@ namespace XRTK.Editor.Profiles.InputSystem.Controllers
             }
         }
 
+        private static int layoutIndex;
+
         internal void RenderControllerMappingButton(MixedRealityControllerMappingProfile controllerMappingProfile)
         {
             var controllerType = controllerMappingProfile.ControllerType.Type;
 
+            if (controllerType == null)
+            {
+                return;
+            }
+
             var handedness = controllerMappingProfile.Handedness;
 
-            if (handedness != Handedness.Right)
+            if (handedness != Handedness.Right && layoutIndex > 0)
             {
+                layoutIndex = 0;
+                GUILayout.EndHorizontal();
+            }
+
+            if (handedness == Handedness.Left)
+            {
+                layoutIndex++;
                 GUILayout.BeginHorizontal();
             }
 
-            var typeName = controllerType?.Name.ToProperCase();
+            var buttonContent = new GUIContent($"Edit {controllerType.Name.ToProperCase()} Action Mapping", ControllerMappingUtilities.GetControllerTextureScaled(controllerMappingProfile));
 
-            if (controllerType?.Name == "WindowsMixedRealityMotionController" && controllerMappingProfile.Handedness == Handedness.None)
-            {
-                typeName = "HoloLens 1";
-            }
-
-            var buttonContent = new GUIContent($"Edit {typeName} Action Mapping", ControllerMappingUtilities.GetControllerTextureScaled(controllerMappingProfile));
             if (GUILayout.Button(buttonContent, ControllerButtonStyle, GUILayout.Height(128f), GUILayout.MinWidth(32f), GUILayout.ExpandWidth(true)))
             {
                 EditorApplication.delayCall += () => ControllerPopupWindow.Show(controllerMappingProfile, new SerializedObject(controllerMappingProfile).FindProperty("interactionMappingProfiles"));
             }
 
-            if (handedness != Handedness.Left)
+            if (handedness == Handedness.Right && layoutIndex == 1)
             {
+                layoutIndex--;
                 GUILayout.EndHorizontal();
             }
         }

--- a/XRTK-Core/Packages/com.xrtk.core/package.json
+++ b/XRTK-Core/Packages/com.xrtk.core/package.json
@@ -10,7 +10,7 @@
     "Mixed Reality",
     "DI"
   ],
-  "version": "0.2.4",
+  "version": "0.2.5",
   "unity": "2019.4",
   "license": "MIT",
   "author": "XRTK Team (https://github.com/XRTK)",

--- a/XRTK-Core/Packages/packages-lock.json
+++ b/XRTK-Core/Packages/packages-lock.json
@@ -230,7 +230,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.xrtk.core": "0.2.3",
+        "com.xrtk.core": "0.2.4",
         "com.unity.xr.windowsmr.metro": "4.2.3"
       }
     },


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

<!-- Please provide a clear and concise description of the pull request. -->
Fixed inspector to render the mapping profiles correctly if we're missing a left or right controller.

## Changes

<!-- Brief list of the targeted features that are being changed. -->

- Fixes rendering of the controller mapping profiles if we're missing a left or right controller
- Cleaned up old references for the `WindowsMixedRealityMotionController` mapping workaround for displaying HoloLens One input actions. We now have a dedicated `HoloLensOneController` type for HoloLens hand input on the HoloLens One (see [submodule changes](https://github.com/XRTK/WindowsMixedReality/pull/120))

## Submodule Changes

<!--  Include any submodule PR links here -->

- [WMR](https://github.com/XRTK/WindowsMixedReality/pull/120)
