### PR TITLE
Fix controller action mappings only display hand controller mappings

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/MixedRealityInputSystemProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/InputSystem/MixedRealityInputSystemProfileInspector.cs
@@ -86,7 +86,7 @@ namespace XRTK.Editor.Profiles.InputSystem
                 var configurationProfileProperty = configurationProperty.FindPropertyRelative("profile");
 
                 if (configurationProfileProperty != null &&
-                    configurationProfileProperty.objectReferenceValue is BaseHandControllerDataProviderProfile controllerDataProviderProfile)
+                    configurationProfileProperty.objectReferenceValue is BaseMixedRealityControllerDataProviderProfile controllerDataProviderProfile)
                 {
                     if (controllerDataProviderProfile.IsNull() ||
                         controllerDataProviderProfile.ControllerMappingProfiles == null)


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

The aggregated controller action mappings inspector in the input system profile inspector would only display hand controller mappings instead of all controller mappings. Fixed.