### PR TITLE
Fix themed logo usage

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/MixedRealityInspectorUtility.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Utilities/MixedRealityInspectorUtility.cs
@@ -151,7 +151,7 @@ namespace XRTK.Editor.Utilities
         /// </summary>
         public static void RenderMixedRealityToolkitLogo()
         {
-            RenderInspectorHeader(EditorGUIUtility.isProSkin ? LightThemeLogo : DarkThemeLogo);
+            RenderInspectorHeader(EditorGUIUtility.isProSkin ? DarkThemeLogo : LightThemeLogo);
         }
 
         /// <summary>


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

The inspector utility was using the wrong themed logo. This was not an issue with default XRTK inspectors since we use the same logo for both themes. But in custom extension service inspectors the issue was noticable.
