### PR TITLE
Fix/git utilities root path calculation fallback

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/GitUtilities.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/GitUtilities.cs
@@ -36,7 +36,8 @@ namespace XRTK.Editor.Utilities
                     return projectRootDir = rootDir.ToBackSlashes().Replace("\n", string.Empty);
                 }
 
-                return projectRootDir = Directory.GetParent(Application.dataPath).FullName;
+                Debug.LogWarning($"git command failed! Do you have git installed?\n{rootDir}");
+                return projectRootDir = Directory.GetParent(Directory.GetParent(Application.dataPath).FullName).FullName;
             }
         }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Fixed an issue where the Git Project Root path was incorrectly calculated for the fallback path if git is not installed.