### PR TITLE
Fixed package installer exception

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/PackageInstaller.cs
@@ -77,7 +77,9 @@ namespace XRTK.Editor
                 {
                     var destinationDirectory = Path.GetFullPath(destinationPath);
 
-                    if (!Directory.Exists(destinationDirectory))
+                    // Check if directory or symbolic link exists before attempting to create it
+                    if (!Directory.Exists(destinationDirectory) &&
+                        !File.Exists(destinationDirectory))
                     {
                         Directory.CreateDirectory(destinationDirectory);
                     }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Fixed an exception when package installer tries to create a directory when a symbolic link is already pointing to it