### PR TITLE
Dev/quieter scene switcher

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityPreferences.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityPreferences.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/AutoSceneSwitcher.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/AutoSceneSwitcher.cs
@@ -76,7 +76,7 @@ namespace XRTK.Editor.Utilities
             // loaded scene(s) may not contain a proper XRTK service locator game object configuration.
             // Least we can do now is offer the user to auto configure the current scene, if none of the
             // loaded scenes already contains a XRTK configuration.
-            if (!MixedRealityToolkit.IsInitialized && EditorPreferences.Get($"{nameof(AutoSceneSwitcher)}", true))
+            if (!MixedRealityToolkit.IsInitialized && EditorPreferences.Get($"{nameof(AutoSceneSwitcher)}", false))
             {
                 var dialogResult = EditorUtility.DisplayDialogComplex(
                         title: "Missing the MixedRealityToolkit",

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/SymbolicLinks/SymbolicLinker.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/SymbolicLinks/SymbolicLinker.cs
@@ -453,7 +453,7 @@ namespace XRTK.Editor.Utilities.SymbolicLinks
                 }
                 else
                 {
-                    var tempFile = $"{targetAbsolutePath}/temp.txt";
+                    var tempFile = $"{targetAbsolutePath}/temp_test.txt";
 
                     try
                     {


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
The auto scene switcher shouldn't ask about switching unless the XRTK is setup initially at least once.

Renamed the temp file generated when validating symbolic links so we don't accidentally delete valid temp.txt files.