### PR TITLE
Remove internal flag on parent profile property

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/AssemblyInfo.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/AssemblyInfo.cs
@@ -14,6 +14,7 @@ using System.Runtime.CompilerServices;
 // Note: these are the names of the assembly definitions themselves, not necessarily the actual namespace the class is in.
 [assembly: InternalsVisibleTo("XRTK.Editor")]
 [assembly: InternalsVisibleTo("XRTK.Tests")]
+[assembly: InternalsVisibleTo("XRTK.Examples.Editor")]
 [assembly: InternalsVisibleTo("XRTK.WindowsMixedReality")]
 [assembly: InternalsVisibleTo("XRTK.WindowsMixedReality.Player")]
 [assembly: InternalsVisibleTo("XRTK.Oculus")]

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/BaseMixedRealityProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/BaseMixedRealityProfile.cs
@@ -13,6 +13,6 @@ namespace XRTK.Definitions
         /// <summary>
         /// The profile's parent in the service graph hierarchy.
         /// </summary>
-        public BaseMixedRealityProfile ParentProfile { get; set; } = null;
+        public BaseMixedRealityProfile ParentProfile { get; internal set; } = null;
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/BaseMixedRealityProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/BaseMixedRealityProfile.cs
@@ -13,6 +13,6 @@ namespace XRTK.Definitions
         /// <summary>
         /// The profile's parent in the service graph hierarchy.
         /// </summary>
-        public BaseMixedRealityProfile ParentProfile { get; internal set; } = null;
+        public BaseMixedRealityProfile ParentProfile { get; set; } = null;
     }
 }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Removed the `internal` keyword on the `BaseMixedRealityProfile.ParentProfile` property setter. This was necessary to be able to set parent profiles  in code that lives in another assembly.