### PR TITLE
Fixed issue with platform dropdown when platform not installed.

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -137,7 +137,18 @@ namespace XRTK.Editor.PropertyDrawers
 
             foreach (var assembly in assemblies)
             {
-                var compiledAssembly = Assembly.Load(assembly.name);
+                Assembly compiledAssembly;
+
+                try
+                {
+                    compiledAssembly = Assembly.Load(assembly.name);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError(e);
+                    continue;
+                }
+
                 FilterTypes(compiledAssembly, filter, excludedTypes, types);
             }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Added try/catch around assembly load in `TypeReferencePropertyDrawer.GetFilteredTypes`

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Fixes: https://github.com/XRTK/XRTK-Core/issues/813
